### PR TITLE
fix(frontend): pnpm frozen-lockfile overrides mismatch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
   },
   "pnpm": {
     "overrides": {
-      "typescript": "$typescript"
+      "typescript": "~6.0.2"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
### 概要
CI の `pnpm install --frozen-lockfile` が `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` で落ちる件です。`origin/main` にはまだ `pnpm.overrides.typescript: \"$typescript\"` が残っており、`pnpm-lock.yaml` の `overrides`（`~6.0.2`）と一致していません。

### 変更
- `frontend/package.json` の `pnpm.overrides.typescript` を `~6.0.2` に変更（ロックファイルと同一表記）

### 確認
- `CI=1 npx pnpm@9.15.9 install --frozen-lockfile`（`frontend/`）で成功

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jo3qma/vrctweaker/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
