### PR TITLE
feat: 起動時ギャラリー増分同期（Tweaker終了〜起動のスクショ）

### DIFF
--- a/app.go
+++ b/app.go
@@ -106,6 +106,59 @@ func (a *App) startup(ctx context.Context) {
 	a.startOutputLogWatcher(ctx, eventBus)
 
 	a.startPictureFolderWatcher(ctx)
+	go a.startupGalleryIncremental()
+}
+
+// onShutdown persists state before the process exits (Wails lifecycle).
+func (a *App) onShutdown(ctx context.Context) {
+	if a.settings == nil {
+		return
+	}
+	if err := a.settings.SetGalleryLastExitAt(ctx, time.Now().UTC()); err != nil {
+		runtime.LogWarning(ctx, "gallery last exit at: "+err.Error())
+	}
+}
+
+func (a *App) startupGalleryIncremental() {
+	const waitTick = 50 * time.Millisecond
+	const waitMaxIters = 3600 // ~3 minutes while a manual folder scan is in progress
+
+	for i := 0; i < waitMaxIters && a.IsGalleryScanning(); i++ {
+		select {
+		case <-a.ctx.Done():
+			return
+		case <-time.After(waitTick):
+		}
+	}
+	if a.IsGalleryScanning() {
+		runtime.LogWarning(a.ctx, "startup gallery incremental: skipped (folder scan still running)")
+		return
+	}
+
+	root := a.resolveVRChatPictureWatchRoot()
+	if root == "" {
+		return
+	}
+	if _, err := os.Stat(root); err != nil {
+		return
+	}
+
+	since, ok := a.settings.GetGalleryLastExitAt(a.ctx)
+	if !ok {
+		return
+	}
+
+	count, err := a.media.IngestUnderPictureRootSince(a.ctx, root, since)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		runtime.LogWarning(a.ctx, "startup gallery incremental: "+err.Error())
+		return
+	}
+	if count > 0 {
+		runtime.EventsEmit(a.ctx, galleryScreenshotsChangedEvent, struct{}{})
+	}
 }
 
 func (a *App) subscribeAutomationEvents(ctx context.Context, eventBus event.EventBus) {

--- a/internal/usecase/media_usecase.go
+++ b/internal/usecase/media_usecase.go
@@ -166,6 +166,53 @@ func (uc *MediaUseCase) ScanDirectory(ctx context.Context, basePath string, onPr
 	return count, nil
 }
 
+// IngestUnderPictureRootSince walks basePath for image files whose ModTime is strictly after since
+// and ingests new paths only (see IngestScreenshotFile). Skips files on ingest error, like ScanDirectory.
+func (uc *MediaUseCase) IngestUnderPictureRootSince(ctx context.Context, basePath string, since time.Time) (int, error) {
+	basePath = filepath.Clean(basePath)
+	info, err := os.Stat(basePath)
+	if err != nil {
+		return 0, err
+	}
+	if !info.IsDir() {
+		return 0, nil
+	}
+
+	createdCount := 0
+	err = filepath.Walk(basePath, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".png", ".jpg", ".jpeg":
+		default:
+			return nil
+		}
+		if !fi.ModTime().After(since) {
+			return nil
+		}
+		_, created, ingestErr := uc.IngestScreenshotFile(ctx, path)
+		if ingestErr != nil {
+			return nil
+		}
+		if created {
+			createdCount++
+		}
+		return nil
+	})
+	if err != nil {
+		return createdCount, err
+	}
+	return createdCount, nil
+}
+
 // DeleteScreenshot removes a screenshot record.
 func (uc *MediaUseCase) DeleteScreenshot(ctx context.Context, id string) error {
 	return uc.repo.Delete(ctx, id)

--- a/internal/usecase/media_usecase_test.go
+++ b/internal/usecase/media_usecase_test.go
@@ -226,6 +226,75 @@ func TestMediaUseCase_IngestScreenshotFile_SkipsNonImage(t *testing.T) {
 	}
 }
 
+func TestMediaUseCase_IngestUnderPictureRootSince_onlyNewerMtime(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old.png")
+	newPath := filepath.Join(dir, "new.png")
+	_ = os.WriteFile(oldPath, []byte("a"), 0o644)
+	_ = os.WriteFile(newPath, []byte("b"), 0o644)
+	oldM := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	newM := time.Date(2030, 6, 7, 8, 9, 10, 0, time.UTC)
+	if err := os.Chtimes(oldPath, oldM, oldM); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newPath, newM, newM); err != nil {
+		t.Fatal(err)
+	}
+
+	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	repo := newMockScreenshotRepo()
+	uc := NewMediaUseCase(repo, nil)
+	ctx := context.Background()
+
+	count, err := uc.IngestUnderPictureRootSince(ctx, dir, since)
+	if err != nil {
+		t.Fatalf("IngestUnderPictureRootSince: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+	if repo.byPath[oldPath] != nil {
+		t.Error("old.png should not be ingested")
+	}
+	if repo.byPath[newPath] == nil {
+		t.Fatal("new.png should be ingested")
+	}
+}
+
+func TestMediaUseCase_IngestUnderPictureRootSince_notADir(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "file.png")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uc := NewMediaUseCase(newMockScreenshotRepo(), nil)
+	count, err := uc.IngestUnderPictureRootSince(context.Background(), f, time.Time{})
+	if err != nil {
+		t.Fatalf("IngestUnderPictureRootSince: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+}
+
+func TestMediaUseCase_IngestUnderPictureRootSince_contextCancelDuringWalk(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "n.png")
+	_ = os.WriteFile(p, []byte("x"), 0o644)
+	future := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	_ = os.Chtimes(p, future, future)
+
+	repo := newMockScreenshotRepo()
+	uc := NewMediaUseCase(repo, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := uc.IngestUnderPictureRootSince(ctx, dir, time.Time{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
 func TestMediaUseCase_ReindexScreenshots(t *testing.T) {
 	dir := t.TempDir()
 	basePath := filepath.Join(dir, "screenshots")

--- a/internal/usecase/settings_usecase.go
+++ b/internal/usecase/settings_usecase.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"vrchat-tweaker/internal/domain/settings"
 )
@@ -66,7 +67,27 @@ const (
 	keyVRChatPathWindows = "vrchat_path_windows"
 	keySteamPathLinux    = "steam_path_linux"
 	keyOutputLogPath     = "output_log_path"
+	keyGalleryLastExitAt = "gallery_last_exit_at"
 )
+
+// GetGalleryLastExitAt returns the last app shutdown time used for incremental gallery sync.
+// The second return is false when unset or not parseable.
+func (uc *SettingsUseCase) GetGalleryLastExitAt(ctx context.Context) (time.Time, bool) {
+	v, err := uc.repo.Get(ctx, keyGalleryLastExitAt)
+	if err != nil || v == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, v)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+// SetGalleryLastExitAt persists the shutdown instant for the next startup incremental gallery sync.
+func (uc *SettingsUseCase) SetGalleryLastExitAt(ctx context.Context, t time.Time) error {
+	return uc.repo.Set(ctx, keyGalleryLastExitAt, t.UTC().Format(time.RFC3339Nano))
+}
 
 // PathSettings holds VRChat/Steam/output_log paths.
 type PathSettings struct {

--- a/internal/usecase/settings_usecase_test.go
+++ b/internal/usecase/settings_usecase_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 // fakeAppSettingsRepo implements settings.AppSettingsRepository for tests.
@@ -79,5 +80,45 @@ func TestSettingsUseCase_ValidatePath_empty(t *testing.T) {
 
 	if uc.ValidatePath("") {
 		t.Error("ValidatePath(\"\") should return false")
+	}
+}
+
+func TestSettingsUseCase_GalleryLastExitAt_roundtrip(t *testing.T) {
+	repo := &fakeAppSettingsRepo{m: make(map[string]string)}
+	uc := NewSettingsUseCase(repo)
+	ctx := context.Background()
+
+	want := time.Date(2025, 3, 21, 12, 30, 45, 123456789, time.FixedZone("JST", 9*3600))
+	if err := uc.SetGalleryLastExitAt(ctx, want); err != nil {
+		t.Fatalf("SetGalleryLastExitAt: %v", err)
+	}
+	got, ok := uc.GetGalleryLastExitAt(ctx)
+	if !ok {
+		t.Fatal("GetGalleryLastExitAt: want ok true")
+	}
+	if !got.Equal(want.UTC()) {
+		t.Errorf("time: got %v, want %v", got, want.UTC())
+	}
+}
+
+func TestSettingsUseCase_GetGalleryLastExitAt_empty(t *testing.T) {
+	repo := &fakeAppSettingsRepo{m: make(map[string]string)}
+	uc := NewSettingsUseCase(repo)
+	ctx := context.Background()
+
+	_, ok := uc.GetGalleryLastExitAt(ctx)
+	if ok {
+		t.Error("GetGalleryLastExitAt: want ok false for empty")
+	}
+}
+
+func TestSettingsUseCase_GetGalleryLastExitAt_invalid(t *testing.T) {
+	repo := &fakeAppSettingsRepo{m: map[string]string{keyGalleryLastExitAt: "not-a-time"}}
+	uc := NewSettingsUseCase(repo)
+	ctx := context.Background()
+
+	_, ok := uc.GetGalleryLastExitAt(ctx)
+	if ok {
+		t.Error("GetGalleryLastExitAt: want ok false for invalid string")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 		},
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
 		OnStartup:        app.startup,
+		OnShutdown:       app.onShutdown,
 		Bind: []interface{}{
 			app,
 		},


### PR DESCRIPTION
## 概要
Tweaker を閉じているあいだに VRChat で撮ったスクショを、次回起動時に自動で DB に取り込みます（フルスキャン不要のケース向け）。

## 仕様
- **終了時**: `OnShutdown` で `gallery_last_exit_at`（UTC RFC3339Nano）を保存
- **起動時**: `resolveVRChatPictureWatchRoot()` と同じルートを Walk し、`ModTime` が終了時刻より**後**の `.png` / `.jpg` / `.jpeg` だけ `IngestScreenshotFile`
- キー未設定・不正なら増分はスキップ（初回は手動フルスキャン）
- 新規が 1 件以上なら `gallery:screenshots-changed` を emit
- 手動フォルダスキャン中は最大約 3 分待機、タイムアウト時はログのうえスキップ

## 変更ファイル
- `main.go`: `OnShutdown`
- `app.go`: `onShutdown`, `startupGalleryIncremental`
- `settings_usecase.go`: `Get/SetGalleryLastExitAt`
- `media_usecase.go`: `IngestUnderPictureRootSince`
- 各 `*_test.go`

## 備考
古い日付の画像をコピーしただけのケースは `mtime` が古いと拾えないため、従来どおり手動フルスキャンを利用してください。

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jo3qma/vrctweaker/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
