### PR TITLE
feat: 動画タブと yt-dlp 自動更新 (closes #9)

### DIFF
--- a/app.go
+++ b/app.go
@@ -1066,6 +1066,43 @@ func (a *App) DefaultVRChatPictureFolder() (string, error) {
 	return filepath.Join(home, "Pictures", "VRChat"), nil
 }
 
+// GetYTDLPBasics returns the yt-dlp install path and local version without calling GitHub.
+func (a *App) GetYTDLPBasics() YTDLPUpdateStatusDTO {
+	u := usecase.NewYTDLPUpdater()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	st := u.GetBasics(ctx, getVRChatConfigPath())
+	return toYTDLPUpdateStatusDTO(st)
+}
+
+// GetYTDLPUpdateStatus compares the local VRChat yt-dlp.exe (if any) with the latest GitHub release.
+// Call from the UI on user action only; GitHub API is rate-limited when unauthenticated.
+func (a *App) GetYTDLPUpdateStatus() YTDLPUpdateStatusDTO {
+	u := usecase.NewYTDLPUpdater()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	st := u.GetUpdateStatus(ctx, getVRChatConfigPath())
+	return toYTDLPUpdateStatusDTO(st)
+}
+
+// ApplyYTDLP downloads yt-dlp.exe from downloadURL and installs it under VRChat's Tools folder.
+// downloadURL and latestTag should come from a successful GetYTDLPUpdateStatus response.
+func (a *App) ApplyYTDLP(downloadURL, latestTag string) YTDLPApplyResultDTO {
+	downloadURL = strings.TrimSpace(downloadURL)
+	latestTag = strings.TrimSpace(latestTag)
+	if downloadURL == "" {
+		return YTDLPApplyResultDTO{
+			Ok:    false,
+			Error: "ダウンロード URL がありません。先に「最新版を確認」を実行してください。",
+		}
+	}
+	u := usecase.NewYTDLPUpdater()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	r := u.ApplyLatest(ctx, getVRChatConfigPath(), downloadURL, latestTag)
+	return toYTDLPApplyResultDTO(r)
+}
+
 // getVRChatConfigPath returns the path to VRChat's config.json.
 // On Windows: %LocalAppData%Low\VRChat\VRChat\config.json
 // On other OS: falls back to ~/.local/share/VRChat/VRChat/config.json

--- a/app.go
+++ b/app.go
@@ -1069,7 +1069,7 @@ func (a *App) DefaultVRChatPictureFolder() (string, error) {
 // GetYTDLPBasics returns the yt-dlp install path and local version without calling GitHub.
 func (a *App) GetYTDLPBasics() YTDLPUpdateStatusDTO {
 	u := usecase.NewYTDLPUpdater()
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(a.ctx, 15*time.Second)
 	defer cancel()
 	st := u.GetBasics(ctx, getVRChatConfigPath())
 	return toYTDLPUpdateStatusDTO(st)
@@ -1079,7 +1079,7 @@ func (a *App) GetYTDLPBasics() YTDLPUpdateStatusDTO {
 // Call from the UI on user action only; GitHub API is rate-limited when unauthenticated.
 func (a *App) GetYTDLPUpdateStatus() YTDLPUpdateStatusDTO {
 	u := usecase.NewYTDLPUpdater()
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	ctx, cancel := context.WithTimeout(a.ctx, 45*time.Second)
 	defer cancel()
 	st := u.GetUpdateStatus(ctx, getVRChatConfigPath())
 	return toYTDLPUpdateStatusDTO(st)
@@ -1097,7 +1097,7 @@ func (a *App) ApplyYTDLP(downloadURL, latestTag string) YTDLPApplyResultDTO {
 		}
 	}
 	u := usecase.NewYTDLPUpdater()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(a.ctx, 10*time.Minute)
 	defer cancel()
 	r := u.ApplyLatest(ctx, getVRChatConfigPath(), downloadURL, latestTag)
 	return toYTDLPApplyResultDTO(r)

--- a/bindings.go
+++ b/bindings.go
@@ -492,3 +492,45 @@ func fromVRChatConfigDTO(d VRChatConfigDTO) *vrchatconfig.VRChatConfig {
 		DisableRichPresence:      d.DisableRichPresence,
 	}
 }
+
+// YTDLPUpdateStatusDTO is returned by GetYTDLPUpdateStatus (yt-dlp release vs local exe).
+type YTDLPUpdateStatusDTO struct {
+	Supported         bool   `json:"supported"`
+	TargetPath        string `json:"targetPath"`
+	LocalVersion      string `json:"localVersion"`
+	LatestVersion     string `json:"latestVersion"`
+	LatestTag         string `json:"latestTag"`
+	LatestDownloadURL string `json:"latestDownloadUrl"`
+	LatestError       string `json:"latestError"`
+	UnsupportedReason string `json:"unsupportedReason,omitempty"`
+}
+
+// YTDLPApplyResultDTO is returned by ApplyYTDLP.
+type YTDLPApplyResultDTO struct {
+	Ok             bool   `json:"ok"`
+	AppliedVersion string `json:"appliedVersion"`
+	Message        string `json:"message"`
+	Error          string `json:"error"`
+}
+
+func toYTDLPUpdateStatusDTO(s usecase.YTDLPUpdateStatus) YTDLPUpdateStatusDTO {
+	return YTDLPUpdateStatusDTO{
+		Supported:         s.Supported,
+		TargetPath:        s.TargetPath,
+		LocalVersion:      s.LocalVersion,
+		LatestVersion:     s.LatestVersion,
+		LatestTag:         s.LatestTag,
+		LatestDownloadURL: s.LatestDownloadURL,
+		LatestError:       s.LatestError,
+		UnsupportedReason: s.UnsupportedReason,
+	}
+}
+
+func toYTDLPApplyResultDTO(r usecase.YTDLPApplyResult) YTDLPApplyResultDTO {
+	return YTDLPApplyResultDTO{
+		Ok:             r.Ok,
+		AppliedVersion: r.AppliedVersion,
+		Message:        r.Message,
+		Error:          r.Error,
+	}
+}

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -24,6 +24,15 @@ test.describe("VRChat Tweaker", () => {
     await expect(page.locator("h1")).toContainText("設定");
   });
 
+  test("navigates to video", async ({ page }) => {
+    await page.goto("/");
+    await page.click("text=動画");
+    await expect(page.locator("h1")).toContainText("動画");
+    await expect(
+      page.getByRole("heading", { name: "yt-dlp のバージョン管理" }),
+    ).toBeVisible();
+  });
+
   test.describe("Dashboard", () => {
     test("displays default profile and status buttons", async ({ page }) => {
       await page.goto("/");

--- a/frontend/e2e/fixtures/mock-wails.ts
+++ b/frontend/e2e/fixtures/mock-wails.ts
@@ -137,6 +137,33 @@ export function getMockWailsInitScript(): string {
         DeleteVRChatConfig: () => Promise.resolve(),
         DefaultVRChatPictureFolder: () =>
           Promise.resolve('C:\\\\Temp\\\\VRChatTweakerE2E\\\\Pictures\\\\VRChat'),
+        GetYTDLPBasics: () =>
+          Promise.resolve({
+            supported: true,
+            targetPath: 'C:\\\\Mock\\\\VRChat\\\\VRChat\\\\Tools\\\\yt-dlp.exe',
+            localVersion: '2023.11.16',
+            latestVersion: '',
+            latestTag: '',
+            latestDownloadUrl: '',
+            latestError: '',
+          }),
+        GetYTDLPUpdateStatus: () =>
+          Promise.resolve({
+            supported: true,
+            targetPath: 'C:\\\\Mock\\\\VRChat\\\\VRChat\\\\Tools\\\\yt-dlp.exe',
+            localVersion: '2023.11.16',
+            latestVersion: '2025.12.31',
+            latestTag: '2025.12.31',
+            latestDownloadUrl: 'https://example.com/yt-dlp.exe',
+            latestError: '',
+          }),
+        ApplyYTDLP: (_url, _tag) =>
+          Promise.resolve({
+            ok: true,
+            appliedVersion: '2025.12.31',
+            message: '適用しました。変更を反映するには VRChat を再起動してください。',
+            error: '',
+          }),
       };
     })();
   `.trim();

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -22,6 +22,7 @@ const menuItems = [
   { path: "/", icon: "🏠", label: "ダッシュボード" },
   { path: "/launcher", icon: "🚀", label: "ランチャー" },
   { path: "/gallery", icon: "🖼️", label: "ギャラリー" },
+  { path: "/video", icon: "🎬", label: "動画" },
   { path: "/activity", icon: "📊", label: "アクティビティ" },
   { path: "/friends", icon: "👥", label: "フレンド" },
   { path: "/automation", icon: "🤖", label: "オートメーション" },

--- a/frontend/src/components/__tests__/Sidebar.spec.ts
+++ b/frontend/src/components/__tests__/Sidebar.spec.ts
@@ -21,7 +21,7 @@ describe("Sidebar", () => {
       },
     });
     const links = wrapper.findAll(".sidebar-link");
-    expect(links.length).toBeGreaterThanOrEqual(7); // 7 main + settings
+    expect(links.length).toBeGreaterThanOrEqual(9); // 8 main + settings
   });
 
   it("has dashboard link", () => {
@@ -31,5 +31,14 @@ describe("Sidebar", () => {
       },
     });
     expect(wrapper.text()).toContain("ダッシュボード");
+  });
+
+  it("has video link", () => {
+    const wrapper = mount(Sidebar, {
+      global: {
+        plugins: [router],
+      },
+    });
+    expect(wrapper.text()).toContain("動画");
   });
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -24,6 +24,12 @@ const routes: RouteRecordRaw[] = [
     meta: { title: "ギャラリー" },
   },
   {
+    path: "/video",
+    name: "video",
+    component: () => import("./views/VideoView.vue"),
+    meta: { title: "動画" },
+  },
+  {
     path: "/activity",
     name: "activity",
     component: () => import("./views/ActivityView.vue"),

--- a/frontend/src/views/VideoView.vue
+++ b/frontend/src/views/VideoView.vue
@@ -1,0 +1,277 @@
+<template>
+  <div class="video-view">
+    <h1 class="page-title">動画</h1>
+
+    <section class="settings-section ytdlp-section">
+      <h2>yt-dlp のバージョン管理</h2>
+      <p class="section-lead">
+        VRChat が参照する公式
+        <code>yt-dlp.exe</code>
+        を GitHub の最新リリースで置き換えます。YouTube
+        再生不具合の対策に使えます。
+      </p>
+
+      <div v-if="basicsLoading" class="muted">読み込み中…</div>
+      <template v-else>
+        <p v-if="!status.supported" class="banner-warn" role="status">
+          {{ status.unsupportedReason || "この環境では利用できません。" }}
+        </p>
+        <template v-else>
+          <dl class="ytdlp-dl">
+            <dt>配置先</dt>
+            <dd>
+              <code class="path-code">{{ status.targetPath || "—" }}</code>
+            </dd>
+            <dt>現在のバージョン</dt>
+            <dd>{{ status.localVersion || "（未取得・未配置）" }}</dd>
+            <dt>GitHub 最新</dt>
+            <dd>
+              {{
+                status.latestVersion
+                  ? status.latestVersion
+                  : status.latestError
+                    ? "—"
+                    : "未確認（下のボタンで取得）"
+              }}
+            </dd>
+          </dl>
+          <p v-if="status.latestError" class="banner-error" role="alert">
+            最新版の取得に失敗しました: {{ status.latestError }}
+          </p>
+          <div class="ytdlp-actions">
+            <button
+              type="button"
+              class="btn-refresh"
+              data-testid="ytdlp-check-latest"
+              :disabled="latestCheckLoading || applyLoading"
+              @click="checkLatest"
+            >
+              {{ latestCheckLoading ? "確認中…" : "GitHub で最新版を確認" }}
+            </button>
+            <button
+              type="button"
+              class="btn-apply"
+              data-testid="ytdlp-apply"
+              :disabled="
+                applyLoading ||
+                latestCheckLoading ||
+                !status.latestDownloadUrl ||
+                !!status.latestError
+              "
+              @click="applyLatest"
+            >
+              {{
+                applyLoading
+                  ? "適用中…"
+                  : "最新版をダウンロードして VRChat に適用"
+              }}
+            </button>
+          </div>
+          <p v-if="applyFlash" class="apply-flash" :class="applyFlashClass">
+            {{ applyFlash }}
+          </p>
+        </template>
+      </template>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { App, type YTDLPUpdateStatusDTO } from "../wails/app";
+
+const status = ref<YTDLPUpdateStatusDTO>({
+  supported: false,
+  targetPath: "",
+  localVersion: "",
+  latestVersion: "",
+  latestTag: "",
+  latestDownloadUrl: "",
+  latestError: "",
+});
+const basicsLoading = ref(true);
+const latestCheckLoading = ref(false);
+const applyLoading = ref(false);
+const applyFlash = ref("");
+const applyFlashClass = ref("");
+
+async function loadBasics() {
+  basicsLoading.value = true;
+  try {
+    status.value = await App.getYTDLPBasics();
+  } finally {
+    basicsLoading.value = false;
+  }
+}
+
+async function checkLatest() {
+  latestCheckLoading.value = true;
+  applyFlash.value = "";
+  try {
+    status.value = await App.getYTDLPUpdateStatus();
+  } finally {
+    latestCheckLoading.value = false;
+  }
+}
+
+async function applyLatest() {
+  if (!status.value.latestDownloadUrl) return;
+  applyLoading.value = true;
+  applyFlash.value = "";
+  try {
+    const r = await App.applyYTDLP(
+      status.value.latestDownloadUrl,
+      status.value.latestTag,
+    );
+    if (r.ok) {
+      applyFlashClass.value = "apply-flash--ok";
+      applyFlash.value = r.message || "適用しました。";
+      status.value = await App.getYTDLPBasics();
+    } else {
+      applyFlashClass.value = "apply-flash--err";
+      applyFlash.value = r.error || "適用に失敗しました。";
+    }
+  } finally {
+    applyLoading.value = false;
+  }
+}
+
+onMounted(() => {
+  void loadBasics();
+});
+</script>
+
+<style scoped>
+.video-view {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.page-title {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+}
+
+.settings-section {
+  padding: 1rem 1.25rem;
+  background: var(--bg-secondary);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+.settings-section h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.section-lead {
+  margin: 0 0 1rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.section-lead code {
+  font-size: 0.85em;
+  padding: 0.1em 0.35em;
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+}
+
+.muted {
+  color: var(--text-secondary);
+}
+
+.banner-warn {
+  margin: 0 0 1rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius);
+  border-left: 3px solid var(--accent);
+  color: var(--text-secondary);
+}
+
+.banner-error {
+  margin: 0.75rem 0;
+  padding: 0.75rem 1rem;
+  background: rgba(229, 115, 115, 0.12);
+  border-radius: var(--radius);
+  color: var(--danger);
+}
+
+.ytdlp-dl {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  gap: 0.35rem 1rem;
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+}
+
+.ytdlp-dl dt {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.ytdlp-dl dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.path-code {
+  font-size: 0.8rem;
+}
+
+.ytdlp-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.btn-refresh {
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.btn-refresh:hover:not(:disabled) {
+  background: var(--bg-primary);
+}
+
+.btn-refresh:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn-apply {
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--radius);
+  border: none;
+  background: var(--accent);
+  color: white;
+}
+
+.btn-apply:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.btn-apply:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.apply-flash {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+}
+
+.apply-flash--ok {
+  color: var(--success);
+}
+
+.apply-flash--err {
+  color: var(--danger);
+}
+</style>

--- a/frontend/src/views/__tests__/VideoView.spec.ts
+++ b/frontend/src/views/__tests__/VideoView.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createRouter, createWebHashHistory } from "vue-router";
+import VideoView from "../VideoView.vue";
+
+const mockGetYTDLPBasics = vi.fn();
+const mockGetYTDLPUpdateStatus = vi.fn();
+const mockApplyYTDLP = vi.fn();
+
+vi.mock("../../wails/app", () => ({
+  App: {
+    getYTDLPBasics: () => mockGetYTDLPBasics(),
+    getYTDLPUpdateStatus: () => mockGetYTDLPUpdateStatus(),
+    applyYTDLP: (u: string, t: string) => mockApplyYTDLP(u, t),
+  },
+}));
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [{ path: "/video", component: VideoView }],
+});
+
+const supportedBasics = {
+  supported: true,
+  targetPath: "C:\\VRChat\\VRChat\\Tools\\yt-dlp.exe",
+  localVersion: "2024.01.01",
+  latestVersion: "",
+  latestTag: "",
+  latestDownloadUrl: "",
+  latestError: "",
+};
+
+describe("VideoView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetYTDLPBasics.mockResolvedValue({ ...supportedBasics });
+    mockGetYTDLPUpdateStatus.mockResolvedValue({
+      ...supportedBasics,
+      latestVersion: "2025.01.01",
+      latestTag: "2025.01.01",
+      latestDownloadUrl: "https://github.com/y/y/releases/download/ytdlp.exe",
+      latestError: "",
+    });
+    mockApplyYTDLP.mockResolvedValue({
+      ok: true,
+      appliedVersion: "2025.01.01",
+      message: "適用しました。",
+      error: "",
+    });
+  });
+
+  it("renders page title", async () => {
+    await router.push("/video");
+    await router.isReady();
+    const wrapper = mount(VideoView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+    expect(wrapper.find(".page-title").text()).toBe("動画");
+  });
+
+  it("disables apply until latest is confirmed", async () => {
+    await router.push("/video");
+    await router.isReady();
+    const wrapper = mount(VideoView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+    const applyBtn = wrapper.get('[data-testid="ytdlp-apply"]');
+    expect(applyBtn.attributes("disabled")).toBeDefined();
+
+    await wrapper.get('[data-testid="ytdlp-check-latest"]').trigger("click");
+    await flushPromises();
+
+    expect(mockGetYTDLPUpdateStatus).toHaveBeenCalled();
+    expect(applyBtn.attributes("disabled")).toBeUndefined();
+  });
+
+  it("shows unsupported message when basics say so", async () => {
+    mockGetYTDLPBasics.mockResolvedValue({
+      supported: false,
+      targetPath: "",
+      localVersion: "",
+      latestVersion: "",
+      latestTag: "",
+      latestDownloadUrl: "",
+      latestError: "",
+      unsupportedReason: "Windows のみ",
+    });
+    await router.push("/video");
+    await router.isReady();
+    const wrapper = mount(VideoView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+    expect(wrapper.text()).toContain("Windows のみ");
+  });
+});

--- a/frontend/src/wails/app.ts
+++ b/frontend/src/wails/app.ts
@@ -162,6 +162,34 @@ export interface VRChatConfigDTO {
   disableRichPresence: boolean | null;
 }
 
+export interface YTDLPUpdateStatusDTO {
+  supported: boolean;
+  targetPath: string;
+  localVersion: string;
+  latestVersion: string;
+  latestTag: string;
+  latestDownloadUrl: string;
+  latestError: string;
+  unsupportedReason?: string;
+}
+
+export interface YTDLPApplyResultDTO {
+  ok: boolean;
+  appliedVersion: string;
+  message: string;
+  error: string;
+}
+
+const emptyYTDLPStatus: YTDLPUpdateStatusDTO = {
+  supported: false,
+  targetPath: "",
+  localVersion: "",
+  latestVersion: "",
+  latestTag: "",
+  latestDownloadUrl: "",
+  latestError: "",
+};
+
 interface AppBindings {
   Greet(name: string): Promise<string>;
   LaunchProfiles(): Promise<LaunchProfileDTO[]>;
@@ -225,6 +253,12 @@ interface AppBindings {
   SaveVRChatConfig(dto: VRChatConfigDTO): Promise<void>;
   DeleteVRChatConfig(): Promise<void>;
   DefaultVRChatPictureFolder(): Promise<string>;
+  GetYTDLPBasics(): Promise<YTDLPUpdateStatusDTO>;
+  GetYTDLPUpdateStatus(): Promise<YTDLPUpdateStatusDTO>;
+  ApplyYTDLP(
+    downloadURL: string,
+    latestTag: string,
+  ): Promise<YTDLPApplyResultDTO>;
 }
 
 declare global {
@@ -513,5 +547,22 @@ export const App = {
   },
   async defaultVRChatPictureFolder(): Promise<string> {
     return callApp((a) => a.DefaultVRChatPictureFolder(), "");
+  },
+  async getYTDLPBasics(): Promise<YTDLPUpdateStatusDTO> {
+    return callApp((a) => a.GetYTDLPBasics(), emptyYTDLPStatus);
+  },
+  async getYTDLPUpdateStatus(): Promise<YTDLPUpdateStatusDTO> {
+    return callApp((a) => a.GetYTDLPUpdateStatus(), emptyYTDLPStatus);
+  },
+  async applyYTDLP(
+    downloadURL: string,
+    latestTag: string,
+  ): Promise<YTDLPApplyResultDTO> {
+    return callApp((a) => a.ApplyYTDLP(downloadURL, latestTag), {
+      ok: false,
+      appliedVersion: "",
+      message: "",
+      error: "App not available",
+    });
   },
 };

--- a/internal/usecase/ytdlp_update.go
+++ b/internal/usecase/ytdlp_update.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -130,8 +129,11 @@ func (u *YTDLPUpdater) FetchLatestRelease(ctx context.Context) (tagName, downloa
 	return ytdlpExeAssetFromReleaseJSON(body)
 }
 
-// LocalYTDLPVersion runs yt-dlp.exe --version when the file exists.
+// LocalYTDLPVersion returns a display version for yt-dlp.exe at exePath.
+// On Windows it reads VERSIONINFO strings (FileVersion / ProductVersion) without executing
+// the binary — the same values shown in Explorer’s file properties. On other OS it returns "".
 func LocalYTDLPVersion(ctx context.Context, exePath string) string {
+	_ = ctx
 	if exePath == "" {
 		return ""
 	}
@@ -139,15 +141,7 @@ func LocalYTDLPVersion(ctx context.Context, exePath string) string {
 	if err != nil || st.IsDir() {
 		return ""
 	}
-	cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(cctx, exePath, "--version")
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
-	return strings.TrimSpace(line)
+	return localYTDLPFileVersionString(exePath)
 }
 
 // GetBasics returns the install path and local yt-dlp version without calling GitHub.

--- a/internal/usecase/ytdlp_update.go
+++ b/internal/usecase/ytdlp_update.go
@@ -1,0 +1,293 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Name of the Windows binary in yt-dlp/yt-dlp GitHub Releases (see releases/latest assets).
+const ytdlpReleaseAssetName = "yt-dlp.exe"
+
+// DefaultYTDLPReleasesLatestURL is the GitHub API URL for the latest yt-dlp release.
+const DefaultYTDLPReleasesLatestURL = "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest"
+
+// userAgentGitHub is sent with requests to GitHub API and release asset downloads.
+const userAgentGitHub = "VRChatTweaker/1.0.0 (+https://github.com/JO3QMA/vrctweaker)"
+
+// VRChatYTDLPExePath returns the path VRChat uses for yt-dlp on Windows, derived from
+// the same directory as config.json (…/VRChat/VRChat/config.json → …/Tools/yt-dlp.exe).
+func VRChatYTDLPExePath(vrchatConfigJSONPath string) string {
+	dir := filepath.Dir(vrchatConfigJSONPath)
+	return filepath.Join(dir, "Tools", ytdlpReleaseAssetName)
+}
+
+// YTDLPUpdateStatus is the outcome of checking local and latest yt-dlp versions.
+type YTDLPUpdateStatus struct {
+	Supported         bool   `json:"supported"`
+	TargetPath        string `json:"targetPath"`
+	LocalVersion      string `json:"localVersion"`
+	LatestVersion     string `json:"latestVersion"`
+	LatestTag         string `json:"latestTag"`
+	LatestDownloadURL string `json:"latestDownloadUrl"`
+	LatestError       string `json:"latestError"`
+	UnsupportedReason string `json:"unsupportedReason,omitempty"`
+}
+
+// YTDLPApplyResult is the outcome of downloading and installing yt-dlp.exe.
+type YTDLPApplyResult struct {
+	Ok             bool   `json:"ok"`
+	AppliedVersion string `json:"appliedVersion"`
+	Message        string `json:"message"`
+	Error          string `json:"error"`
+}
+
+type githubReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type githubReleaseLatest struct {
+	TagName string               `json:"tag_name"`
+	Assets  []githubReleaseAsset `json:"assets"`
+}
+
+// YTDLPUpdater fetches official yt-dlp releases and installs the Windows exe.
+type YTDLPUpdater struct {
+	HTTPClient        *http.Client
+	ReleasesLatestURL string
+}
+
+// NewYTDLPUpdater returns an updater with sane defaults.
+func NewYTDLPUpdater() *YTDLPUpdater {
+	return &YTDLPUpdater{
+		HTTPClient: &http.Client{
+			Timeout: 5 * time.Minute,
+		},
+		ReleasesLatestURL: DefaultYTDLPReleasesLatestURL,
+	}
+}
+
+func (u *YTDLPUpdater) httpClient() *http.Client {
+	if u.HTTPClient != nil {
+		return u.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// ytdlpExeAssetFromReleaseJSON extracts tag and yt-dlp.exe download URL from a GitHub release JSON body.
+func ytdlpExeAssetFromReleaseJSON(data []byte) (tagName, downloadURL string, err error) {
+	var rel githubReleaseLatest
+	if err := json.Unmarshal(data, &rel); err != nil {
+		return "", "", fmt.Errorf("parse release JSON: %w", err)
+	}
+	tag := strings.TrimSpace(rel.TagName)
+	if tag == "" {
+		return "", "", errors.New("release has empty tag_name")
+	}
+	for _, a := range rel.Assets {
+		if a.Name == ytdlpReleaseAssetName && strings.TrimSpace(a.BrowserDownloadURL) != "" {
+			return tag, a.BrowserDownloadURL, nil
+		}
+	}
+	return "", "", fmt.Errorf("asset %q not found in release", ytdlpReleaseAssetName)
+}
+
+// FetchLatestRelease resolves the latest release tag and yt-dlp.exe browser_download_url.
+func (u *YTDLPUpdater) FetchLatestRelease(ctx context.Context) (tagName, downloadURL string, err error) {
+	apiURL := u.ReleasesLatestURL
+	if strings.TrimSpace(apiURL) == "" {
+		apiURL = DefaultYTDLPReleasesLatestURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", userAgentGitHub)
+
+	resp, err := u.httpClient().Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("github api request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return "", "", fmt.Errorf("read release response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("github api: %s: %s", resp.Status, truncateForErr(string(body), 200))
+	}
+	return ytdlpExeAssetFromReleaseJSON(body)
+}
+
+// LocalYTDLPVersion runs yt-dlp.exe --version when the file exists.
+func LocalYTDLPVersion(ctx context.Context, exePath string) string {
+	if exePath == "" {
+		return ""
+	}
+	st, err := os.Stat(exePath)
+	if err != nil || st.IsDir() {
+		return ""
+	}
+	cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, exePath, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	return strings.TrimSpace(line)
+}
+
+// GetBasics returns the install path and local yt-dlp version without calling GitHub.
+func (u *YTDLPUpdater) GetBasics(ctx context.Context, vrchatConfigJSONPath string) YTDLPUpdateStatus {
+	target := VRChatYTDLPExePath(vrchatConfigJSONPath)
+	if runtime.GOOS != "windows" {
+		return YTDLPUpdateStatus{
+			Supported:         false,
+			TargetPath:        target,
+			UnsupportedReason: "この機能は Windows 版のみ利用できます。",
+		}
+	}
+	local := LocalYTDLPVersion(ctx, target)
+	return YTDLPUpdateStatus{
+		Supported:    true,
+		TargetPath:   target,
+		LocalVersion: local,
+	}
+}
+
+// GetUpdateStatus loads local version (if any) and fetches latest from GitHub.
+func (u *YTDLPUpdater) GetUpdateStatus(ctx context.Context, vrchatConfigJSONPath string) YTDLPUpdateStatus {
+	st := u.GetBasics(ctx, vrchatConfigJSONPath)
+	if !st.Supported {
+		return st
+	}
+	tag, url, err := u.FetchLatestRelease(ctx)
+	if err != nil {
+		st.LatestError = err.Error()
+		return st
+	}
+	st.LatestVersion = normalizeReleaseTag(tag)
+	st.LatestTag = strings.TrimSpace(tag)
+	st.LatestDownloadURL = url
+	return st
+}
+
+func normalizeReleaseTag(tag string) string {
+	return strings.TrimPrefix(strings.TrimSpace(tag), "v")
+}
+
+// ApplyLatest downloads the given URL and replaces target exe with backup.
+func (u *YTDLPUpdater) ApplyLatest(ctx context.Context, vrchatConfigJSONPath, downloadURL, expectedTag string) YTDLPApplyResult {
+	if runtime.GOOS != "windows" {
+		return YTDLPApplyResult{
+			Ok:    false,
+			Error: "この機能は Windows 版のみ利用できます。",
+		}
+	}
+	exePath := VRChatYTDLPExePath(vrchatConfigJSONPath)
+	toolsDir := filepath.Dir(exePath)
+	if err := os.MkdirAll(toolsDir, 0o755); err != nil {
+		return YTDLPApplyResult{Ok: false, Error: fmt.Sprintf("Tools フォルダを作成できません: %v", err)}
+	}
+
+	partPath := exePath + ".part"
+	if err := downloadToFile(ctx, u.httpClient(), downloadURL, partPath); err != nil {
+		_ = os.Remove(partPath)
+		return YTDLPApplyResult{Ok: false, Error: err.Error()}
+	}
+
+	if err := finishYTDLPInstall(exePath, partPath); err != nil {
+		_ = os.Remove(partPath)
+		return YTDLPApplyResult{
+			Ok:    false,
+			Error: fmt.Sprintf("既存ファイルの退避または配置に失敗しました（VRChat 終了後に再試行してください）: %v", err),
+		}
+	}
+
+	applied := normalizeReleaseTag(expectedTag)
+	if applied == "" {
+		applied = LocalYTDLPVersion(ctx, exePath)
+	}
+	return YTDLPApplyResult{
+		Ok:             true,
+		AppliedVersion: applied,
+		Message:        "適用しました。変更を反映するには VRChat を再起動してください。",
+	}
+}
+
+func tryRestoreFromBak(exePath, bakPath string) error {
+	if _, err := os.Stat(bakPath); err != nil {
+		return err
+	}
+	return os.Rename(bakPath, exePath)
+}
+
+// finishYTDLPInstall moves partPath into exePath after backing up an existing exe to .bak.
+func finishYTDLPInstall(exePath, partPath string) error {
+	bakPath := exePath + ".bak"
+	_ = os.Remove(bakPath)
+	if _, err := os.Stat(exePath); err == nil {
+		if err := os.Rename(exePath, bakPath); err != nil {
+			return fmt.Errorf("backup: %w", err)
+		}
+	}
+	if err := os.Rename(partPath, exePath); err != nil {
+		_ = tryRestoreFromBak(exePath, bakPath)
+		return fmt.Errorf("install: %w", err)
+	}
+	return nil
+}
+
+func downloadToFile(ctx context.Context, client *http.Client, url, dest string) error {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgentGitHub)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("ダウンロード要求に失敗しました: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		slurp, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("ダウンロードに失敗しました (%s): %s", resp.Status, truncateForErr(string(slurp), 200))
+	}
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("一時ファイルを作成できません: %w", err)
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("書き込みに失敗しました: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func truncateForErr(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/internal/usecase/ytdlp_update_test.go
+++ b/internal/usecase/ytdlp_update_test.go
@@ -1,0 +1,204 @@
+package usecase
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestYtdlpExeAssetFromReleaseJSON(t *testing.T) {
+	t.Parallel()
+	const payload = `{
+  "tag_name": "2025.01.15",
+  "assets": [
+    {"name": "other.zip", "browser_download_url": "https://example.com/o.zip"},
+    {"name": "yt-dlp.exe", "browser_download_url": "https://github.com/y/y/releases/download/2025.01.15/yt-dlp.exe"}
+  ]
+}`
+	tag, url, err := ytdlpExeAssetFromReleaseJSON([]byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "2025.01.15" {
+		t.Fatalf("tag: got %q", tag)
+	}
+	if !strings.HasSuffix(url, "yt-dlp.exe") {
+		t.Fatalf("url: got %q", url)
+	}
+}
+
+func TestYtdlpExeAssetFromReleaseJSON_missingAsset(t *testing.T) {
+	t.Parallel()
+	const payload = `{"tag_name": "1.0.0", "assets": [{"name": "foo", "browser_download_url": "https://x"}]}`
+	_, _, err := ytdlpExeAssetFromReleaseJSON([]byte(payload))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNormalizeReleaseTag(t *testing.T) {
+	t.Parallel()
+	if g := normalizeReleaseTag("v2024.12.01"); g != "2024.12.01" {
+		t.Fatalf("got %q", g)
+	}
+}
+
+func TestFetchLatestRelease_httptest(t *testing.T) {
+	t.Parallel()
+	const relJSON = `{
+  "tag_name": "2025.02.01",
+  "assets": [
+    {"name": "yt-dlp.exe", "browser_download_url": "PLACEHOLDER"}
+  ]
+}`
+	var srvURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/latest", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method %s", r.Method)
+		}
+		body := strings.ReplaceAll(relJSON, "PLACEHOLDER", srvURL+"/bin/yt-dlp.exe")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+	mux.HandleFunc("/bin/yt-dlp.exe", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("MZfake"))
+	})
+	srv := httptest.NewServer(mux)
+	srvURL = srv.URL
+	defer srv.Close()
+
+	u := &YTDLPUpdater{
+		HTTPClient:        srv.Client(),
+		ReleasesLatestURL: srv.URL + "/api/latest",
+	}
+	ctx := context.Background()
+	tag, dl, err := u.FetchLatestRelease(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "2025.02.01" {
+		t.Fatalf("tag %q", tag)
+	}
+	if !strings.HasSuffix(dl, "/bin/yt-dlp.exe") {
+		t.Fatalf("dl %q", dl)
+	}
+}
+
+func TestDownloadToFile(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello-ytdlp"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.part")
+	ctx := context.Background()
+	if err := downloadToFile(ctx, srv.Client(), srv.URL, dest); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "hello-ytdlp" {
+		t.Fatalf("content %q", b)
+	}
+}
+
+func TestFinishYTDLPInstall_backupAndReplace(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "yt-dlp.exe")
+	part := filepath.Join(dir, "yt-dlp.exe.part")
+	bak := filepath.Join(dir, "yt-dlp.exe.bak")
+
+	if err := os.WriteFile(exe, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(part, []byte("newbinary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := finishYTDLPInstall(exe, part); err != nil {
+		t.Fatal(err)
+	}
+	gotExe, _ := os.ReadFile(exe)
+	if string(gotExe) != "newbinary" {
+		t.Fatalf("exe content %q", gotExe)
+	}
+	gotBak, _ := os.ReadFile(bak)
+	if string(gotBak) != "old" {
+		t.Fatalf("bak content %q", gotBak)
+	}
+	if _, err := os.Stat(part); !os.IsNotExist(err) {
+		t.Fatal("part should be gone")
+	}
+}
+
+func TestFinishYTDLPInstall_freshInstall(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "yt-dlp.exe")
+	part := filepath.Join(dir, "yt-dlp.exe.part")
+	if err := os.WriteFile(part, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := finishYTDLPInstall(exe, part); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(exe)
+	if string(b) != "x" {
+		t.Fatal(string(b))
+	}
+}
+
+func TestLocalYTDLPVersion_script(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script not used on windows")
+	}
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "yt-dlp-exe-mock")
+	script := "#!/bin/sh\necho 2099.01.01\n"
+	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	v := LocalYTDLPVersion(ctx, exe)
+	if v != "2099.01.01" {
+		t.Fatalf("got %q", v)
+	}
+}
+
+func TestGetUpdateStatus_unsupportedOS(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("windows is supported")
+	}
+	u := NewYTDLPUpdater()
+	st := u.GetUpdateStatus(context.Background(), filepath.Join("/tmp", "VRChat", "VRChat", "config.json"))
+	if st.Supported {
+		t.Fatal("expected unsupported")
+	}
+	if st.UnsupportedReason == "" {
+		t.Fatal("expected reason")
+	}
+}
+
+func TestVRChatYTDLPExePath(t *testing.T) {
+	t.Parallel()
+	cfg := filepath.Join("/home", "u", ".local", "share", "VRChat", "VRChat", "config.json")
+	want := filepath.Join("/home", "u", ".local", "share", "VRChat", "VRChat", "Tools", ytdlpReleaseAssetName)
+	if g := VRChatYTDLPExePath(cfg); g != want {
+		t.Fatalf("got %q want %q", g, want)
+	}
+}

--- a/internal/usecase/ytdlp_update_test.go
+++ b/internal/usecase/ytdlp_update_test.go
@@ -160,22 +160,21 @@ func TestFinishYTDLPInstall_freshInstall(t *testing.T) {
 	}
 }
 
-func TestLocalYTDLPVersion_script(t *testing.T) {
+func TestLocalYTDLPVersion_nonWindowsNoExec(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
-		t.Skip("shell script not used on windows")
+		t.Skip("Windows reads VERSIONINFO in ytdlp_version_windows.go")
 	}
 	dir := t.TempDir()
-	exe := filepath.Join(dir, "yt-dlp-exe-mock")
-	script := "#!/bin/sh\necho 2099.01.01\n"
-	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
+	exe := filepath.Join(dir, "yt-dlp.exe")
+	if err := os.WriteFile(exe, []byte("not a real exe"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	v := LocalYTDLPVersion(ctx, exe)
-	if v != "2099.01.01" {
-		t.Fatalf("got %q", v)
+	if v != "" {
+		t.Fatalf("expected empty on non-Windows, got %q", v)
 	}
 }
 

--- a/internal/usecase/ytdlp_version_other.go
+++ b/internal/usecase/ytdlp_version_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package usecase
+
+func localYTDLPFileVersionString(_ string) string {
+	return ""
+}

--- a/internal/usecase/ytdlp_version_windows.go
+++ b/internal/usecase/ytdlp_version_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package usecase
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// localYTDLPFileVersionString reads FileVersion / ProductVersion from the PE VERSIONINFO
+// resource (same metadata as Explorer “詳細” / file properties), without executing the exe.
+func localYTDLPFileVersionString(exePath string) string {
+	if exePath == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(exePath)
+	if err != nil {
+		abs = exePath
+	}
+	size, err := windows.GetFileVersionInfoSize(abs, nil)
+	if err != nil || size == 0 {
+		return ""
+	}
+	buf := make([]byte, size)
+	err = windows.GetFileVersionInfo(abs, 0, size, unsafe.Pointer(&buf[0]))
+	if err != nil {
+		return ""
+	}
+	return stringFileInfoVersionKeys(unsafe.Pointer(&buf[0]), "FileVersion", "ProductVersion")
+}
+
+func stringFileInfoVersionKeys(block unsafe.Pointer, keys ...string) string {
+	var trans unsafe.Pointer
+	var transLen uint32
+	err := windows.VerQueryValue(block, `\VarFileInfo\Translation`, unsafe.Pointer(&trans), &transLen)
+	if err != nil || trans == nil || transLen < 4 {
+		return ""
+	}
+	nLang := int(transLen) / 4
+	langCPs := unsafe.Slice((*uint32)(trans), nLang)
+	for _, langCP := range langCPs {
+		lang := langCP & 0xffff
+		cp := (langCP >> 16) & 0xffff
+		prefix := fmt.Sprintf(`\StringFileInfo\%04x%04x\`, lang, cp)
+		for _, key := range keys {
+			var val unsafe.Pointer
+			var valLen uint32
+			sub := prefix + key
+			err = windows.VerQueryValue(block, sub, unsafe.Pointer(&val), &valLen)
+			if err != nil || val == nil || valLen < 2 {
+				continue
+			}
+			n := valLen / 2
+			if n == 0 {
+				continue
+			}
+			u16 := unsafe.Slice((*uint16)(val), n)
+			s := windows.UTF16ToString(u16)
+			s = strings.TrimSpace(s)
+			if s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}

--- a/internal/usecase/ytdlp_version_windows_test.go
+++ b/internal/usecase/ytdlp_version_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package usecase
+
+import "testing"
+
+func TestLocalYTDLPFileVersionString_nonexistent(t *testing.T) {
+	t.Parallel()
+	if g := localYTDLPFileVersionString(`C:\path\that\does\not\exist\yt-dlp.exe`); g != "" {
+		t.Fatalf("want empty, got %q", g)
+	}
+}


### PR DESCRIPTION
## 概要
GitHub [Issue #9](https://github.com/JO3QMA/vrctweaker/issues/9) に対応します。

## 変更内容
- **UI**: サイドバーに「動画」タブを追加し、`VideoView` で yt-dlp のバージョン表示・GitHub 最新確認・公式 `yt-dlp.exe` のダウンロード適用を提供します。
- **バックエンド**: `internal/usecase/ytdlp_update.go` で GitHub API `releases/latest` から `yt-dlp.exe` を取得し、`getVRChatConfigPath()` と同じルート配下の `Tools/yt-dlp.exe` に配置します。既存 exe は `yt-dlp.exe.bak` に退避します。**Windows のみ**が対象です（他 OS は未対応メッセージ）。
- **Wails**: `GetYTDLPBasics`（GitHub 非呼び出し）、`GetYTDLPUpdateStatus`、`ApplyYTDLP` を追加しました。
- **テスト**: Go 単体テスト、Vitest、Playwright モックを更新しました。

## 確認
- `make fmt` / `make test` / `make lint` 済み

closes #9

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jo3qma/vrctweaker/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
