### PR TITLE
test(e2e): cover all app routes with Playwright specs

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -14,6 +14,6 @@ if [[ -f "go.mod" ]]; then
 fi
 
 if [[ -f "frontend/package.json" ]]; then
-  cd frontend && pnpm install && pnpm exec playwright install chromium && cd ..
+  cd frontend && pnpm install && pnpm exec playwright install --with-deps chromium && cd ..
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # vrchat-tweaker Makefile
 # フルビルド、front/backendビルド、lint、fmt、test、e2e を実行
 
-.PHONY: all build build-native build-windows build-front build-back dev-wails lint fmt test test-e2e clean help
+.PHONY: all build build-native build-windows build-front build-back dev-wails lint fmt test test-e2e setup-e2e clean help
 
 # デフォルトターゲット
 all: build
@@ -76,8 +76,11 @@ test-front:
 
 # --- E2E テスト ---
 
+## E2E テスト環境の初回セットアップ（pnpm install + Playwright chromium）
+setup-e2e: install-front test-e2e-install
+
 ## E2Eテスト（Playwright）
-## 初回は `make test-e2e-install` でブラウザをインストール
+## 初回は `make setup-e2e`（または `make test-e2e-install`）でブラウザをインストール
 ## 手元で通常の `pnpm run dev` が :5173 を占有していると E2E 用サーバーが起動できないため、失敗時は dev を止めてから再実行すること
 test-e2e:
 	cd frontend && pnpm run test:e2e
@@ -123,6 +126,7 @@ help:
 	@echo "  make test         - 全体のユニットテスト"
 	@echo "  make test-back    - バックエンドテスト"
 	@echo "  make test-front   - フロントエンドテスト"
+	@echo "  make setup-e2e    - E2E 環境の初回セットアップ"
 	@echo "  make test-e2e     - E2Eテスト（Playwright）"
 	@echo "  make test-e2e-install - Playwright ブラウザのインストール"
 	@echo ""

--- a/frontend/e2e/activity.spec.ts
+++ b/frontend/e2e/activity.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+import { E2E_TEST_USER_DISPLAY_NAME } from "./fixtures/seed-data";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getMockWailsInitScript());
+});
+
+test.describe("Activity", () => {
+  test("shows playtime and encounter sections with seeded data", async ({
+    page,
+  }) => {
+    await page.goto("/#/activity");
+    await expect(page.locator("h1")).toContainText("アクティビティ");
+
+    const playtimeCard = page.locator(".section-card--playtime");
+    await expect(playtimeCard.getByText("読み込み中")).toBeHidden({
+      timeout: 15_000,
+    });
+
+    await expect(
+      playtimeCard.getByText("プレイ時間（直近14日）"),
+    ).toBeVisible();
+    await expect(
+      playtimeCard.locator(".playtime-chart-wrap canvas"),
+    ).toBeVisible();
+
+    const encounterCard = page.locator(".section-card--encounters");
+    await expect(encounterCard.getByText("読み込み中")).toBeHidden({
+      timeout: 15_000,
+    });
+    await expect(encounterCard.getByText("遭遇ログ（滞在区間）")).toBeVisible();
+
+    const encounterTable = encounterCard.locator(".el-table");
+    await expect(encounterTable).toBeVisible();
+    await expect(
+      encounterTable
+        .getByRole("button", { name: E2E_TEST_USER_DISPLAY_NAME })
+        .first(),
+    ).toBeVisible();
+    await expect(encounterTable.locator(".el-table__row")).toHaveCount(3);
+  });
+
+  test("filters encounters by display name and refresh works", async ({
+    page,
+  }) => {
+    await page.goto("/#/activity");
+    await expect(page.locator("h1")).toContainText("アクティビティ");
+
+    const encounterCard = page.locator(".section-card--encounters");
+    await expect(encounterCard.getByText("読み込み中")).toBeHidden({
+      timeout: 15_000,
+    });
+
+    const displayNameInput = encounterCard.getByPlaceholder("表示名で検索");
+    await displayNameInput.fill("E2E Test");
+    await expect(encounterCard.locator(".el-table__row")).toHaveCount(2);
+
+    await displayNameInput.fill("E2E Visitor");
+    await expect(encounterCard.locator(".el-table__row")).toHaveCount(1);
+    await expect(
+      encounterCard.getByRole("button", { name: "E2E Visitor" }),
+    ).toBeVisible();
+
+    await displayNameInput.clear();
+    await expect(encounterCard.locator(".el-table__row")).toHaveCount(3);
+
+    await encounterCard.getByRole("button", { name: "更新" }).click();
+    await expect(encounterCard.getByText("読み込み中")).toBeHidden({
+      timeout: 15_000,
+    });
+    await expect(encounterCard.locator(".el-table__row")).toHaveCount(3);
+  });
+});

--- a/frontend/e2e/automation.spec.ts
+++ b/frontend/e2e/automation.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getMockWailsInitScript());
+});
+
+test.describe("Automation", () => {
+  test("shows seeded rule and opens new rule editor", async ({ page }) => {
+    await page.goto("/#/automation");
+    await expect(page.locator("h1")).toContainText("オートメーション");
+
+    await expect(page.getByText("E2E AFK → Busy")).toBeVisible();
+
+    await page.getByRole("button", { name: "+ 新規ルール" }).click();
+    await expect(page.locator(".rule-editor")).toBeVisible();
+    await expect(page.locator(".rule-editor")).toContainText("新規ルール");
+  });
+
+  test("clicking seeded rule opens editor with rule name field", async ({
+    page,
+  }) => {
+    await page.goto("/#/automation");
+    await expect(page.locator("h1")).toContainText("オートメーション");
+
+    await page
+      .locator(".rule-card")
+      .filter({ hasText: "E2E AFK → Busy" })
+      .click();
+    await expect(page.locator(".rule-editor")).toBeVisible();
+    await expect(page.locator(".rule-editor")).toContainText("ルールを編集");
+
+    const nameInput = page
+      .locator(".rule-editor .el-form-item")
+      .filter({ hasText: "ルール名" })
+      .locator("input")
+      .first();
+    await expect(nameInput).toHaveValue("E2E AFK → Busy");
+  });
+});

--- a/frontend/e2e/config.spec.ts
+++ b/frontend/e2e/config.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getMockWailsInitScript());
+});
+
+test.describe("Config", () => {
+  test("shows editor when VRChat config exists and camera preset interaction", async ({
+    page,
+  }) => {
+    await page.goto("/#/config");
+    await expect(page.locator("h1")).toContainText("その他の設定");
+
+    // mock: VRChatConfigExists → true → editor mode with save button
+    await expect(page.getByTestId("save-config-btn")).toBeVisible();
+
+    await page.getByTestId("camera-preset-fhd").click();
+    await expect(page.getByTestId("picture-output-folder-input")).toBeVisible();
+  });
+});

--- a/frontend/e2e/detail-views.spec.ts
+++ b/frontend/e2e/detail-views.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+import {
+  E2E_TEST_USER_DISPLAY_NAME,
+  E2E_TEST_USER_ID,
+  E2E_WORLD_ID,
+} from "./fixtures/seed-data";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getMockWailsInitScript());
+});
+
+test.describe("Detail views", () => {
+  test("encounter-history shows warning for invalid query", async ({
+    page,
+  }) => {
+    await page.goto("/#/activity/encounter-history");
+    await expect(page.locator(".el-alert--warning")).toContainText(
+      "表示できません",
+    );
+  });
+
+  test("encounter-history shows world title for kind=world", async ({
+    page,
+  }) => {
+    await page.goto(
+      `/#/activity/encounter-history?kind=world&worldId=${E2E_WORLD_ID}`,
+    );
+    await expect(page.locator("h1")).toContainText("ワールド別");
+  });
+
+  test("user-profile shows error when user id is missing", async ({ page }) => {
+    await page.goto("/#/user-profile");
+    await expect(page.locator(".el-alert--warning")).toContainText(
+      "ユーザー ID が指定されていません",
+    );
+  });
+
+  test("user-profile shows display name from ResolveUserProfileNavigation", async ({
+    page,
+  }) => {
+    const query = new URLSearchParams({
+      vrcUserId: E2E_TEST_USER_ID,
+      displayName: E2E_TEST_USER_DISPLAY_NAME,
+    }).toString();
+    await page.goto(`/#/user-profile?${query}`);
+    await expect(page.locator(".profile-display-name")).toHaveText(
+      E2E_TEST_USER_DISPLAY_NAME,
+    );
+  });
+
+  test("licenses page shows OSS licenses table with npm rows", async ({
+    page,
+  }) => {
+    await page.goto("/#/licenses");
+    await expect(page.locator("h1")).toContainText("OSS ライセンス");
+    const rowCount = await page.locator(".licenses-table tbody tr").count();
+    expect(rowCount).toBeGreaterThan(0);
+  });
+});

--- a/frontend/e2e/fixtures/app-routes.ts
+++ b/frontend/e2e/fixtures/app-routes.ts
@@ -1,0 +1,46 @@
+import {
+  E2E_TEST_USER_DISPLAY_NAME,
+  E2E_TEST_USER_ID,
+  E2E_WORLD_ID,
+} from "./seed-data";
+
+const userProfileQuery = new URLSearchParams({
+  vrcUserId: E2E_TEST_USER_ID,
+  displayName: E2E_TEST_USER_DISPLAY_NAME,
+}).toString();
+
+const encounterHistoryUserQuery = new URLSearchParams({
+  kind: "user",
+  vrcUserId: E2E_TEST_USER_ID,
+}).toString();
+
+/** frontend/src/main.ts の全 11 ルート（hash ルーター。Playwright では /#/path 形式で遷移） */
+export const APP_ROUTES = [
+  { path: "/", name: "dashboard", titleJa: "ダッシュボード" },
+  { path: "/launcher", name: "launcher", titleJa: "ランチャー" },
+  { path: "/gallery", name: "gallery", titleJa: "ギャラリー" },
+  { path: "/activity", name: "activity", titleJa: "アクティビティ" },
+  {
+    path: `/activity/encounter-history?${encounterHistoryUserQuery}`,
+    name: "encounter-history",
+    titleJa: "遭遇履歴",
+  },
+  { path: "/friends", name: "friends", titleJa: "フレンド" },
+  {
+    path: `/user-profile?${userProfileQuery}`,
+    name: "user-profile",
+    titleJa: "ユーザー",
+  },
+  { path: "/automation", name: "automation", titleJa: "オートメーション" },
+  { path: "/config", name: "config", titleJa: "その他の設定" },
+  { path: "/settings", name: "settings", titleJa: "設定" },
+  { path: "/licenses", name: "licenses", titleJa: "OSSライセンス" },
+] as const;
+
+/** 遭遇履歴（ワールド別）の例。APP_ROUTES 外の補助定数 */
+export const ENCOUNTER_HISTORY_WORLD_PATH = `/activity/encounter-history?${new URLSearchParams(
+  {
+    kind: "world",
+    worldId: E2E_WORLD_ID,
+  },
+).toString()}`;

--- a/frontend/e2e/fixtures/mock-wails.ts
+++ b/frontend/e2e/fixtures/mock-wails.ts
@@ -10,34 +10,125 @@
  * - mock-wails.ts は app.spec.ts 経由でのみ参照され、app.spec.ts は Playwright テストランナー専用
  */
 
+import {
+  E2E_TEST_USER_ID,
+  SEED_ACTIVITY_STATS,
+  SEED_AUTOMATION_RULES,
+  SEED_ENCOUNTERS,
+  SEED_FRIENDS,
+  SEED_LAUNCH_PROFILES,
+  SEED_PATH_SETTINGS,
+  SEED_SCREENSHOTS,
+  SEED_VRCHAT_CONFIG,
+  seedUserProfileNavigation,
+} from "./seed-data";
+
 /** ページ読み込み前に注入する window.go スタブの初期化スクリプトを返す（中身はブラウザでそのまま実行されるため TypeScript 構文不可） */
 export function getMockWailsInitScript(): string {
-  const seedProfiles = [
-    {
-      id: "profile-1",
-      name: "デフォルトプロファイル",
-      arguments: "",
-      isDefault: true,
-      createdAt: "2025-01-01T00:00:00Z",
-      updatedAt: "2025-01-01T00:00:00Z",
-    },
-  ];
-
-  const seedPathSettings = {
-    vrchatPathWindows: "",
-    steamPathLinux: "",
-    outputLogPath: "",
-  };
-
-  // JSON として埋め込み、ブラウザ側でパースして使用
-  const profilesJson = JSON.stringify(seedProfiles);
-  const pathSettingsJson = JSON.stringify(seedPathSettings);
+  const profilesJson = JSON.stringify(SEED_LAUNCH_PROFILES);
+  const pathSettingsJson = JSON.stringify(SEED_PATH_SETTINGS);
+  const screenshotsJson = JSON.stringify(SEED_SCREENSHOTS);
+  const encountersJson = JSON.stringify(SEED_ENCOUNTERS);
+  const friendsJson = JSON.stringify(SEED_FRIENDS);
+  const activityStatsJson = JSON.stringify(SEED_ACTIVITY_STATS);
+  const automationRulesJson = JSON.stringify(SEED_AUTOMATION_RULES);
+  const vrchatConfigJson = JSON.stringify(SEED_VRCHAT_CONFIG);
+  const e2eTestUserIdJson = JSON.stringify(E2E_TEST_USER_ID);
+  const resolveUserProfileSeedJson = JSON.stringify(
+    seedUserProfileNavigation(E2E_TEST_USER_ID),
+  );
 
   return `
     (function() {
       if (typeof window === 'undefined') return;
       const profiles = ${profilesJson};
       const pathSettings = ${pathSettingsJson};
+      const screenshots = ${screenshotsJson};
+      const encounters = ${encountersJson};
+      const friends = ${friendsJson};
+      const activityStats = ${activityStatsJson};
+      const automationRules = ${automationRulesJson};
+      const vrchatConfig = ${vrchatConfigJson};
+      const e2eTestUserId = ${e2eTestUserIdJson};
+      const resolveUserProfileSeed = ${resolveUserProfileSeedJson};
+
+      function filterScreenshotsByWorldId(list, worldId) {
+        if (!worldId || !String(worldId).trim()) return list;
+        return list.filter(function(s) { return s.worldId === worldId; });
+      }
+
+      function searchScreenshots(list, filter) {
+        var result = list;
+        if (!filter) return result;
+        if (filter.worldId && String(filter.worldId).trim()) {
+          result = result.filter(function(s) { return s.worldId === filter.worldId; });
+        }
+        if (filter.worldName && String(filter.worldName).trim()) {
+          var q = String(filter.worldName).trim().toLowerCase();
+          result = result.filter(function(s) {
+            return s.worldName && s.worldName.toLowerCase().indexOf(q) !== -1;
+          });
+        }
+        if (filter.dateFrom && String(filter.dateFrom).trim()) {
+          var from = String(filter.dateFrom).trim();
+          result = result.filter(function(s) {
+            return !s.takenAt || s.takenAt.slice(0, 10) >= from;
+          });
+        }
+        if (filter.dateTo && String(filter.dateTo).trim()) {
+          var to = String(filter.dateTo).trim();
+          result = result.filter(function(s) {
+            return !s.takenAt || s.takenAt.slice(0, 10) <= to;
+          });
+        }
+        return result;
+      }
+
+      function encountersByVrcUserId(list, vrcUserId) {
+        return list.filter(function(e) { return e.vrcUserId === vrcUserId; });
+      }
+
+      function encountersByWorldId(list, worldId) {
+        return list.filter(function(e) { return e.worldId === worldId; });
+      }
+
+      function resolveUserProfileNavigation(vrcUserId) {
+        if (vrcUserId === e2eTestUserId) {
+          return {
+            user: resolveUserProfileSeed.user,
+            openInFriendsView: resolveUserProfileSeed.openInFriendsView,
+          };
+        }
+        return {
+          user: {
+            vrcUserId: vrcUserId,
+            displayName: '',
+            status: '',
+            isFavorite: false,
+            lastUpdated: '',
+          },
+          openInFriendsView: false,
+        };
+      }
+
+      var wailsEventHandlers = {};
+      function emitWailsEvent(eventName, data) {
+        var handlers = wailsEventHandlers[eventName] || [];
+        handlers.forEach(function(h) { h(data); });
+      }
+
+      window.runtime = {
+        EventsOn: function(eventName, cb) {
+          if (!wailsEventHandlers[eventName]) wailsEventHandlers[eventName] = [];
+          wailsEventHandlers[eventName].push(cb);
+          return function() {
+            wailsEventHandlers[eventName] = (wailsEventHandlers[eventName] || []).filter(function(h) {
+              return h !== cb;
+            });
+          };
+        },
+      };
+
       window.go = window.go || {};
       window.go.main = window.go.main || {};
       window.go.main.App = {
@@ -90,35 +181,40 @@ export function getMockWailsInitScript(): string {
         OpenVRChatLogFolder: () => Promise.resolve(),
         OpenFileDialog: () => Promise.resolve(''),
         OpenDirectoryDialog: () => Promise.resolve(''),
-        Screenshots: () => Promise.resolve([]),
-        SearchScreenshots: () => Promise.resolve([]),
-        GetScreenshot: () => Promise.resolve(null),
+        Screenshots: (worldId) =>
+          Promise.resolve(filterScreenshotsByWorldId(screenshots, worldId)),
+        SearchScreenshots: (filter) =>
+          Promise.resolve(searchScreenshots(screenshots, filter)),
+        GetScreenshot: (id) =>
+          Promise.resolve(
+            screenshots.find(function(s) { return s.id === id; }) || null,
+          ),
         ScreenshotThumbnailDataURL: () =>
           Promise.resolve(
             'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
           ),
         OpenScreenshotExternally: () => Promise.resolve(),
         RevealScreenshotInFileManager: () => Promise.resolve(),
-        ScanScreenshotDir: () => Promise.resolve(0),
+        ScanScreenshotDir: function() {
+          return Promise.resolve(0).then(function(count) {
+            setTimeout(function() {
+              emitWailsEvent('gallery:scan-done', { count: count });
+            }, 0);
+            return count;
+          });
+        },
         IsGalleryScanning: () => Promise.resolve(false),
         ReindexScreenshotDir: () => Promise.resolve(0),
-        Encounters: () => Promise.resolve([]),
-        EncountersByVRCUserID: () => Promise.resolve([]),
-        EncountersByWorldID: () => Promise.resolve([]),
+        Encounters: () => Promise.resolve(encounters),
+        EncountersByVRCUserID: (vrcUserId) =>
+          Promise.resolve(encountersByVrcUserId(encounters, vrcUserId)),
+        EncountersByWorldID: (worldId) =>
+          Promise.resolve(encountersByWorldId(encounters, worldId)),
         RotateEncounters: () => Promise.resolve(0),
-        GetActivityStats: () => Promise.resolve({ dailyPlaySeconds: [], topWorlds: [] }),
-        Friends: () => Promise.resolve([]),
-        ResolveUserProfileNavigation: (_id) =>
-          Promise.resolve({
-            user: {
-              vrcUserId: _id,
-              displayName: '',
-              status: '',
-              isFavorite: false,
-              lastUpdated: '',
-            },
-            openInFriendsView: false,
-          }),
+        GetActivityStats: (_fromISO, _toISO) => Promise.resolve(activityStats),
+        Friends: () => Promise.resolve(friends),
+        ResolveUserProfileNavigation: (id) =>
+          Promise.resolve(resolveUserProfileNavigation(id)),
         SetFavorite: () => Promise.resolve(),
         SetStatus: () => Promise.resolve(),
         SetStatusDescription: () => Promise.resolve(),
@@ -139,24 +235,12 @@ export function getMockWailsInitScript(): string {
         ClearEncounters: () => Promise.resolve(0),
         ClearScreenshots: () => Promise.resolve(0),
         ClearFriendsCache: () => Promise.resolve(0),
-        ListAutomationRules: () => Promise.resolve([]),
+        ListAutomationRules: () => Promise.resolve(automationRules),
         SaveAutomationRule: () => Promise.resolve(),
         DeleteAutomationRule: () => Promise.resolve(),
         ToggleAutomationRule: () => Promise.resolve(),
-        VRChatConfigExists: () => Promise.resolve(false),
-        GetVRChatConfig: () => Promise.resolve({
-          cameraResWidth: 1920,
-          cameraResHeight: 1080,
-          screenshotResWidth: 1920,
-          screenshotResHeight: 1080,
-          pictureOutputFolder: '',
-          pictureOutputSplitByDate: null,
-          fpvSteadycamFov: 0,
-          cacheDirectory: '',
-          cacheSize: 0,
-          cacheExpiryDelay: 0,
-          disableRichPresence: null,
-        }),
+        VRChatConfigExists: () => Promise.resolve(true),
+        GetVRChatConfig: () => Promise.resolve(vrchatConfig),
         SaveVRChatConfig: () => Promise.resolve(),
         DeleteVRChatConfig: () => Promise.resolve(),
         DefaultVRChatPictureFolder: () =>

--- a/frontend/e2e/fixtures/seed-data.ts
+++ b/frontend/e2e/fixtures/seed-data.ts
@@ -1,0 +1,311 @@
+/**
+ * E2E 用 Wails モックのシードデータ。
+ * Playwright spec からも参照可能。mock-wails.ts は JSON 化してブラウザへ注入する。
+ */
+
+export interface SeedLaunchProfile {
+  id: string;
+  name: string;
+  arguments: string;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SeedPathSettings {
+  vrchatPathWindows: string;
+  steamPathLinux: string;
+  outputLogPath: string;
+}
+
+export interface SeedScreenshot {
+  id: string;
+  filePath: string;
+  worldId: string;
+  worldName: string;
+  takenAt: string;
+  fileSizeBytes: number;
+}
+
+export interface SeedEncounter {
+  id: string;
+  vrcUserId: string;
+  displayName: string;
+  worldId: string;
+  worldDisplayName: string;
+  instanceId: string;
+  joinedAt: string;
+  leftAt: string;
+}
+
+export interface SeedFriend {
+  vrcUserId: string;
+  displayName: string;
+  status: string;
+  isFavorite: boolean;
+  lastUpdated: string;
+  location?: string;
+  statusDescription?: string;
+}
+
+export interface SeedDailyPlaySeconds {
+  date: string;
+  seconds: number;
+}
+
+export interface SeedTopWorld {
+  worldId: string;
+  worldName: string;
+  seconds: number;
+  sessions: number;
+}
+
+export interface SeedActivityStats {
+  dailyPlaySeconds: SeedDailyPlaySeconds[];
+  topWorlds: SeedTopWorld[];
+}
+
+export interface SeedAutomationRule {
+  id: string;
+  name: string;
+  triggerType: string;
+  conditionJson: string;
+  actionType: string;
+  actionPayload: string;
+  isEnabled: boolean;
+}
+
+export interface SeedUserProfileNavigation {
+  user: SeedFriend;
+  openInFriendsView: boolean;
+}
+
+/** ResolveUserProfileNavigation / user-profile ルート用の代表ユーザー ID */
+export const E2E_TEST_USER_ID = "usr_e2e_test";
+
+/** ギャラリー・遭遇履歴（ワールド別）で共有するワールド ID */
+export const E2E_WORLD_ID = "wrld_e2e_gallery";
+
+export const E2E_TEST_USER_DISPLAY_NAME = "E2E Test User";
+
+export const SEED_LAUNCH_PROFILES: SeedLaunchProfile[] = [
+  {
+    id: "profile-1",
+    name: "デフォルトプロファイル",
+    arguments: "",
+    isDefault: true,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+];
+
+export const SEED_PATH_SETTINGS: SeedPathSettings = {
+  vrchatPathWindows: "",
+  steamPathLinux: "",
+  outputLogPath: "",
+};
+
+export const SEED_SCREENSHOTS: SeedScreenshot[] = [
+  {
+    id: "ss_e2e_001",
+    filePath: "C:/VRChat/2025-06-01/VRChat_2025-06-01_12-00-00.png",
+    worldId: E2E_WORLD_ID,
+    worldName: "E2E Gallery World",
+    takenAt: "2025-06-01T12:00:00Z",
+    fileSizeBytes: 245_760,
+  },
+  {
+    id: "ss_e2e_002",
+    filePath: "C:/VRChat/2025-06-02/VRChat_2025-06-02_18-30-00.png",
+    worldId: "wrld_e2e_other",
+    worldName: "E2E Other World",
+    takenAt: "2025-06-02T18:30:00Z",
+    fileSizeBytes: 512_000,
+  },
+];
+
+export const SEED_ENCOUNTERS: SeedEncounter[] = [
+  {
+    id: "enc_e2e_001",
+    vrcUserId: E2E_TEST_USER_ID,
+    displayName: E2E_TEST_USER_DISPLAY_NAME,
+    worldId: E2E_WORLD_ID,
+    worldDisplayName: "E2E Gallery World",
+    instanceId: "inst_e2e_001",
+    joinedAt: "2025-06-01T10:00:00Z",
+    leftAt: "2025-06-01T11:30:00Z",
+  },
+  {
+    id: "enc_e2e_002",
+    vrcUserId: "usr_e2e_visitor",
+    displayName: "E2E Visitor",
+    worldId: E2E_WORLD_ID,
+    worldDisplayName: "E2E Gallery World",
+    instanceId: "inst_e2e_001",
+    joinedAt: "2025-06-01T10:15:00Z",
+    leftAt: "2025-06-01T10:45:00Z",
+  },
+  {
+    id: "enc_e2e_003",
+    vrcUserId: E2E_TEST_USER_ID,
+    displayName: E2E_TEST_USER_DISPLAY_NAME,
+    worldId: "wrld_e2e_other",
+    worldDisplayName: "E2E Other World",
+    instanceId: "inst_e2e_002",
+    joinedAt: "2025-06-02T14:00:00Z",
+    leftAt: "2025-06-02T15:00:00Z",
+  },
+];
+
+export const SEED_FRIENDS: SeedFriend[] = [
+  {
+    vrcUserId: "usr_e2e_online",
+    displayName: "E2E Online Friend",
+    status: "active",
+    isFavorite: true,
+    lastUpdated: "2025-06-01T09:00:00Z",
+    location: "wrld_e2e_gallery:12345",
+    statusDescription: "E2E オンライン",
+  },
+  {
+    vrcUserId: "usr_e2e_offline",
+    displayName: "E2E Offline Friend",
+    status: "offline",
+    isFavorite: false,
+    lastUpdated: "2025-05-30T20:00:00Z",
+    location: "offline",
+    statusDescription: "",
+  },
+];
+
+export const SEED_ACTIVITY_STATS: SeedActivityStats = {
+  dailyPlaySeconds: [
+    { date: "2025-05-28", seconds: 3600 },
+    { date: "2025-05-29", seconds: 5400 },
+    { date: "2025-05-30", seconds: 1800 },
+    { date: "2025-05-31", seconds: 7200 },
+    { date: "2025-06-01", seconds: 4500 },
+    { date: "2025-06-02", seconds: 2700 },
+    { date: "2025-06-03", seconds: 6300 },
+  ],
+  topWorlds: [
+    {
+      worldId: E2E_WORLD_ID,
+      worldName: "E2E Gallery World",
+      seconds: 12_600,
+      sessions: 8,
+    },
+    {
+      worldId: "wrld_e2e_other",
+      worldName: "E2E Other World",
+      seconds: 5400,
+      sessions: 3,
+    },
+  ],
+};
+
+export const SEED_AUTOMATION_RULES: SeedAutomationRule[] = [
+  {
+    id: "rule_e2e_001",
+    name: "E2E AFK → Busy",
+    triggerType: "afk_detected",
+    conditionJson: "{}",
+    actionType: "change_status",
+    actionPayload: "busy",
+    isEnabled: true,
+  },
+];
+
+export const SEED_VRCHAT_CONFIG = {
+  cameraResWidth: 1920,
+  cameraResHeight: 1080,
+  screenshotResWidth: 1920,
+  screenshotResHeight: 1080,
+  pictureOutputFolder: "",
+  pictureOutputSplitByDate: null,
+  fpvSteadycamFov: 0,
+  cacheDirectory: "",
+  cacheSize: 0,
+  cacheExpiryDelay: 0,
+  disableRichPresence: null,
+};
+
+/** usr_e2e_test 向け ResolveUserProfileNavigation の戻り値 */
+export function seedUserProfileNavigation(
+  vrcUserId: string,
+): SeedUserProfileNavigation {
+  if (vrcUserId === E2E_TEST_USER_ID) {
+    return {
+      user: {
+        vrcUserId: E2E_TEST_USER_ID,
+        displayName: E2E_TEST_USER_DISPLAY_NAME,
+        status: "active",
+        isFavorite: false,
+        lastUpdated: "2025-06-01T09:00:00Z",
+        statusDescription: "E2E プロフィール",
+        bio: "E2E テスト用ユーザーです。",
+      },
+      openInFriendsView: false,
+    };
+  }
+  return {
+    user: {
+      vrcUserId,
+      displayName: "",
+      status: "",
+      isFavorite: false,
+      lastUpdated: "",
+    },
+    openInFriendsView: false,
+  };
+}
+
+export function filterScreenshotsByWorldId(
+  list: SeedScreenshot[],
+  worldId?: string,
+): SeedScreenshot[] {
+  if (!worldId?.trim()) return list;
+  return list.filter((s) => s.worldId === worldId);
+}
+
+export function searchSeedScreenshots(
+  list: SeedScreenshot[],
+  filter: {
+    worldId?: string;
+    worldName?: string;
+    dateFrom?: string;
+    dateTo?: string;
+  },
+): SeedScreenshot[] {
+  let result = list;
+  if (filter.worldId?.trim()) {
+    result = result.filter((s) => s.worldId === filter.worldId);
+  }
+  if (filter.worldName?.trim()) {
+    const q = filter.worldName.trim().toLowerCase();
+    result = result.filter((s) => s.worldName.toLowerCase().includes(q));
+  }
+  if (filter.dateFrom?.trim()) {
+    const from = filter.dateFrom.trim();
+    result = result.filter((s) => !s.takenAt || s.takenAt.slice(0, 10) >= from);
+  }
+  if (filter.dateTo?.trim()) {
+    const to = filter.dateTo.trim();
+    result = result.filter((s) => !s.takenAt || s.takenAt.slice(0, 10) <= to);
+  }
+  return result;
+}
+
+export function encountersByVrcUserId(
+  list: SeedEncounter[],
+  vrcUserId: string,
+): SeedEncounter[] {
+  return list.filter((e) => e.vrcUserId === vrcUserId);
+}
+
+export function encountersByWorldId(
+  list: SeedEncounter[],
+  worldId: string,
+): SeedEncounter[] {
+  return list.filter((e) => e.worldId === worldId);
+}

--- a/frontend/e2e/friends.spec.ts
+++ b/frontend/e2e/friends.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getMockWailsInitScript());
+});
+
+test.describe("Friends", () => {
+  test("shows login hint when not logged in", async ({ page }) => {
+    await page.goto("/#/friends");
+    await expect(page.locator("h1")).toContainText("フレンド");
+
+    await expect(page.locator(".login-hint")).toBeVisible();
+    await expect(page.locator(".login-hint")).toContainText(
+      "フレンド一覧の更新にはログインが必要です",
+    );
+  });
+
+  test("shows cached online friends and empty search message when not logged in", async ({
+    page,
+  }) => {
+    await page.goto("/#/friends");
+    await expect(page.locator("h1")).toContainText("フレンド");
+
+    await expect(page.getByText("読み込み中")).toBeHidden({ timeout: 15_000 });
+
+    await expect(page.getByText("E2E Online Friend")).toBeVisible();
+    await expect(page.getByText("E2E Offline Friend")).toBeHidden();
+
+    const searchInput = page.getByTestId("friends-search-display-name");
+    await searchInput.fill("存在しない名前");
+    await expect(
+      page.getByText("検索に一致するフレンドはいません"),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/gallery.spec.ts
+++ b/frontend/e2e/gallery.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getMockWailsInitScript());
+});
+
+test.describe("Gallery", () => {
+  test("shows gallery page title", async ({ page }) => {
+    await page.goto("/#/gallery");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "ギャラリー",
+    );
+  });
+
+  test("seed screenshots populate grid after load", async ({ page }) => {
+    await page.goto("/#/gallery");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "ギャラリー",
+    );
+
+    const grid = page.getByTestId("gallery-grid-scroll");
+    const empty = page.getByText("スクリーンショットがありません");
+
+    await expect(grid.or(empty)).toBeVisible({ timeout: 15_000 });
+    await expect(empty).toBeHidden();
+    await expect(grid).toBeVisible();
+  });
+
+  test("scan folder button completes scan via mock", async ({ page }) => {
+    await page.goto("/#/gallery");
+    await expect(page.getByTestId("gallery-grid-scroll")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const scanBtn = page.getByTestId("gallery-scan-folder");
+    await scanBtn.click();
+    // E2E mock resolves ScanScreenshotDir immediately; progress may flash too fast to assert visible.
+    await expect(page.getByTestId("gallery-scan-progress")).toBeHidden({
+      timeout: 15_000,
+    });
+    await expect(scanBtn).toBeEnabled();
+    await expect(page.getByTestId("gallery-grid-scroll")).toBeVisible();
+  });
+
+  test("selecting first screenshot shows detail preview", async ({ page }) => {
+    await page.goto("/#/gallery");
+    const grid = page.getByTestId("gallery-grid-scroll");
+    await expect(grid).toBeVisible({ timeout: 15_000 });
+
+    const firstItem = grid.locator(".grid-item").first();
+    await expect(firstItem).toBeVisible();
+    await firstItem.click();
+    await expect(page.getByTestId("gallery-detail-preview")).toBeVisible();
+  });
+});

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "@playwright/test";
+import { APP_ROUTES } from "./fixtures/app-routes";
+import {
+  E2E_TEST_USER_DISPLAY_NAME,
+  E2E_TEST_USER_ID,
+} from "./fixtures/seed-data";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+
+/** Sidebar.vue の el-menu-item（設定除く） */
+const MAIN_SIDEBAR_PATHS = [
+  "/",
+  "/launcher",
+  "/gallery",
+  "/activity",
+  "/friends",
+  "/automation",
+  "/config",
+] as const;
+
+/**
+ * navigation.spec.ts + gallery.spec.ts で専用のナビ／ロードテストを持つルート名。
+ * APP_ROUTES 11 件のうち 10 件以上（90%）を E2E でカバーする目標。
+ */
+const ROUTES_WITH_DEDICATED_E2E_TESTS = new Set([
+  "dashboard",
+  "launcher",
+  "gallery",
+  "activity",
+  "friends",
+  "automation",
+  "config",
+  "settings",
+  "licenses",
+  "encounter-history",
+  "user-profile",
+]);
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getMockWailsInitScript());
+});
+
+test.describe("Navigation", () => {
+  for (const route of APP_ROUTES.filter((r) =>
+    (MAIN_SIDEBAR_PATHS as readonly string[]).includes(r.path),
+  )) {
+    test(`sidebar click navigates to ${route.name}`, async ({ page }) => {
+      await page.goto("/");
+      await page.getByRole("menuitem", { name: route.titleJa }).click();
+      await expect(page.getByRole("heading", { level: 1 })).toContainText(
+        route.titleJa,
+      );
+    });
+  }
+
+  test("footer settings (⚙️ 設定) navigates to settings", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .locator(".sidebar-footer")
+      .getByRole("menuitem", { name: "設定" })
+      .click();
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("設定");
+  });
+
+  test("settings .btn-licenses navigates to OSS licenses", async ({ page }) => {
+    await page.goto("/#/settings");
+    await page.locator(".btn-licenses").click();
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "OSS ライセンス",
+    );
+  });
+
+  test("direct goto encounter-history shows user encounter history", async ({
+    page,
+  }) => {
+    await page.goto(
+      `/#/activity/encounter-history?kind=user&vrcUserId=${E2E_TEST_USER_ID}`,
+    );
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "ユーザー別 遭遇履歴",
+    );
+  });
+
+  test("direct goto user-profile shows title and display name", async ({
+    page,
+  }) => {
+    const qs = new URLSearchParams({
+      vrcUserId: E2E_TEST_USER_ID,
+      displayName: E2E_TEST_USER_DISPLAY_NAME,
+    });
+    await page.goto(`/#/user-profile?${qs}`);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "ユーザー",
+    );
+    await expect(
+      page.getByRole("heading", {
+        name: E2E_TEST_USER_DISPLAY_NAME,
+        level: 2,
+      }),
+    ).toBeVisible();
+  });
+
+  test("meta: >= 90% of APP_ROUTES have dedicated navigation/load E2E tests", () => {
+    const covered = APP_ROUTES.filter((r) =>
+      ROUTES_WITH_DEDICATED_E2E_TESTS.has(r.name),
+    );
+    const total = APP_ROUTES.length;
+    const minCovered = Math.ceil(total * 0.9);
+    expect(
+      covered.length,
+      `expected >= ${minCovered}/${total} routes covered, got ${covered.length}: ${covered.map((r) => r.name).join(", ")}`,
+    ).toBeGreaterThanOrEqual(minCovered);
+    expect(covered.length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# E2E テスト（Playwright）環境の初回セットアップ。
+# リポジトリルートで実行: bash scripts/setup-e2e.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "error: pnpm が見つかりません。Node.js 20 系と pnpm をインストールしてください。" >&2
+  exit 1
+fi
+
+echo "==> frontend 依存関係をインストール"
+make install-front
+
+echo "==> Playwright chromium（システム依存含む）をインストール"
+make test-e2e-install
+
+echo "==> E2E スモークテスト"
+make test-e2e
+
+echo "==> 完了。以降は make test-e2e で E2E を実行できます。"


### PR DESCRIPTION
## Summary
- Expand E2E Wails mocks (`seed-data.ts`, `app-routes.ts`) with screenshots, encounters, friends, activity stats, automation rules, and config data
- Add Playwright specs for gallery, activity, friends, automation, config, detail views, and sidebar navigation (10 → 38 tests)
- Achieve 11/11 route coverage with a meta test enforcing the 90% target
- Add `make setup-e2e` and `scripts/setup-e2e.sh` for first-time Playwright setup; align Dev Container postCreate with `--with-deps`

## Test plan
- [x] `make test-e2e` — 38 passed
- [x] Route meta test — 11/11 routes covered
- [ ] CI E2E job on this PR


Made with [Cursor](https://cursor.com)