### PR TITLE
test(frontend): raise unit test coverage to 93%

### DIFF
--- a/frontend/src/components/__tests__/VrcUserCacheDetail.spec.ts
+++ b/frontend/src/components/__tests__/VrcUserCacheDetail.spec.ts
@@ -1,27 +1,36 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import VrcUserCacheDetail from "../VrcUserCacheDetail.vue";
 import type { UserCacheDTO } from "../../wails/app";
+import * as vrcUserCacheDisplay from "../../utils/vrcUserCacheDisplay";
 
-function minimalUser(): UserCacheDTO {
+function minimalUser(overrides: Partial<UserCacheDTO> = {}): UserCacheDTO {
   return {
     vrcUserId: "u_detail_1",
     displayName: "Detail Test",
     status: "active",
     isFavorite: false,
-    lastUpdated: "",
+    lastUpdated: "2025-01-01",
+    ...overrides,
   } as UserCacheDTO;
+}
+
+function mountDetail(
+  selected: UserCacheDTO | null,
+  stubs: Record<string, boolean | { template: string }> = {
+    EncounterHistoryList: true,
+  },
+) {
+  return mount(VrcUserCacheDetail, {
+    props: { selected },
+    global: { stubs },
+  });
 }
 
 describe("VrcUserCacheDetail", () => {
   it("renders profile content inside Element Plus card body", async () => {
-    const wrapper = mount(VrcUserCacheDetail, {
-      props: { selected: minimalUser() },
-      global: {
-        stubs: { EncounterHistoryList: true },
-      },
-    });
+    const wrapper = mountDetail(minimalUser());
     await flushPromises();
     await nextTick();
 
@@ -31,5 +40,224 @@ describe("VrcUserCacheDetail", () => {
     expect(wrapper.find(".el-tabs").exists()).toBe(true);
     expect(wrapper.text()).toContain("遭遇履歴");
     expect(wrapper.find(".el-descriptions").exists()).toBe(true);
+  });
+
+  it("renders nothing when selected is null", () => {
+    const wrapper = mountDetail(null);
+    expect(wrapper.find(".friend-detail").exists()).toBe(false);
+  });
+
+  it("shows username, bio, status description, and bio links", async () => {
+    const wrapper = mountDetail(
+      minimalUser({
+        username: "detail_user",
+        bio: "Hello\nWorld",
+        statusDescription: "Building worlds",
+        bioLinksJson: '["https://example.com/a","https://example.com/b"]',
+      }),
+    );
+    await flushPromises();
+
+    expect(wrapper.find(".profile-handle").text()).toBe("@detail_user");
+    expect(wrapper.find(".profile-bio").text()).toBe("Hello\nWorld");
+    expect(wrapper.find(".profile-status-desc").text()).toBe("Building worlds");
+    const links = wrapper.findAll(".profile-bio-links a");
+    expect(links).toHaveLength(2);
+    expect(links[0]?.attributes("href")).toBe("https://example.com/a");
+    expect(links[1]?.text()).toBe("https://example.com/b");
+  });
+
+  it("emits favoriteChange when favorite checkbox toggles", async () => {
+    const user = minimalUser({ isFavorite: false });
+    const wrapper = mountDetail(user);
+    await flushPromises();
+
+    const checkbox = wrapper.find(".profile-toolbar-actions input");
+    await checkbox.setValue(true);
+    await flushPromises();
+
+    expect(wrapper.emitted("favoriteChange")).toEqual([[user, true]]);
+  });
+
+  it("copies display name when copy button is clicked", async () => {
+    const copySpy = vi
+      .spyOn(vrcUserCacheDisplay, "copyDisplayName")
+      .mockResolvedValue(undefined);
+    const wrapper = mountDetail(minimalUser({ displayName: "Copy Me" }));
+    await flushPromises();
+
+    await wrapper
+      .find('[data-testid="friend-copy-display-name"]')
+      .trigger("click");
+    await flushPromises();
+
+    expect(copySpy).toHaveBeenCalledWith("Copy Me");
+    copySpy.mockRestore();
+  });
+
+  it("shows avatar and banner images when URLs are available", async () => {
+    const wrapper = mountDetail(
+      minimalUser({
+        currentAvatarThumbnailImageUrl: "https://cdn/avatar.png",
+        profilePicOverride: "https://cdn/banner.png",
+      }),
+    );
+    await flushPromises();
+
+    expect(wrapper.find(".profile-avatar").attributes("src")).toBe(
+      "https://cdn/avatar.png",
+    );
+    expect(wrapper.find(".profile-banner-img").attributes("src")).toBe(
+      "https://cdn/banner.png",
+    );
+  });
+
+  it("shows detail tab fields including tags and location", async () => {
+    const wrapper = mountDetail(
+      minimalUser({
+        state: "online",
+        location: "wrld_x:123~grp",
+        developerType: "trusted",
+        platform: "standalonewindows",
+        lastPlatform: "android",
+        tagsJson: '["system_trust_basic"]',
+        currentAvatarTagsJson: '["author_tag"]',
+      }),
+    );
+    await flushPromises();
+
+    const text = wrapper.find(".el-descriptions").text();
+    expect(text).toContain("online");
+    expect(text).toContain("wrld_x:123~grp");
+    expect(text).toContain("trusted");
+    expect(text).toContain("standalonewindows");
+    expect(text).toContain("system_trust_basic");
+    expect(text).toContain("author_tag");
+  });
+
+  it("switches to encounters tab", async () => {
+    const wrapper = mountDetail(minimalUser(), {
+      EncounterHistoryList: {
+        template: '<div data-testid="encounter-list-stub" />',
+      },
+    });
+    await flushPromises();
+
+    const tabs = wrapper.findAll(".el-tabs__item");
+    const encountersTab = tabs.find((t) => t.text().includes("遭遇履歴"));
+    await encountersTab?.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="encounter-list-stub"]').exists()).toBe(
+      true,
+    );
+  });
+
+  it("resets tab to detail when selected user changes", async () => {
+    const wrapper = mountDetail(minimalUser());
+    await flushPromises();
+
+    const tabs = wrapper.findAll(".el-tabs__item");
+    const encountersTab = tabs.find((t) => t.text().includes("遭遇履歴"));
+    await encountersTab?.trigger("click");
+    await flushPromises();
+
+    await wrapper.setProps({
+      selected: minimalUser({
+        vrcUserId: "u_detail_2",
+        displayName: "Other User",
+      }),
+    });
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find(".profile-display-name").text()).toBe("Other User");
+    const activeTab = wrapper.find(".el-tabs__item.is-active");
+    expect(activeTab.text()).toContain("詳細");
+  });
+
+  it("shows sticky header after scrolling card body", async () => {
+    const wrapper = mountDetail(minimalUser());
+    await flushPromises();
+    await nextTick();
+
+    const body = wrapper.find(".el-card__body").element as HTMLElement;
+    const anchor = wrapper.find(".profile-name-row").element as HTMLElement;
+    vi.spyOn(body, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 400,
+      width: 400,
+      height: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(anchor, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 24,
+      width: 200,
+      height: 24,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    Object.defineProperty(body, "scrollTop", {
+      configurable: true,
+      value: 120,
+      writable: true,
+    });
+    body.dispatchEvent(new Event("scroll"));
+    await nextTick();
+
+    expect(wrapper.find(".detail-sticky-header").classes()).toContain(
+      "visible",
+    );
+  });
+
+  it("shows extended detail rows and image links", async () => {
+    const wrapper = mountDetail(
+      minimalUser({
+        lastLogin: "2025-01-01T00:00:00Z",
+        lastActivity: "2025-01-02T00:00:00Z",
+        lastMobile: "2025-01-03T00:00:00Z",
+        friendKey: "fk_abc",
+        currentAvatarImageUrl: "https://cdn/avatar-big.png",
+        userIcon: "https://cdn/icon.png",
+        imageUrl: "https://cdn/image.png",
+        profilePicOverride: "https://cdn/override.png",
+        profilePicOverrideThumbnail: "https://cdn/override-thumb.png",
+      }),
+    );
+    await flushPromises();
+
+    const text = wrapper.find(".el-descriptions").text();
+    expect(text).toContain("2025-01-01T00:00:00Z");
+    expect(text).toContain("2025-01-02T00:00:00Z");
+    expect(text).toContain("2025-01-03T00:00:00Z");
+    expect(text).toContain("fk_abc");
+    expect(wrapper.find('a[href="https://cdn/avatar-big.png"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('a[href="https://cdn/icon.png"]').exists()).toBe(true);
+    expect(wrapper.find('a[href="https://cdn/image.png"]').exists()).toBe(true);
+    expect(wrapper.find('a[href="https://cdn/override.png"]').exists()).toBe(
+      true,
+    );
+    expect(
+      wrapper.find('a[href="https://cdn/override-thumb.png"]').exists(),
+    ).toBe(true);
+  });
+
+  it("shows placeholder avatar and banner when URLs are missing", async () => {
+    const wrapper = mountDetail(minimalUser());
+    await flushPromises();
+
+    expect(wrapper.find(".profile-avatar--placeholder").exists()).toBe(true);
+    expect(wrapper.find(".profile-banner-fallback").exists()).toBe(true);
   });
 });

--- a/frontend/src/composables/useSessionUnlock.spec.ts
+++ b/frontend/src/composables/useSessionUnlock.spec.ts
@@ -4,6 +4,19 @@ import {
   unlockFailureRequiresRelogin,
 } from "./useSessionUnlock";
 
+const cryptoMocks = vi.hoisted(() => ({
+  wrapToken: vi.fn(),
+  unwrapBlob: vi.fn(),
+  deleteWrappingKey: vi.fn(),
+}));
+
+vi.mock("@/services/credentialCrypto", () => ({
+  WRAPPED_BLOB_MAGIC: "VRCTWKV1:",
+  wrapToken: cryptoMocks.wrapToken,
+  unwrapBlob: cryptoMocks.unwrapBlob,
+  deleteWrappingKey: cryptoMocks.deleteWrappingKey,
+}));
+
 vi.mock("@/wails/app", () => ({
   App: {
     hasStoredCredential: vi.fn().mockResolvedValue(false),
@@ -13,6 +26,24 @@ vi.mock("@/wails/app", () => ({
     persistWrappedCredential: vi.fn().mockResolvedValue(undefined),
   },
 }));
+
+async function loadUnlock() {
+  vi.resetModules();
+  const mod = await import("./useSessionUnlock");
+  mod.resetSessionUnlockForStorybook();
+  return mod;
+}
+
+async function appMocks() {
+  const { App } = await import("@/wails/app");
+  return {
+    hasStoredCredential: vi.mocked(App.hasStoredCredential),
+    getCredentialBlob: vi.mocked(App.getCredentialBlob),
+    unlockVRChatSession: vi.mocked(App.unlockVRChatSession),
+    clearStoredCredential: vi.mocked(App.clearStoredCredential),
+    persistWrappedCredential: vi.mocked(App.persistWrappedCredential),
+  };
+}
 
 describe("unlockFailureRequiresRelogin", () => {
   it.each([
@@ -35,43 +66,205 @@ describe("unlockFailureRequiresRelogin", () => {
 });
 
 describe("useSessionUnlock beginStartupUnlock", () => {
-  beforeEach(async () => {
-    vi.resetModules();
-    const { App } = await import("@/wails/app");
-    vi.mocked(App.hasStoredCredential).mockReset();
-    vi.mocked(App.hasStoredCredential).mockResolvedValue(false);
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cryptoMocks.wrapToken.mockReset();
+    cryptoMocks.unwrapBlob.mockReset();
+    cryptoMocks.deleteWrappingKey.mockReset();
   });
 
   it("returns the same promise when called twice", async () => {
-    const { useSessionUnlock } = await import("./useSessionUnlock");
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(false);
     const u = useSessionUnlock();
     const p1 = u.beginStartupUnlock();
     const p2 = u.beginStartupUnlock();
     expect(p1).toBe(p2);
     await p1;
-    const { App } = await import("@/wails/app");
-    expect(vi.mocked(App.hasStoredCredential)).toHaveBeenCalledTimes(1);
+    expect(app.hasStoredCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets needs-relogin when stored blob is empty", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(true);
+    app.getCredentialBlob.mockResolvedValue("");
+    const u = useSessionUnlock();
+    await u.beginStartupUnlock();
+    expect(u.state.value).toBe("needs-relogin");
+  });
+
+  it("unlocks session when wrapped blob decrypts successfully", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(true);
+    app.getCredentialBlob.mockResolvedValue("VRCTWKV1:wrapped");
+    cryptoMocks.unwrapBlob.mockResolvedValue("plain-token");
+    app.unlockVRChatSession.mockResolvedValue(undefined);
+    const u = useSessionUnlock();
+    await u.beginStartupUnlock();
+    expect(u.state.value).toBe("unlocked");
+    expect(app.unlockVRChatSession).toHaveBeenCalledWith("plain-token");
+  });
+
+  it("clears credential and sets needs-relogin when unwrap fails", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(true);
+    app.getCredentialBlob.mockResolvedValue("VRCTWKV1:bad");
+    cryptoMocks.unwrapBlob.mockRejectedValue(new Error("decrypt failed"));
+    const u = useSessionUnlock();
+    await u.beginStartupUnlock();
+    expect(u.state.value).toBe("needs-relogin");
+    expect(app.clearStoredCredential).toHaveBeenCalled();
+    expect(u.errorMessage.value).toContain("再ログイン");
+  });
+
+  it("migrates legacy plaintext blob before unlock", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(true);
+    app.getCredentialBlob.mockResolvedValue("legacy-plain-token");
+    cryptoMocks.unwrapBlob.mockResolvedValue("legacy-plain-token");
+    cryptoMocks.wrapToken.mockResolvedValue("VRCTWKV1:new-wrap");
+    app.unlockVRChatSession.mockResolvedValue(undefined);
+    const u = useSessionUnlock();
+    await u.beginStartupUnlock();
+    expect(cryptoMocks.wrapToken).toHaveBeenCalledWith("legacy-plain-token");
+    expect(app.persistWrappedCredential).toHaveBeenCalledWith(
+      "VRCTWKV1:new-wrap",
+    );
+    expect(u.state.value).toBe("unlocked");
+  });
+
+  it("clears credential on auth failure during unlock", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(true);
+    app.getCredentialBlob.mockResolvedValue("VRCTWKV1:wrapped");
+    cryptoMocks.unwrapBlob.mockResolvedValue("token");
+    app.unlockVRChatSession.mockRejectedValue(
+      new Error(`wrapped: ${UNLOCK_NEEDS_RELOGIN_MARKER}`),
+    );
+    const u = useSessionUnlock();
+    await u.beginStartupUnlock();
+    expect(u.state.value).toBe("needs-relogin");
+    expect(app.clearStoredCredential).toHaveBeenCalled();
+  });
+
+  it("keeps credential and sets error on transient unlock failure", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(true);
+    app.getCredentialBlob.mockResolvedValue("VRCTWKV1:wrapped");
+    cryptoMocks.unwrapBlob.mockResolvedValue("token");
+    app.unlockVRChatSession.mockRejectedValue(
+      new Error("dial tcp: connection refused"),
+    );
+    const u = useSessionUnlock();
+    await u.beginStartupUnlock();
+    expect(u.state.value).toBe("error");
+    expect(app.clearStoredCredential).not.toHaveBeenCalled();
+    expect(u.errorMessage.value).toContain("connection refused");
+  });
+});
+
+describe("useSessionUnlock persistAfterLogin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cryptoMocks.wrapToken.mockReset();
+  });
+
+  it("wraps token and persists credential on success", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    cryptoMocks.wrapToken.mockResolvedValue("VRCTWKV1:stored");
+    const u = useSessionUnlock();
+    await u.persistAfterLogin("fresh-token");
+    expect(cryptoMocks.wrapToken).toHaveBeenCalledWith("fresh-token");
+    expect(app.persistWrappedCredential).toHaveBeenCalledWith(
+      "VRCTWKV1:stored",
+    );
+    expect(u.state.value).toBe("unlocked");
+  });
+
+  it("ignores empty token", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    const u = useSessionUnlock();
+    await u.persistAfterLogin("");
+    expect(cryptoMocks.wrapToken).not.toHaveBeenCalled();
+    expect(app.persistWrappedCredential).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when wrap fails", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    cryptoMocks.wrapToken.mockRejectedValue(new Error("idb unavailable"));
+    const u = useSessionUnlock();
+    await expect(u.persistAfterLogin("token")).resolves.toBeUndefined();
+  });
+});
+
+describe("useSessionUnlock tryUnlockOnStartup migration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cryptoMocks.wrapToken.mockReset();
+    cryptoMocks.unwrapBlob.mockReset();
+  });
+
+  it("still unlocks when legacy migration persist fails", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(true);
+    app.getCredentialBlob.mockResolvedValue("legacy-plain-token");
+    cryptoMocks.unwrapBlob.mockResolvedValue("legacy-plain-token");
+    cryptoMocks.wrapToken.mockRejectedValue(new Error("wrap failed"));
+    app.unlockVRChatSession.mockResolvedValue(undefined);
+    const u = useSessionUnlock();
+    await u.tryUnlockOnStartup();
+    expect(u.state.value).toBe("unlocked");
+    expect(app.unlockVRChatSession).toHaveBeenCalledWith("legacy-plain-token");
+  });
+});
+
+describe("useSessionUnlock handleLogout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cryptoMocks.deleteWrappingKey.mockReset();
+  });
+
+  it("clears stored credential and wrapping key", async () => {
+    const { useSessionUnlock } = await loadUnlock();
+    const app = await appMocks();
+    cryptoMocks.deleteWrappingKey.mockResolvedValue(undefined);
+    const u = useSessionUnlock();
+    u.state.value = "unlocked";
+    u.errorMessage.value = "old";
+    await u.handleLogout();
+    expect(app.clearStoredCredential).toHaveBeenCalled();
+    expect(cryptoMocks.deleteWrappingKey).toHaveBeenCalled();
+    expect(u.state.value).toBe("needs-relogin");
+    expect(u.errorMessage.value).toBe("");
   });
 });
 
 describe("resetSessionUnlockForStorybook", () => {
-  beforeEach(async () => {
-    vi.resetModules();
-    const { App } = await import("@/wails/app");
-    vi.mocked(App.hasStoredCredential).mockReset();
-    vi.mocked(App.hasStoredCredential).mockResolvedValue(false);
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   it("clears shared state so beginStartupUnlock can run again", async () => {
     const { useSessionUnlock, resetSessionUnlockForStorybook } =
-      await import("./useSessionUnlock");
+      await loadUnlock();
+    const app = await appMocks();
+    app.hasStoredCredential.mockResolvedValue(false);
     const u = useSessionUnlock();
     await u.beginStartupUnlock();
     expect(u.state.value).toBe("needs-relogin");
     resetSessionUnlockForStorybook();
     expect(u.state.value).toBe("idle");
     await u.beginStartupUnlock();
-    const { App } = await import("@/wails/app");
-    expect(vi.mocked(App.hasStoredCredential)).toHaveBeenCalledTimes(2);
+    expect(app.hasStoredCredential).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/i18n/index.spec.ts
+++ b/frontend/src/i18n/index.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import enEl from "element-plus/es/locale/lang/en";
+import jaEl from "element-plus/es/locale/lang/ja";
+import koEl from "element-plus/es/locale/lang/ko";
+import zhCnEl from "element-plus/es/locale/lang/zh-cn";
+import zhTwEl from "element-plus/es/locale/lang/zh-tw";
+import {
+  APP_LOCALES,
+  appLocaleToBcp47,
+  elLocale,
+  i18n,
+  isAppLocale,
+  setLanguage,
+  type AppLocale,
+} from "./index";
+
+describe("appLocaleToBcp47", () => {
+  it.each([
+    ["ja", "ja-JP"],
+    ["ko", "ko-KR"],
+    ["zh-TW", "zh-TW"],
+    ["zh-CN", "zh-CN"],
+    ["en", "en-US"],
+    ["fr", "en-US"],
+    ["", "en-US"],
+  ] as const)("maps %s to %s", (locale, expected) => {
+    expect(appLocaleToBcp47(locale)).toBe(expected);
+  });
+});
+
+describe("isAppLocale", () => {
+  it("accepts supported app locales", () => {
+    for (const locale of APP_LOCALES) {
+      expect(isAppLocale(locale)).toBe(true);
+    }
+  });
+
+  it("rejects unknown locale strings", () => {
+    expect(isAppLocale("de")).toBe(false);
+    expect(isAppLocale("zh")).toBe(false);
+    expect(isAppLocale("")).toBe(false);
+  });
+});
+
+describe("setLanguage", () => {
+  beforeEach(() => {
+    setLanguage("ja");
+  });
+
+  it.each([
+    ["ja", jaEl],
+    ["en", enEl],
+    ["ko", koEl],
+    ["zh-CN", zhCnEl],
+    ["zh-TW", zhTwEl],
+  ] as const)("syncs vue-i18n and Element Plus locale for %s", (lang, el) => {
+    setLanguage(lang);
+    expect(i18n.global.locale.value).toBe(lang);
+    expect(elLocale.value).toBe(el);
+  });
+
+  it("falls back Element Plus locale to English for unknown keys", () => {
+    setLanguage("en" as AppLocale);
+    setLanguage("ja");
+
+    setLanguage("xx" as AppLocale);
+    expect(i18n.global.locale.value).toBe("xx");
+    expect(elLocale.value).toBe(enEl);
+  });
+});

--- a/frontend/src/utils/formatEncounteredAt.spec.ts
+++ b/frontend/src/utils/formatEncounteredAt.spec.ts
@@ -1,14 +1,38 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import { formatEncounteredAt } from "./formatEncounteredAt";
 
 describe("formatEncounteredAt", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("formats valid ISO string with ja-JP locale", () => {
     const s = formatEncounteredAt("2025-01-01T12:00:00.000Z");
     expect(s).toMatch(/2025/);
     expect(s.length).toBeGreaterThan(4);
   });
 
+  it("uses the provided calendar locale", () => {
+    const spy = vi
+      .spyOn(Date.prototype, "toLocaleString")
+      .mockReturnValue("localized");
+
+    expect(formatEncounteredAt("2025-06-01T00:00:00.000Z", "en-US")).toBe(
+      "localized",
+    );
+    expect(spy).toHaveBeenCalledWith("en-US");
+  });
+
   it("does not throw on empty input", () => {
     expect(() => formatEncounteredAt("")).not.toThrow();
+  });
+
+  it("returns the original ISO string when formatting throws", () => {
+    vi.spyOn(Date.prototype, "toLocaleString").mockImplementation(() => {
+      throw new Error("locale failure");
+    });
+
+    const iso = "2025-01-01T12:00:00.000Z";
+    expect(formatEncounteredAt(iso)).toBe(iso);
   });
 });

--- a/frontend/src/views/__tests__/ActivityView.spec.ts
+++ b/frontend/src/views/__tests__/ActivityView.spec.ts
@@ -25,6 +25,14 @@ const {
   }),
 }));
 
+const runtimeHooks = vi.hoisted(() => ({
+  encountersChangedHandler: null as (() => void) | null,
+}));
+
+vi.mock("../../utils/openEncounterHistoryWindow", () => ({
+  openEncounterHistoryWindow: vi.fn(),
+}));
+
 vi.mock("../../components/PlayTimeChart.vue", () => ({
   default: {
     name: "PlayTimeChartStub",
@@ -45,10 +53,56 @@ vi.mock("../../wails/app", async (importOriginal) => {
   };
 });
 
+vi.mock("../../wails/runtime", () => ({
+  getRuntime: () => ({
+    EventsOn: (event: string, handler: () => void) => {
+      if (event === "activity:encounters-changed") {
+        runtimeHooks.encountersChangedHandler = handler;
+      }
+      return () => {};
+    },
+  }),
+}));
+
+import { openEncounterHistoryWindow } from "../../utils/openEncounterHistoryWindow";
+
 describe("ActivityView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    runtimeHooks.encountersChangedHandler = null;
+    mockEncounters.mockResolvedValue([]);
+    mockGetActivityStats.mockResolvedValue({
+      dailyPlaySeconds: [],
+      topWorlds: [],
+    });
   });
+
+  async function mountActivity() {
+    const router = createRouter({
+      history: createWebHashHistory(),
+      routes: [
+        { path: "/activity", component: ActivityView },
+        {
+          path: "/friends",
+          name: "friends",
+          component: { template: "<div/>" },
+        },
+        {
+          path: "/user-profile",
+          name: "user-profile",
+          component: { template: "<div/>" },
+        },
+      ],
+    });
+    await router.push("/activity");
+    await router.isReady();
+    const wrapper = mount(ActivityView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    return { wrapper, router };
+  }
 
   it("uses layout classes for playtime card and encounter log scroll region", async () => {
     const router = createRouter({
@@ -255,5 +309,142 @@ describe("ActivityView", () => {
       name: "user-profile",
       query: { vrcUserId: "u3", displayName: "FailUser" },
     });
+  });
+
+  it("loads encounters and stats on mount", async () => {
+    await mountActivity();
+    expect(mockEncounters).toHaveBeenCalled();
+    expect(mockGetActivityStats).toHaveBeenCalled();
+  });
+
+  it("shows playtime chart when stats are available", async () => {
+    mockGetActivityStats.mockResolvedValue({
+      dailyPlaySeconds: [{ date: "2026-06-01", seconds: 3600 }],
+      topWorlds: [],
+    });
+    const { wrapper } = await mountActivity();
+    expect(wrapper.find(".playtime-chart-stub").exists()).toBe(true);
+  });
+
+  it("filters encounters by display name", async () => {
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "u1",
+        displayName: "Alpha",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+      },
+      {
+        id: "2",
+        vrcUserId: "u2",
+        displayName: "Beta",
+        instanceId: "inst",
+        joinedAt: "2024-01-02T12:00:00.000Z",
+      },
+    ]);
+    const { wrapper } = await mountActivity();
+
+    const input = wrapper.find(".filters .el-input input");
+    await input.setValue("beta");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("Beta");
+    expect(wrapper.text()).not.toContain("Alpha");
+  });
+
+  it("reloads encounters when refresh button is clicked", async () => {
+    const { wrapper } = await mountActivity();
+    mockEncounters.mockClear();
+
+    const buttons = wrapper.findAll(".filters .el-button");
+    await buttons[0]!.trigger("click");
+    await flushPromises();
+
+    expect(mockEncounters).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders muted display name when encounter has no vrcUserId", async () => {
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "",
+        displayName: "Anonymous",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+      },
+    ]);
+    const { wrapper } = await mountActivity();
+
+    expect(wrapper.find(".timeline-name-muted").text()).toBe("Anonymous");
+    expect(wrapper.find(".timeline-link").exists()).toBe(false);
+  });
+
+  it("shows dash for missing leave time", async () => {
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "u1",
+        displayName: "StillHere",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+        leftAt: "",
+      },
+    ]);
+    const { wrapper } = await mountActivity();
+    expect(wrapper.text()).toContain("—");
+  });
+
+  it("opens world encounter history when world link is clicked", async () => {
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "u1",
+        displayName: "User",
+        worldId: "wrld_abc",
+        worldDisplayName: "Test World",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+      },
+    ]);
+    const { wrapper, router } = await mountActivity();
+
+    const worldLinks = wrapper.findAll(".timeline-link");
+    await worldLinks[worldLinks.length - 1]!.trigger("click");
+
+    expect(openEncounterHistoryWindow).toHaveBeenCalledWith(
+      router,
+      "world",
+      "wrld_abc",
+    );
+  });
+
+  it("debounces encounter reload on activity:encounters-changed event", async () => {
+    vi.useFakeTimers();
+    await mountActivity();
+    mockEncounters.mockClear();
+
+    runtimeHooks.encountersChangedHandler?.();
+    runtimeHooks.encountersChangedHandler?.();
+    expect(mockEncounters).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(mockEncounters).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("shows empty encounters message when list is empty", async () => {
+    mockEncounters.mockResolvedValue([]);
+    const { wrapper } = await mountActivity();
+    expect(wrapper.find(".empty").text()).toContain("遭遇");
+  });
+
+  it("collapses encounter section when header toggle is clicked", async () => {
+    const { wrapper } = await mountActivity();
+    const encountersCard = wrapper.find(".section-card--encounters");
+    const toggle = encountersCard.find(".section-card__toggle");
+
+    await toggle.trigger("click");
+    expect(encountersCard.classes()).toContain("section-card--collapsed");
   });
 });

--- a/frontend/src/views/__tests__/ConfigView.spec.ts
+++ b/frontend/src/views/__tests__/ConfigView.spec.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { mount } from "@vue/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
 import { createRouter, createWebHashHistory } from "vue-router";
-import { ElSlider } from "element-plus";
+import { ElMessageBox, ElSlider } from "element-plus";
 import ConfigView from "../ConfigView.vue";
+import { App } from "../../wails/app";
+import type { VRChatConfigDTO } from "../../wails/app";
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -22,6 +24,51 @@ function radioInput(wrapper: ReturnType<typeof mount>, testId: string) {
 /** ElInputNumber 内の native input を返す（value / disabled / setValue 用） */
 function numInput(wrapper: ReturnType<typeof mount>, testId: string) {
   return wrapper.find(`[data-testid="${testId}"] input`);
+}
+
+/** ElInput の内側 input を返す */
+function textInput(wrapper: ReturnType<typeof mount>, testId: string) {
+  const root = wrapper.find(`[data-testid="${testId}"]`);
+  if (root.exists()) {
+    const inner = root.find("input");
+    return inner.exists() ? inner : root;
+  }
+  const idMap: Record<string, string> = {
+    "picture-output-folder-input": "picture-output-folder",
+    "cache-directory-input": "cache-directory",
+  };
+  const byId = wrapper.find(`#${idMap[testId] ?? testId}`);
+  if (byId.exists()) {
+    const inner = byId.find("input");
+    return inner.exists() ? inner : byId;
+  }
+  return root;
+}
+
+const sampleConfig: VRChatConfigDTO = {
+  cameraResWidth: 1920,
+  cameraResHeight: 1080,
+  screenshotResWidth: 1920,
+  screenshotResHeight: 1080,
+  pictureOutputFolder: "C:\\Pictures\\VRChat",
+  pictureOutputSplitByDate: true,
+  fpvSteadycamFov: 55,
+  cacheDirectory: "C:\\VRChat\\Cache",
+  cacheSize: 30,
+  cacheExpiryDelay: 30,
+  disableRichPresence: false,
+};
+
+async function mountEditor() {
+  vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(false);
+  vi.spyOn(App, "saveVRChatConfig").mockResolvedValue(undefined);
+  await router.push("/config");
+  await router.isReady();
+  const wrapper = mount(ConfigView, { global: { plugins: [router] } });
+  await flushPromises();
+  await wrapper.find("[data-testid='create-config-btn']").trigger("click");
+  await flushPromises();
+  return wrapper;
 }
 
 describe("ConfigView", () => {
@@ -316,6 +363,254 @@ describe("ConfigView", () => {
       .element.closest("[role='radiogroup']");
     expect(shot?.getAttribute("aria-label")).toBe(
       "スクリーンショット解像度プリセット",
+    );
+  });
+});
+
+describe("ConfigView save and delete", () => {
+  beforeEach(() => {
+    vi.spyOn(App, "openDirectoryDialog").mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("saves config and shows success alert", async () => {
+    const wrapper = await mountEditor();
+
+    await wrapper.find("[data-testid='save-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(App.saveVRChatConfig).toHaveBeenCalled();
+    expect(wrapper.text()).toContain("保存しました");
+  });
+
+  it("shows save error when App.saveVRChatConfig fails", async () => {
+    vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(false);
+    vi.spyOn(App, "saveVRChatConfig")
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("disk full"));
+    await router.push("/config");
+    await router.isReady();
+    const wrapper = mount(ConfigView, { global: { plugins: [router] } });
+    await flushPromises();
+    await wrapper.find("[data-testid='create-config-btn']").trigger("click");
+    await flushPromises();
+
+    await wrapper.find("[data-testid='save-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find(".el-alert--error").text()).toContain("disk full");
+  });
+
+  it("includes rich presence and split-by-date flags in save payload", async () => {
+    const wrapper = await mountEditor();
+    vi.mocked(App.saveVRChatConfig).mockClear();
+
+    const richPresence = wrapper.find(
+      "[data-testid='disable-rich-presence-checkbox'] input",
+    );
+    await richPresence.setValue(true);
+    await wrapper.vm.$nextTick();
+
+    const splitByDate = wrapper.find(
+      "[data-testid='picture-split-by-date-checkbox'] input",
+    );
+    await splitByDate.setValue(false);
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find("[data-testid='save-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(App.saveVRChatConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disableRichPresence: true,
+        pictureOutputSplitByDate: false,
+      }),
+    );
+  });
+
+  it("deletes config after confirmation", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
+    vi.spyOn(App, "deleteVRChatConfig").mockResolvedValue(undefined);
+    const wrapper = await mountEditor();
+
+    await wrapper.find("[data-testid='delete-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(App.deleteVRChatConfig).toHaveBeenCalled();
+    expect(wrapper.find("[data-testid='create-config-btn']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find("[data-testid='save-config-btn']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("does not delete config when confirmation is cancelled", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockRejectedValue(new Error("cancel"));
+    vi.spyOn(App, "deleteVRChatConfig").mockResolvedValue(undefined);
+    const wrapper = await mountEditor();
+
+    await wrapper.find("[data-testid='delete-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(App.deleteVRChatConfig).not.toHaveBeenCalled();
+    expect(wrapper.find("[data-testid='save-config-btn']").exists()).toBe(true);
+  });
+
+  it("shows delete error when App.deleteVRChatConfig fails", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
+    vi.spyOn(App, "deleteVRChatConfig").mockRejectedValueOnce(
+      new Error("permission denied"),
+    );
+    const wrapper = await mountEditor();
+
+    await wrapper.find("[data-testid='delete-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find(".el-alert--error").text()).toContain(
+      "permission denied",
+    );
+    expect(wrapper.find("[data-testid='save-config-btn']").exists()).toBe(true);
+  });
+});
+
+describe("ConfigView browse and load", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("browse picture output folder sets input value", async () => {
+    vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(false);
+    vi.spyOn(App, "saveVRChatConfig").mockResolvedValue(undefined);
+    vi.spyOn(App, "openDirectoryDialog").mockResolvedValue(
+      "D:\\VRChat\\Pictures",
+    );
+    const wrapper = await mountEditor();
+
+    await wrapper
+      .find("[data-testid='picture-output-folder-browse']")
+      .trigger("click");
+    await flushPromises();
+
+    expect(
+      (
+        textInput(wrapper, "picture-output-folder-input")
+          .element as HTMLInputElement
+      ).value,
+    ).toBe("D:\\VRChat\\Pictures");
+  });
+
+  it("browse cache directory sets input value", async () => {
+    vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(false);
+    vi.spyOn(App, "saveVRChatConfig").mockResolvedValue(undefined);
+    vi.spyOn(App, "openDirectoryDialog").mockResolvedValue("D:\\VRChat\\Cache");
+    const wrapper = await mountEditor();
+
+    await wrapper
+      .find("[data-testid='cache-directory-browse']")
+      .trigger("click");
+    await flushPromises();
+
+    expect(
+      (textInput(wrapper, "cache-directory-input").element as HTMLInputElement)
+        .value,
+    ).toBe("D:\\VRChat\\Cache");
+  });
+
+  it("loads existing config into editor on mount", async () => {
+    vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(true);
+    vi.spyOn(App, "getVRChatConfig").mockResolvedValue(sampleConfig);
+    await router.push("/config");
+    await router.isReady();
+
+    const wrapper = mount(ConfigView, { global: { plugins: [router] } });
+    await flushPromises();
+
+    expect(App.getVRChatConfig).toHaveBeenCalled();
+    expect(wrapper.find("[data-testid='save-config-btn']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='create-config-btn']").exists()).toBe(
+      false,
+    );
+    expect(
+      (numInput(wrapper, "camera-width-input").element as HTMLInputElement)
+        .value,
+    ).toBe("1920");
+    expect(
+      (numInput(wrapper, "camera-height-input").element as HTMLInputElement)
+        .value,
+    ).toBe("1080");
+    expect(
+      (
+        textInput(wrapper, "picture-output-folder-input")
+          .element as HTMLInputElement
+      ).value,
+    ).toBe(sampleConfig.pictureOutputFolder);
+  });
+
+  it("shows create button when getVRChatConfig fails on mount", async () => {
+    vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(true);
+    vi.spyOn(App, "getVRChatConfig").mockRejectedValue(
+      new Error("read failed"),
+    );
+    await router.push("/config");
+    await router.isReady();
+
+    const wrapper = mount(ConfigView, { global: { plugins: [router] } });
+    await flushPromises();
+
+    expect(wrapper.find("[data-testid='create-config-btn']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find("[data-testid='save-config-btn']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("shows create error message when initial create fails", async () => {
+    vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(false);
+    vi.spyOn(App, "saveVRChatConfig").mockRejectedValueOnce(
+      new Error("create failed"),
+    );
+    await router.push("/config");
+    await router.isReady();
+
+    const wrapper = mount(ConfigView, { global: { plugins: [router] } });
+    await flushPromises();
+    await wrapper.find("[data-testid='create-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-testid='create-config-btn']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find("[data-testid='save-config-btn']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("clamps cache values below minimum when saving", async () => {
+    vi.spyOn(App, "vrchatConfigExists").mockResolvedValue(false);
+    vi.spyOn(App, "saveVRChatConfig").mockResolvedValue(undefined);
+    await router.push("/config");
+    await router.isReady();
+    const wrapper = mount(ConfigView, { global: { plugins: [router] } });
+    await flushPromises();
+    await wrapper.find("[data-testid='create-config-btn']").trigger("click");
+    await flushPromises();
+    vi.mocked(App.saveVRChatConfig).mockClear();
+
+    const cacheInner = numInput(wrapper, "cache-size-input");
+    await cacheInner.setValue(10);
+    await cacheInner.trigger("blur");
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find("[data-testid='save-config-btn']").trigger("click");
+    await flushPromises();
+
+    expect(App.saveVRChatConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheSize: 30 }),
     );
   });
 });

--- a/frontend/src/views/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/__tests__/DashboardView.spec.ts
@@ -191,4 +191,84 @@ describe("DashboardView", () => {
     expect(errorSpy).toHaveBeenCalledWith("backend string err");
     errorSpy.mockRestore();
   });
+
+  it("calls App.launchVRChat with default profile id when launch is clicked", async () => {
+    mockLaunchProfiles.mockResolvedValue([defaultLaunchProfile]);
+    const wrapper = mount(DashboardView);
+    await flushPromises();
+
+    await wrapper.find(".launch-btn").trigger("click");
+    await flushPromises();
+
+    expect(mockLaunchVRChat).toHaveBeenCalledWith("p-default");
+  });
+
+  it("uses first profile when none is marked default", async () => {
+    mockLaunchProfiles.mockResolvedValue([
+      {
+        id: "p-first",
+        name: "FirstOnly",
+        arguments: "",
+        isDefault: false,
+      },
+    ]);
+    const wrapper = mount(DashboardView);
+    await flushPromises();
+
+    const launchBtn = wrapper.find(".launch-btn");
+    expect((launchBtn.element as HTMLButtonElement).disabled).toBe(false);
+    expect(launchBtn.text()).toContain("FirstOnly");
+  });
+
+  it("setStatusOnly calls join me and ask me statuses", async () => {
+    const wrapper = mount(DashboardView);
+    await flushPromises();
+
+    await wrapper
+      .find('[data-testid="dashboard-quick-status-join-me"]')
+      .trigger("click");
+    await flushPromises();
+    expect(mockSetStatus).toHaveBeenCalledWith("join me");
+
+    await wrapper
+      .find('[data-testid="dashboard-quick-status-ask-me"]')
+      .trigger("click");
+    await flushPromises();
+    expect(mockSetStatus).toHaveBeenCalledWith("ask me");
+  });
+
+  it("shows error when applyCustomDescription fails", async () => {
+    mockSetStatusDescription.mockRejectedValueOnce(new Error("desc failed"));
+    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+      close: () => {},
+    }));
+
+    const wrapper = mount(DashboardView);
+    await flushPromises();
+    await wrapper.find(".custom-status-input input").setValue("bad");
+    await wrapper.find(".apply-btn").trigger("click");
+    await flushPromises();
+
+    expect(errorSpy).toHaveBeenCalledWith("desc failed");
+    errorSpy.mockRestore();
+  });
+
+  it("shows error when applyTemplate fails", async () => {
+    mockSetStatusAndDescription.mockRejectedValueOnce({ message: "tpl fail" });
+    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+      close: () => {},
+    }));
+
+    const wrapper = mount(DashboardView);
+    await flushPromises();
+
+    const joinTemplateBtn = wrapper
+      .findAll(".templates-panel .status-btn")
+      .find((b) => b.text() === "だれでもどうぞ");
+    await joinTemplateBtn!.trigger("click");
+    await flushPromises();
+
+    expect(errorSpy).toHaveBeenCalledWith("tpl fail");
+    errorSpy.mockRestore();
+  });
 });

--- a/frontend/src/views/__tests__/FriendsView.spec.ts
+++ b/frontend/src/views/__tests__/FriendsView.spec.ts
@@ -21,10 +21,13 @@ async function mountFriendsView(query: Record<string, string> = {}) {
   return wrapper;
 }
 
-const { mockFriends, mockIsLoggedIn } = vi.hoisted(() => ({
-  mockFriends: vi.fn(),
-  mockIsLoggedIn: vi.fn(),
-}));
+const { mockFriends, mockIsLoggedIn, mockRefreshFriends, mockSetFavorite } =
+  vi.hoisted(() => ({
+    mockFriends: vi.fn(),
+    mockIsLoggedIn: vi.fn(),
+    mockRefreshFriends: vi.fn(),
+    mockSetFavorite: vi.fn(),
+  }));
 
 vi.mock("../../composables/useSessionUnlock", () => ({
   useSessionUnlock: () => ({
@@ -55,9 +58,9 @@ vi.mock("../../wails/app", async (importOriginal) => {
       ...actual.App,
       friends: mockFriends,
       isLoggedIn: mockIsLoggedIn,
-      refreshFriends: vi.fn(),
+      refreshFriends: mockRefreshFriends,
       reconcileVRChatSocialCache: vi.fn().mockResolvedValue(undefined),
-      setFavorite: vi.fn(),
+      setFavorite: mockSetFavorite,
     },
   };
 });
@@ -93,6 +96,7 @@ describe("FriendsView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsLoggedIn.mockResolvedValue(false);
+    mockSetFavorite.mockResolvedValue(undefined);
     runtimeHooks.friendsChangedHandler = null;
   });
 
@@ -339,5 +343,139 @@ describe("FriendsView", () => {
     const router = wrapper.vm.$router;
     expect(router.currentRoute.value.query.vrcUserId).toBeUndefined();
     warnSpy.mockRestore();
+  });
+
+  it("shows login hint when user is not logged in", async () => {
+    mockFriends.mockResolvedValue([]);
+    mockIsLoggedIn.mockResolvedValue(false);
+    const wrapper = await mountFriendsView();
+
+    expect(wrapper.find(".login-hint").exists()).toBe(true);
+    expect(wrapper.text()).toContain("ログイン");
+  });
+
+  it("shows online-none message when online list is empty", async () => {
+    mockFriends.mockResolvedValue([]);
+    const wrapper = await mountFriendsView();
+    expect(wrapper.text()).toContain("オンラインのフレンドはいません");
+  });
+
+  it("shows offline-none message when offline list is empty", async () => {
+    mockFriends.mockResolvedValue([
+      minimalUser({
+        vrcUserId: "1",
+        displayName: "OnUser",
+        status: "active",
+      }),
+    ]);
+    const wrapper = await mountFriendsView();
+
+    await switchInput(wrapper, "friends-filter-mode").setValue(true);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("オフラインのフレンドはいません");
+  });
+
+  it("refresh reconciles and reloads friends when logged in", async () => {
+    mockFriends.mockResolvedValue([
+      minimalUser({
+        vrcUserId: "1",
+        displayName: "Alice",
+        status: "active",
+      }),
+    ]);
+    mockIsLoggedIn.mockResolvedValue(true);
+    const wrapper = await mountFriendsView();
+    await flushPromises();
+
+    const reconcile = vi.mocked(App.reconcileVRChatSocialCache);
+    reconcile.mockClear();
+    mockFriends.mockClear();
+
+    await wrapper.find(".friends-header .el-button").trigger("click");
+    await flushPromises();
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(mockFriends).toHaveBeenCalled();
+  });
+
+  it("toggleFavorite calls App.setFavorite from list panel", async () => {
+    mockFriends.mockResolvedValue([
+      minimalUser({
+        vrcUserId: "1",
+        displayName: "FavUser",
+        status: "active",
+        isFavorite: false,
+      }),
+    ]);
+    const wrapper = await mountFriendsView();
+
+    await wrapper.find(".btn-favorite").trigger("click");
+    await flushPromises();
+
+    expect(mockSetFavorite).toHaveBeenCalledWith("1", true);
+  });
+
+  it("does not change favorite when list toggle fails", async () => {
+    mockSetFavorite.mockRejectedValueOnce(new Error("fail"));
+    mockFriends.mockResolvedValue([
+      minimalUser({
+        vrcUserId: "1",
+        displayName: "FavUser",
+        status: "active",
+        isFavorite: false,
+      }),
+    ]);
+    const wrapper = await mountFriendsView();
+
+    await wrapper.find(".btn-favorite").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find(".btn-favorite").classes()).not.toContain(
+      "el-button--primary",
+    );
+  });
+
+  it("clears selection when selected friend disappears after reload", async () => {
+    mockFriends
+      .mockResolvedValueOnce([
+        minimalUser({
+          vrcUserId: "u1",
+          displayName: "Alice",
+          status: "active",
+        }),
+      ])
+      .mockResolvedValueOnce([]);
+    const wrapper = await mountFriendsView();
+    await flushPromises();
+
+    await wrapper.find(".friend-card").trigger("click");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".friend-card.active").exists()).toBe(true);
+
+    runtimeHooks.friendsChangedHandler?.();
+    await flushPromises();
+
+    expect(wrapper.find(".friend-card.active").exists()).toBe(false);
+  });
+
+  it("reconciles on visibility when logged in after throttle interval", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+    mockFriends.mockResolvedValue([]);
+    mockIsLoggedIn.mockResolvedValue(true);
+    const wrapper = await mountFriendsView();
+    await flushPromises();
+
+    const reconcile = vi.mocked(App.reconcileVRChatSocialCache);
+    reconcile.mockClear();
+
+    vi.setSystemTime(new Date("2026-01-01T12:01:01.000Z"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flushPromises();
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/views/__tests__/LauncherView.spec.ts
+++ b/frontend/src/views/__tests__/LauncherView.spec.ts
@@ -448,6 +448,526 @@ describe("LauncherView", () => {
     );
   });
 
+  it("addNew creates first profile as default when list is empty", async () => {
+    mockLaunchProfiles.mockResolvedValue([]);
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    await wrapper.find(".btn-add").trigger("click");
+    await flushPromises();
+
+    const defaultLabel = wrapper
+      .findAll(".el-checkbox")
+      .find((c) => c.text().includes("デフォルトに設定"));
+    const defaultInput = defaultLabel?.find("input");
+    expect((defaultInput?.element as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("saves a new profile via merge and saveLaunchProfile", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    await wrapper.find(".btn-add").trigger("click");
+    await flushPromises();
+
+    await wrapper
+      .find(".profile-editor .el-input input")
+      .setValue("My Custom Profile");
+    await checkInput(wrapper, "no-vr-checkbox").setValue(true);
+    mockMergeLaunchArgsForGUI.mockResolvedValue("-no-vr");
+    await wrapper.find(".btn-save").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({ noVr: true }),
+    );
+    expect(mockSaveLaunchProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "",
+        name: "My Custom Profile",
+        arguments: "-no-vr",
+      }),
+    );
+    expect(mockLaunchProfiles).toHaveBeenCalled();
+  });
+
+  it("applies resolution preset dimensions on save", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "resolution-enabled-checkbox").setValue(true);
+    await flushPromises();
+    await wrapper
+      .find("[data-testid='resolution-preset-4k'] input")
+      .setValue(true);
+    await flushPromises();
+
+    mockMergeLaunchArgsForGUI.mockResolvedValue(
+      "-screen-width 3840 -screen-height 2160",
+    );
+    await wrapper.find(".btn-save").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        screenWidth: 3840,
+        screenHeight: 2160,
+      }),
+    );
+  });
+
+  it("clears resolution when disabled before save", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    mockParseLaunchArgsForGUI.mockResolvedValue({
+      noVr: false,
+      screenMode: "",
+      screenWidth: 1920,
+      screenHeight: 1080,
+      fps: 0,
+      processPriority: -999,
+      mainThreadPriority: -999,
+      monitor: 0,
+      profile: -1,
+      midi: "",
+      ignoreTrackers: "",
+      osc: "",
+      affinity: "",
+      custom: "",
+    } as LaunchArgsParsedDTO);
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "resolution-enabled-checkbox").setValue(false);
+    await flushPromises();
+
+    mockMergeLaunchArgsForGUI.mockResolvedValue("");
+    await wrapper.find(".btn-save").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        screenWidth: 0,
+        screenHeight: 0,
+      }),
+    );
+  });
+
+  it("syncs advanced option toggles from parsed args", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    mockParseLaunchArgsForGUI.mockResolvedValue({
+      noVr: false,
+      screenMode: "",
+      screenWidth: 0,
+      screenHeight: 0,
+      fps: 90,
+      skipRegistry: false,
+      processPriority: 1,
+      mainThreadPriority: -999,
+      monitor: 2,
+      profile: 0,
+      enableDebugGui: false,
+      enableSDKLogLevels: false,
+      enableUdonDebugLogging: false,
+      midi: "device1",
+      watchWorlds: false,
+      watchAvatars: false,
+      ignoreTrackers: "serial1",
+      videoDecoding: "",
+      disableAMDStutterWorkaround: false,
+      osc: "9000",
+      affinity: "0,1",
+      enforceWorldServerChecks: false,
+      custom: "",
+    } as LaunchArgsParsedDTO);
+
+    await wrapper.findAll(".profile-card")[1]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    expect(
+      (
+        checkInput(wrapper, "monitor-enabled-checkbox")
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+    expect(
+      (checkInput(wrapper, "fps-enabled-checkbox").element as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+    expect(
+      (
+        checkInput(wrapper, "process-priority-enabled-checkbox")
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+    expect(
+      (
+        checkInput(wrapper, "profile-enabled-checkbox")
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+
+    const debugHeaders = wrapper.findAll(".el-collapse-item__header");
+    const debugHeader = debugHeaders.find((h) =>
+      h.text().includes("クリエイター・デバッグ向け"),
+    );
+    await debugHeader!.trigger("click");
+    await flushPromises();
+
+    expect(
+      (checkInput(wrapper, "midi-enabled-checkbox").element as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+    expect(wrapper.find('[data-testid="midi-input"]').exists()).toBe(true);
+    expect(
+      (
+        checkInput(wrapper, "ignore-trackers-enabled-checkbox")
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+    expect(
+      (checkInput(wrapper, "osc-enabled-checkbox").element as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+    expect(
+      (
+        checkInput(wrapper, "affinity-enabled-checkbox")
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+  });
+
+  it("clears optional fields when their enable toggles are turned off", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    mockParseLaunchArgsForGUI.mockResolvedValue({
+      noVr: false,
+      screenMode: "",
+      screenWidth: 0,
+      screenHeight: 0,
+      fps: 90,
+      processPriority: -999,
+      mainThreadPriority: -999,
+      monitor: 2,
+      profile: -1,
+      midi: "device1",
+      ignoreTrackers: "serial1",
+      osc: "9000",
+      affinity: "0,1",
+      custom: "",
+    } as LaunchArgsParsedDTO);
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "monitor-enabled-checkbox").setValue(false);
+    await checkInput(wrapper, "fps-enabled-checkbox").setValue(false);
+    await flushPromises();
+
+    const debugHeaders = wrapper.findAll(".el-collapse-item__header");
+    const debugHeader = debugHeaders.find((h) =>
+      h.text().includes("クリエイター・デバッグ向け"),
+    );
+    await debugHeader!.trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "midi-enabled-checkbox").setValue(false);
+    await checkInput(wrapper, "osc-enabled-checkbox").setValue(false);
+    await checkInput(wrapper, "ignore-trackers-enabled-checkbox").setValue(
+      false,
+    );
+    await checkInput(wrapper, "affinity-enabled-checkbox").setValue(false);
+    await flushPromises();
+
+    mockMergeLaunchArgsForGUI.mockResolvedValue("");
+    await wrapper.find(".btn-save").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        monitor: 0,
+        fps: 0,
+        midi: "",
+        osc: "",
+        ignoreTrackers: "",
+        affinity: "",
+      }),
+    );
+  });
+
+  it("enables main thread priority and profile index when toggled on", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "main-thread-priority-enabled-checkbox").setValue(
+      true,
+    );
+    await checkInput(wrapper, "profile-enabled-checkbox").setValue(true);
+    await flushPromises();
+
+    mockMergeLaunchArgsForGUI.mockResolvedValue("");
+    await wrapper.find(".btn-save").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mainThreadPriority: 0,
+        profile: 0,
+      }),
+    );
+  });
+
+  it("detects custom resolution preset from parsed args", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    mockParseLaunchArgsForGUI.mockResolvedValue({
+      noVr: false,
+      screenMode: "",
+      screenWidth: 1600,
+      screenHeight: 900,
+      fps: 0,
+      processPriority: -999,
+      mainThreadPriority: -999,
+      monitor: 0,
+      profile: -1,
+      midi: "",
+      ignoreTrackers: "",
+      osc: "",
+      affinity: "",
+      custom: "",
+    } as LaunchArgsParsedDTO);
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    expect(
+      (
+        checkInput(wrapper, "resolution-enabled-checkbox")
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+    expect(isDisabled(wrapper, "screen-width-input")).toBe(false);
+    expect(isDisabled(wrapper, "screen-height-input")).toBe(false);
+  });
+
+  it("launches with popupwindow screen mode", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    await wrapper
+      .find('[data-testid="screen-mode-popupwindow"] input')
+      .setValue(true);
+    mockMergeLaunchArgsForGUI.mockResolvedValue("-popupwindow");
+    await wrapper.find(".btn-launch").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({ screenMode: "popupwindow" }),
+    );
+    expect(mockLaunchVRChatWithArgs).toHaveBeenCalledWith("-popupwindow");
+  });
+
+  it("mounts without profiles and opens editor only after add", async () => {
+    mockLaunchProfiles.mockResolvedValue([]);
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    expect(wrapper.find(".profile-editor").exists()).toBe(false);
+    await wrapper.find(".btn-add").trigger("click");
+    await flushPromises();
+    expect(wrapper.find(".profile-editor").exists()).toBe(true);
+  });
+
+  it("defaults resolution to FHD when enabling empty resolution fields", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    mockParseLaunchArgsForGUI.mockResolvedValue({
+      noVr: false,
+      screenMode: "",
+      screenWidth: 0,
+      screenHeight: 0,
+      fps: 0,
+      processPriority: -999,
+      mainThreadPriority: -999,
+      monitor: 0,
+      profile: -1,
+      midi: "",
+      ignoreTrackers: "",
+      osc: "",
+      affinity: "",
+      custom: "",
+    } as LaunchArgsParsedDTO);
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "resolution-enabled-checkbox").setValue(true);
+    await flushPromises();
+
+    mockMergeLaunchArgsForGUI.mockResolvedValue(
+      "-screen-width 1920 -screen-height 1080",
+    );
+    await wrapper.find(".btn-save").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        screenWidth: 1920,
+        screenHeight: 1080,
+      }),
+    );
+  });
+
+  it("merges monitor, fps, process priority, and debug flags on launch", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    const collapse = wrapper.find(".args-collapse");
+    await collapse.find(".el-collapse-item__header").trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "monitor-enabled-checkbox").setValue(true);
+    await checkInput(wrapper, "fps-enabled-checkbox").setValue(true);
+    await checkInput(wrapper, "process-priority-enabled-checkbox").setValue(
+      true,
+    );
+    await checkInput(wrapper, "skip-registry-checkbox").setValue(true);
+    await flushPromises();
+
+    await inputInner(wrapper, "monitor-input").setValue(2);
+    await inputInner(wrapper, "fps-input").setValue(144);
+    await inputInner(wrapper, "process-priority-input").setValue(1);
+
+    const debugHeaders = wrapper.findAll(".el-collapse-item__header");
+    const debugHeader = debugHeaders.find((h) =>
+      h.text().includes("クリエイター・デバッグ向け"),
+    );
+    await debugHeader!.trigger("click");
+    await flushPromises();
+
+    await checkInput(wrapper, "enable-debug-gui-checkbox").setValue(true);
+    await checkInput(wrapper, "watch-worlds-checkbox").setValue(true);
+    await checkInput(wrapper, "watch-avatars-checkbox").setValue(true);
+    await checkInput(wrapper, "enforce-world-server-checks-checkbox").setValue(
+      true,
+    );
+    await checkInput(
+      wrapper,
+      "disable-amd-stutter-workaround-checkbox",
+    ).setValue(true);
+    await wrapper
+      .find('[data-testid="video-decoding-software"] input')
+      .setValue(true);
+    await flushPromises();
+
+    mockMergeLaunchArgsForGUI.mockResolvedValue("merged-args");
+    await wrapper.find(".btn-launch").trigger("click");
+    await flushPromises();
+
+    expect(mockMergeLaunchArgsForGUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        monitor: 2,
+        fps: 144,
+        processPriority: 1,
+        skipRegistry: true,
+        enableDebugGui: true,
+        watchWorlds: true,
+        watchAvatars: true,
+        enforceWorldServerChecks: true,
+        disableAMDStutterWorkaround: true,
+        videoDecoding: "software",
+      }),
+    );
+    expect(mockLaunchVRChatWithArgs).toHaveBeenCalledWith("merged-args");
+  });
+
+  it("selects remaining profile after delete succeeds", async () => {
+    const wrapper = mount(LauncherView);
+    await flushPromises();
+
+    await wrapper.findAll(".profile-card")[0]?.trigger("click");
+    await flushPromises();
+
+    mockDeleteLaunchProfile.mockResolvedValue(undefined);
+    mockLaunchProfiles.mockResolvedValue([sampleProfiles[1]!]);
+    mockParseLaunchArgsForGUI.mockResolvedValue({
+      noVr: false,
+      screenMode: "windowed",
+      screenWidth: 0,
+      screenHeight: 0,
+      fps: 0,
+      processPriority: -999,
+      mainThreadPriority: -999,
+      monitor: 0,
+      profile: -1,
+      midi: "",
+      ignoreTrackers: "",
+      osc: "",
+      affinity: "",
+      custom: "",
+    } as LaunchArgsParsedDTO);
+
+    const confirmSpy = vi
+      .spyOn(ElMessageBox, "confirm")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValue("confirm" as any);
+
+    await wrapper.find('[data-testid="delete-profile-btn"]').trigger("click");
+    await flushPromises();
+
+    expect(mockDeleteLaunchProfile).toHaveBeenCalledWith("1");
+    expect(wrapper.text()).toContain("With fullscreen");
+
+    confirmSpy.mockRestore();
+  });
+
   it("sets aria-label on screen mode, resolution preset, and video decoding radio groups", async () => {
     const wrapper = mount(LauncherView);
     await flushPromises();

--- a/frontend/src/views/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsView.spec.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
-import { ElMessage } from "element-plus";
+import { ElMessage, ElMessageBox } from "element-plus";
 import { createRouter, createWebHashHistory } from "vue-router";
 import SettingsView from "../SettingsView.vue";
 import { App } from "../../wails/app";
 import * as I18nModule from "../../i18n";
+import { resetSessionUnlockForStorybook } from "../../composables/useSessionUnlock";
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -14,38 +15,589 @@ const router = createRouter({
   ],
 });
 
+const defaultPathSettings = {
+  vrchatPathWindows: "C:\\VRChat\\VRChat.exe",
+  steamPathLinux: "/home/user/.steam/steam",
+  outputLogPath:
+    "C:\\Users\\x\\AppData\\LocalLow\\VRChat\\VRChat\\output_log.txt",
+};
+
+function mountSettings() {
+  return mount(SettingsView, { global: { plugins: [router] } });
+}
+
+function pathRowInput(wrapper: ReturnType<typeof mount>, rowIndex: number) {
+  return wrapper.findAll(".path-row .el-input input")[rowIndex]!;
+}
+
+function validateExistsBtn(
+  wrapper: ReturnType<typeof mount>,
+  rowIndex: number,
+) {
+  return wrapper.findAll(".path-row .el-button--primary")[rowIndex]!;
+}
+
+function setupAppMocks() {
+  vi.spyOn(App, "hasStoredCredential").mockResolvedValue(false);
+  vi.spyOn(App, "isLoggedIn").mockResolvedValue(false);
+  vi.spyOn(App, "getLogRetentionDays").mockResolvedValue(45);
+  vi.spyOn(App, "getSuppressSleepWhileVRChat").mockResolvedValue(true);
+  vi.spyOn(App, "getPathSettings").mockResolvedValue({
+    ...defaultPathSettings,
+  });
+  vi.spyOn(App, "setPathSettings").mockResolvedValue(undefined);
+  vi.spyOn(App, "setLogRetentionDays").mockResolvedValue(undefined);
+  vi.spyOn(App, "setSuppressSleepWhileVRChat").mockResolvedValue(undefined);
+  vi.spyOn(App, "openFileDialog").mockResolvedValue(null);
+  vi.spyOn(App, "openDirectoryDialog").mockResolvedValue(null);
+  vi.spyOn(App, "validatePath").mockResolvedValue(true);
+  vi.spyOn(App, "validateOutputLogPath").mockResolvedValue(true);
+  vi.spyOn(App, "openVRChatLogFolder").mockResolvedValue(undefined);
+  vi.spyOn(App, "vacuumDb").mockResolvedValue(undefined);
+  vi.spyOn(App, "clearEncounters").mockResolvedValue(5);
+  vi.spyOn(App, "clearScreenshots").mockResolvedValue(3);
+  vi.spyOn(App, "clearFriendsCache").mockResolvedValue(2);
+  vi.spyOn(App, "setLanguage").mockResolvedValue(undefined);
+}
+
 describe("SettingsView", () => {
-  it("renders settings title", async () => {
+  beforeEach(async () => {
+    resetSessionUnlockForStorybook();
     await router.push("/settings");
     await router.isReady();
-    const wrapper = mount(SettingsView, {
-      global: {
-        plugins: [router],
-      },
-    });
+    setupAppMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders settings title", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
     expect(wrapper.find(".page-title").text()).toBe("設定");
   });
 
   it("has link to OSS licenses page", async () => {
-    await router.push("/settings");
-    await router.isReady();
-    const wrapper = mount(SettingsView, {
-      global: {
-        plugins: [router],
-      },
-    });
+    const wrapper = mountSettings();
+    await flushPromises();
     const licensesLink = wrapper.find(".btn-licenses");
     expect(licensesLink.exists()).toBe(true);
     expect(licensesLink.attributes("href")).toContain("/licenses");
     expect(licensesLink.text()).toContain("OSS ライセンス一覧");
   });
+
+  it("loads path settings on mount", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    expect(App.getPathSettings).toHaveBeenCalled();
+    expect((pathRowInput(wrapper, 0).element as HTMLInputElement).value).toBe(
+      defaultPathSettings.vrchatPathWindows,
+    );
+    expect((pathRowInput(wrapper, 1).element as HTMLInputElement).value).toBe(
+      defaultPathSettings.steamPathLinux,
+    );
+    expect((pathRowInput(wrapper, 2).element as HTMLInputElement).value).toBe(
+      defaultPathSettings.outputLogPath,
+    );
+  });
+
+  it("loads log retention and suppress sleep on mount", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    expect(App.getLogRetentionDays).toHaveBeenCalled();
+    expect(App.getSuppressSleepWhileVRChat).toHaveBeenCalled();
+    expect(
+      (
+        wrapper.find(".setting-row .el-input-number input")
+          .element as HTMLInputElement
+      ).value,
+    ).toBe("45");
+    expect(
+      wrapper.findComponent({ name: "ElSwitch" }).props("modelValue"),
+    ).toBe(true);
+  });
+
+  it("lists all UI language options", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const options = wrapper.findAllComponents({ name: "ElOption" });
+    expect(options).toHaveLength(5);
+    expect(options.map((o) => o.props("value"))).toEqual([
+      "ja",
+      "en",
+      "ko",
+      "zh-TW",
+      "zh-CN",
+    ]);
+  });
+
+  it("saves path settings when a path input changes", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+    vi.mocked(App.setPathSettings).mockClear();
+
+    const input = pathRowInput(wrapper, 0);
+    await input.setValue("D:\\New\\VRChat.exe");
+    await input.trigger("change");
+    await flushPromises();
+
+    expect(App.setPathSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ vrchatPathWindows: "D:\\New\\VRChat.exe" }),
+    );
+  });
+
+  it("browse VRChat path saves selected file", async () => {
+    vi.mocked(App.openFileDialog).mockResolvedValueOnce(
+      "D:\\Picked\\VRChat.exe",
+    );
+    const wrapper = mountSettings();
+    await flushPromises();
+    vi.mocked(App.setPathSettings).mockClear();
+
+    await wrapper.find('[data-testid="vrchat-path-browse"]').trigger("click");
+    await flushPromises();
+
+    expect(App.openFileDialog).toHaveBeenCalled();
+    expect(App.setPathSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ vrchatPathWindows: "D:\\Picked\\VRChat.exe" }),
+    );
+  });
+
+  it("browse Steam path saves selected file", async () => {
+    vi.mocked(App.openFileDialog).mockResolvedValueOnce("/usr/bin/steam");
+    const wrapper = mountSettings();
+    await flushPromises();
+    vi.mocked(App.setPathSettings).mockClear();
+
+    await wrapper.find('[data-testid="steam-path-browse"]').trigger("click");
+    await flushPromises();
+
+    expect(App.setPathSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ steamPathLinux: "/usr/bin/steam" }),
+    );
+  });
+
+  it("browse output log file saves selected path", async () => {
+    vi.mocked(App.openFileDialog).mockResolvedValueOnce(
+      "C:\\logs\\output_log.txt",
+    );
+    const wrapper = mountSettings();
+    await flushPromises();
+    vi.mocked(App.setPathSettings).mockClear();
+
+    await wrapper
+      .find('[data-testid="output-log-path-browse"]')
+      .trigger("click");
+    await flushPromises();
+
+    expect(App.setPathSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ outputLogPath: "C:\\logs\\output_log.txt" }),
+    );
+  });
+
+  it("browse output log directory saves selected folder", async () => {
+    vi.mocked(App.openDirectoryDialog).mockResolvedValueOnce("C:\\logs");
+    const wrapper = mountSettings();
+    await flushPromises();
+    vi.mocked(App.setPathSettings).mockClear();
+
+    await wrapper
+      .find('[data-testid="output-log-dir-browse"]')
+      .trigger("click");
+    await flushPromises();
+
+    expect(App.setPathSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ outputLogPath: "C:\\logs" }),
+    );
+  });
+
+  it("opens VRChat log folder via App", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const openBtn = wrapper
+      .findAll(".path-row")[2]!
+      .findAll("button")
+      .find((b: { text: () => string }) =>
+        b.text().includes("ログフォルダを開く"),
+      );
+    expect(openBtn).toBeDefined();
+    await openBtn!.trigger("click");
+    await flushPromises();
+
+    expect(App.openVRChatLogFolder).toHaveBeenCalled();
+  });
+
+  it("validates executable paths with App.validatePath", async () => {
+    vi.mocked(App.validatePath).mockResolvedValueOnce(false);
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    await validateExistsBtn(wrapper, 0).trigger("click");
+    await flushPromises();
+
+    expect(App.validatePath).toHaveBeenCalledWith(
+      defaultPathSettings.vrchatPathWindows,
+    );
+    expect(wrapper.text()).toContain("存在しません");
+  });
+
+  it("validates output log path with App.validateOutputLogPath", async () => {
+    vi.mocked(App.validateOutputLogPath).mockResolvedValueOnce(true);
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    await validateExistsBtn(wrapper, 2).trigger("click");
+    await flushPromises();
+
+    expect(App.validateOutputLogPath).toHaveBeenCalledWith(
+      defaultPathSettings.outputLogPath,
+    );
+    expect(wrapper.text()).toContain("存在します");
+  });
+
+  it("saves log retention days on change", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+    vi.mocked(App.setLogRetentionDays).mockClear();
+
+    const retentionInput = wrapper.find(".setting-row .el-input-number input");
+    await retentionInput.setValue("60");
+    await retentionInput.trigger("change");
+    await flushPromises();
+
+    expect(App.setLogRetentionDays).toHaveBeenCalledWith(60);
+  });
+
+  it("saves suppress sleep toggle on change", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+    vi.mocked(App.setSuppressSleepWhileVRChat).mockClear();
+
+    await wrapper.find(".power-switch").trigger("click");
+    await flushPromises();
+
+    expect(App.setSuppressSleepWhileVRChat).toHaveBeenCalledWith(false);
+  });
+
+  it("runs vacuum DB after confirmation", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
+    const successSpy = vi
+      .spyOn(ElMessage, "success")
+      .mockImplementation(() => ({
+        close: () => {},
+      }));
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const vacuumBtn = wrapper
+      .findAll(".maintenance-actions button")
+      .find((b) => b.text().includes("DB最適化"));
+    await vacuumBtn!.trigger("click");
+    await flushPromises();
+
+    expect(App.vacuumDb).toHaveBeenCalled();
+    expect(successSpy).toHaveBeenCalled();
+  });
+
+  it("clears encounters after confirmation", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
+    vi.spyOn(ElMessage, "success").mockImplementation(() => ({
+      close: () => {},
+    }));
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const btn = wrapper
+      .findAll(".maintenance-actions button")
+      .find((b) => b.text().includes("遭遇ログ"));
+    await btn!.trigger("click");
+    await flushPromises();
+
+    expect(App.clearEncounters).toHaveBeenCalled();
+  });
+
+  it("clears screenshots after confirmation", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
+    vi.spyOn(ElMessage, "success").mockImplementation(() => ({
+      close: () => {},
+    }));
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const btn = wrapper
+      .findAll(".maintenance-actions button")
+      .find((b) => b.text().includes("スクショ"));
+    await btn!.trigger("click");
+    await flushPromises();
+
+    expect(App.clearScreenshots).toHaveBeenCalled();
+  });
+
+  it("clears friends cache after confirmation", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
+    vi.spyOn(ElMessage, "success").mockImplementation(() => ({
+      close: () => {},
+    }));
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const btn = wrapper
+      .findAll(".maintenance-actions button")
+      .find((b) => b.text().includes("フレンド"));
+    await btn!.trigger("click");
+    await flushPromises();
+
+    expect(App.clearFriendsCache).toHaveBeenCalled();
+  });
+
+  it("skips maintenance when confirmation is cancelled", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockRejectedValue(new Error("cancel"));
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const vacuumBtn = wrapper
+      .findAll(".maintenance-actions button")
+      .find((b) => b.text().includes("DB最適化"));
+    await vacuumBtn!.trigger("click");
+    await flushPromises();
+
+    expect(App.vacuumDb).not.toHaveBeenCalled();
+  });
+
+  it("shows maintenance error when operation fails", async () => {
+    vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
+    vi.mocked(App.vacuumDb).mockRejectedValueOnce(new Error("vacuum failed"));
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const vacuumBtn = wrapper
+      .findAll(".maintenance-actions button")
+      .find((b) => b.text().includes("DB最適化"));
+    await vacuumBtn!.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find(".el-alert--error").text()).toContain("vacuum failed");
+  });
+
+  it("handles isLoggedIn failure on mount", async () => {
+    vi.mocked(App.isLoggedIn).mockRejectedValueOnce(new Error("backend down"));
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    expect(wrapper.find("#login-username").exists()).toBe(true);
+  });
+
+  it("logs error when openVRChatLogFolder fails", async () => {
+    vi.mocked(App.openVRChatLogFolder).mockRejectedValueOnce(
+      new Error("open failed"),
+    );
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const openBtn = wrapper
+      .findAll(".path-row")[2]!
+      .findAll("button")
+      .find((b: { text: () => string }) =>
+        b.text().includes("ログフォルダを開く"),
+      );
+    await openBtn!.trigger("click");
+    await flushPromises();
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});
+
+describe("SettingsView login and profile", () => {
+  const sampleUser = {
+    id: "usr_abc",
+    displayName: "Test User",
+    username: "testuser",
+    status: "active",
+    statusDescription: "Hello",
+    state: "online",
+    currentAvatarThumbnailImageUrl: "https://example.com/avatar.png",
+    userIcon: "",
+    profilePicOverrideThumbnail: "",
+  };
+
+  beforeEach(async () => {
+    resetSessionUnlockForStorybook();
+    await router.push("/settings");
+    await router.isReady();
+    setupAppMocks();
+    vi.spyOn(App, "login").mockResolvedValue({ ok: false, error: "unused" });
+    vi.spyOn(App, "logout").mockResolvedValue(undefined);
+    vi.spyOn(App, "refreshFriends").mockResolvedValue(undefined);
+    vi.spyOn(App, "clearStoredCredential").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mountLoggedIn(user = sampleUser) {
+    vi.mocked(App.isLoggedIn).mockResolvedValue(true);
+    vi.spyOn(App, "getVRChatCurrentUser").mockResolvedValue(user);
+    return mountSettings();
+  }
+
+  it("shows current user profile when logged in", async () => {
+    const wrapper = mountLoggedIn();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Test User");
+    expect(wrapper.text()).toContain("@testuser");
+    expect(wrapper.text()).toContain("usr_abc");
+    expect(wrapper.find(".current-user-avatar").attributes("src")).toBe(
+      "https://example.com/avatar.png",
+    );
+  });
+
+  it("shows profile error when getVRChatCurrentUser fails", async () => {
+    vi.mocked(App.isLoggedIn).mockResolvedValue(true);
+    vi.spyOn(App, "getVRChatCurrentUser").mockRejectedValue(
+      new Error("profile unavailable"),
+    );
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    expect(wrapper.find(".login-status .el-alert--error").text()).toContain(
+      "profile unavailable",
+    );
+  });
+
+  it("refreshes profile when refresh button is clicked", async () => {
+    const getUser = vi
+      .spyOn(App, "getVRChatCurrentUser")
+      .mockResolvedValue(sampleUser);
+    const wrapper = mountLoggedIn();
+    await flushPromises();
+    getUser.mockClear();
+
+    const refreshBtn = wrapper
+      .findAll(".login-actions button")
+      .find((b) => b.text().includes("プロフィール再取得"));
+    await refreshBtn!.trigger("click");
+    await flushPromises();
+
+    expect(getUser).toHaveBeenCalledWith(true);
+  });
+
+  it("logs in successfully and loads profile", async () => {
+    vi.mocked(App.login).mockResolvedValue({ ok: true });
+    vi.spyOn(App, "getVRChatCurrentUser").mockResolvedValue(sampleUser);
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    await wrapper.find("#login-username").setValue("user");
+    await wrapper.find("#login-password").setValue("pass");
+    await wrapper.find("#login-2fa").setValue("123456");
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("ログイン") && !b.text().includes("中"))!
+      .trigger("click");
+    await flushPromises();
+
+    expect(App.login).toHaveBeenCalledWith("user", "pass", "123456");
+    expect(wrapper.text()).toContain("Test User");
+  });
+
+  it("shows login error when credentials are rejected", async () => {
+    vi.mocked(App.login).mockResolvedValue({
+      ok: false,
+      error: "invalid credentials",
+    });
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    await wrapper.find("#login-username").setValue("user");
+    await wrapper.find("#login-password").setValue("wrong");
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("ログイン") && !b.text().includes("中"))!
+      .trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find(".login-form .el-alert--error").text()).toContain(
+      "invalid credentials",
+    );
+  });
+
+  it("logs out and returns to login form", async () => {
+    const wrapper = mountLoggedIn();
+    await flushPromises();
+
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("ログアウト"))!
+      .trigger("click");
+    await flushPromises();
+
+    expect(App.logout).toHaveBeenCalled();
+    expect(wrapper.find("#login-username").exists()).toBe(true);
+  });
+
+  it("shows logout error after failed backend logout", async () => {
+    vi.mocked(App.logout).mockRejectedValueOnce(new Error("logout failed"));
+    const wrapper = mountLoggedIn();
+    await flushPromises();
+
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("ログアウト"))!
+      .trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("#login-username").exists()).toBe(true);
+    expect(wrapper.find(".login-form .el-alert--error").text()).toContain(
+      "logout failed",
+    );
+  });
+
+  it("calls refreshFriends from logged-in actions", async () => {
+    const wrapper = mountLoggedIn();
+    await flushPromises();
+
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("フレンド一覧を更新"))!
+      .trigger("click");
+    await flushPromises();
+
+    expect(App.refreshFriends).toHaveBeenCalled();
+  });
+
+  it("handles refreshFriends failure", async () => {
+    vi.mocked(App.refreshFriends).mockRejectedValueOnce(
+      new Error("friends refresh failed"),
+    );
+    const wrapper = mountLoggedIn();
+    await flushPromises();
+
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("フレンド一覧を更新"))!
+      .trigger("click");
+    await flushPromises();
+
+    expect(App.refreshFriends).toHaveBeenCalled();
+  });
 });
 
 describe("SettingsView onLanguageChange", () => {
   beforeEach(async () => {
+    resetSessionUnlockForStorybook();
     await router.push("/settings");
     await router.isReady();
-    vi.spyOn(App, "setLanguage").mockResolvedValue(undefined);
+    setupAppMocks();
     vi.spyOn(I18nModule, "setLanguage");
   });
 
@@ -54,11 +606,7 @@ describe("SettingsView onLanguageChange", () => {
   });
 
   it("calls i18n setLanguage after App.setLanguage succeeds", async () => {
-    const wrapper = mount(SettingsView, {
-      global: {
-        plugins: [router],
-      },
-    });
+    const wrapper = mountSettings();
     await flushPromises();
 
     const select = wrapper.findComponent({ name: "ElSelect" });
@@ -75,11 +623,7 @@ describe("SettingsView onLanguageChange", () => {
       close: () => {},
     }));
 
-    const wrapper = mount(SettingsView, {
-      global: {
-        plugins: [router],
-      },
-    });
+    const wrapper = mountSettings();
     await flushPromises();
 
     vi.mocked(I18nModule.setLanguage).mockClear();
@@ -90,5 +634,17 @@ describe("SettingsView onLanguageChange", () => {
 
     expect(I18nModule.setLanguage).not.toHaveBeenCalled();
     expect(elErrorSpy).toHaveBeenCalledWith("save failed");
+  });
+
+  it("ignores invalid locale values", async () => {
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const select = wrapper.findComponent({ name: "ElSelect" });
+    await select.vm.$emit("update:modelValue", "invalid-locale");
+    await flushPromises();
+
+    expect(App.setLanguage).not.toHaveBeenCalled();
+    expect(I18nModule.setLanguage).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/views/__tests__/UserProfileDetailView.spec.ts
+++ b/frontend/src/views/__tests__/UserProfileDetailView.spec.ts
@@ -4,8 +4,9 @@ import { createRouter, createWebHashHistory } from "vue-router";
 import UserProfileDetailView from "../UserProfileDetailView.vue";
 import VrcUserCacheDetail from "../../components/VrcUserCacheDetail.vue";
 
-const { mockResolve } = vi.hoisted(() => ({
+const { mockResolve, mockSetFavorite } = vi.hoisted(() => ({
   mockResolve: vi.fn(),
+  mockSetFavorite: vi.fn(),
 }));
 
 vi.mock("../../wails/app", async (importOriginal) => {
@@ -15,7 +16,7 @@ vi.mock("../../wails/app", async (importOriginal) => {
     App: {
       ...actual.App,
       resolveUserProfileNavigation: mockResolve,
-      setFavorite: vi.fn(),
+      setFavorite: mockSetFavorite,
     },
   };
 });
@@ -76,5 +77,122 @@ describe("UserProfileDetailView", () => {
     expect(detail.exists()).toBe(true);
     expect(detail.props("selected")?.displayName).toBe("FallbackName");
     expect(detail.props("selected")?.vrcUserId).toBe("u2");
+  });
+
+  it("shows warning when vrcUserId query is missing", async () => {
+    const wrapper = await mountWithQuery({});
+    expect(wrapper.find(".el-alert").exists()).toBe(true);
+    expect(wrapper.text()).toContain("ユーザー ID");
+    expect(wrapper.findComponent(VrcUserCacheDetail).exists()).toBe(false);
+  });
+
+  it("uses vrcUserId as display name when resolve omits user id", async () => {
+    mockResolve.mockResolvedValue({
+      openInFriendsView: false,
+      user: {
+        vrcUserId: "",
+        displayName: "",
+        status: "",
+        isFavorite: false,
+        lastUpdated: "",
+      },
+    });
+    const wrapper = await mountWithQuery({ vrcUserId: "usr_only" });
+    const detail = wrapper.findComponent(VrcUserCacheDetail);
+    expect(detail.props("selected")?.vrcUserId).toBe("usr_only");
+    expect(detail.props("selected")?.displayName).toBe("usr_only");
+  });
+
+  it("reads displayName from array query values", async () => {
+    mockResolve.mockRejectedValue(new Error("network"));
+    const router = createRouter({
+      history: createWebHashHistory(),
+      routes: [
+        {
+          path: "/user-profile",
+          name: "user-profile",
+          component: UserProfileDetailView,
+        },
+      ],
+    });
+    await router.push({
+      path: "/user-profile",
+      query: { vrcUserId: "u-array", displayName: ["First", "Second"] },
+    });
+    await router.isReady();
+    const wrapper = mount(UserProfileDetailView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+
+    expect(
+      wrapper.findComponent(VrcUserCacheDetail).props("selected"),
+    ).toMatchObject({
+      vrcUserId: "u-array",
+      displayName: "First",
+    });
+  });
+
+  it("reloads when vrcUserId query changes", async () => {
+    const router = createRouter({
+      history: createWebHashHistory(),
+      routes: [
+        {
+          path: "/user-profile",
+          name: "user-profile",
+          component: UserProfileDetailView,
+        },
+      ],
+    });
+    await router.push({
+      path: "/user-profile",
+      query: { vrcUserId: "first-id" },
+    });
+    await router.isReady();
+    mount(UserProfileDetailView, { global: { plugins: [router] } });
+    await flushPromises();
+    expect(mockResolve).toHaveBeenCalledWith("first-id");
+
+    mockResolve.mockClear();
+    mockResolve.mockResolvedValue({
+      openInFriendsView: false,
+      user: {
+        vrcUserId: "second-id",
+        displayName: "Second",
+        status: "",
+        isFavorite: false,
+        lastUpdated: "",
+      },
+    });
+    await router.push({
+      path: "/user-profile",
+      query: { vrcUserId: "second-id" },
+    });
+    await flushPromises();
+    expect(mockResolve).toHaveBeenCalledWith("second-id");
+  });
+
+  it("persists favorite changes via App.setFavorite", async () => {
+    mockSetFavorite.mockResolvedValue(undefined);
+    const wrapper = await mountWithQuery({ vrcUserId: "u1" });
+    const detail = wrapper.findComponent(VrcUserCacheDetail);
+
+    await detail.vm.$emit("favorite-change", detail.props("selected"), true);
+    await flushPromises();
+
+    expect(mockSetFavorite).toHaveBeenCalledWith("u1", true);
+    expect(detail.props("selected")?.isFavorite).toBe(true);
+  });
+
+  it("reverts favorite when App.setFavorite rejects", async () => {
+    mockSetFavorite.mockRejectedValue(new Error("favorite failed"));
+    const wrapper = await mountWithQuery({ vrcUserId: "u1" });
+    const detail = wrapper.findComponent(VrcUserCacheDetail);
+    expect(detail.props("selected")?.isFavorite).toBe(false);
+
+    await detail.vm.$emit("favorite-change", detail.props("selected"), true);
+    await flushPromises();
+
+    expect(detail.props("selected")?.isFavorite).toBe(false);
   });
 });

--- a/frontend/src/views/friends/__tests__/FriendsListPanel.spec.ts
+++ b/frontend/src/views/friends/__tests__/FriendsListPanel.spec.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import FriendsListPanel from "../FriendsListPanel.vue";
+import type { UserCacheDTO } from "../../../wails/app";
+
+function minimalUser(
+  partial: Partial<UserCacheDTO> &
+    Pick<UserCacheDTO, "vrcUserId" | "displayName" | "status">,
+): UserCacheDTO {
+  return {
+    isFavorite: false,
+    lastUpdated: "",
+    ...partial,
+  } as UserCacheDTO;
+}
+
+describe("FriendsListPanel", () => {
+  it("renders thumbnail when avatar url is available", () => {
+    const user = minimalUser({
+      vrcUserId: "1",
+      displayName: "ThumbUser",
+      status: "active",
+      currentAvatarThumbnailImageUrl: "https://example.com/thumb.png",
+    });
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [user],
+        selected: null,
+        loading: false,
+        emptyMessage: "empty",
+      },
+    });
+
+    const img = wrapper.find(".friend-thumb");
+    expect(img.element.tagName).toBe("IMG");
+    expect(img.attributes("src")).toBe("https://example.com/thumb.png");
+  });
+
+  it("renders placeholder when no thumbnail url", () => {
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [
+          minimalUser({
+            vrcUserId: "1",
+            displayName: "NoThumb",
+            status: "active",
+          }),
+        ],
+        selected: null,
+        loading: false,
+        emptyMessage: "empty",
+      },
+    });
+
+    expect(wrapper.find(".friend-thumb-placeholder").exists()).toBe(true);
+  });
+
+  it("emits select when a friend card is clicked", async () => {
+    const user = minimalUser({
+      vrcUserId: "1",
+      displayName: "PickMe",
+      status: "active",
+    });
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [user],
+        selected: null,
+        loading: false,
+        emptyMessage: "empty",
+      },
+    });
+
+    await wrapper.find(".friend-card").trigger("click");
+    expect(wrapper.emitted("select")?.[0]).toEqual([user]);
+  });
+
+  it("emits toggleFavorite when star button is clicked", async () => {
+    const user = minimalUser({
+      vrcUserId: "1",
+      displayName: "StarMe",
+      status: "active",
+      isFavorite: true,
+    });
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [user],
+        selected: user,
+        loading: false,
+        emptyMessage: "empty",
+      },
+    });
+
+    await wrapper.find(".btn-favorite").trigger("click");
+    expect(wrapper.emitted("toggleFavorite")?.[0]).toEqual([user]);
+  });
+
+  it("shows empty message only when not loading", () => {
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [],
+        selected: null,
+        loading: false,
+        emptyMessage: "オンラインのフレンドはいません",
+      },
+    });
+
+    expect(wrapper.find(".empty-message").text()).toBe(
+      "オンラインのフレンドはいません",
+    );
+  });
+
+  it("hides empty message while loading", () => {
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [],
+        selected: null,
+        loading: true,
+        emptyMessage: "オンラインのフレンドはいません",
+      },
+    });
+
+    expect(wrapper.find(".empty-message").exists()).toBe(false);
+  });
+
+  it("marks selected friend card as active", () => {
+    const user = minimalUser({
+      vrcUserId: "1",
+      displayName: "ActiveUser",
+      status: "active",
+    });
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [user],
+        selected: user,
+        loading: false,
+        emptyMessage: "empty",
+      },
+    });
+
+    expect(wrapper.find(".friend-card.active").exists()).toBe(true);
+  });
+
+  it("uses different favorite button title for favorite state", () => {
+    const favorite = minimalUser({
+      vrcUserId: "1",
+      displayName: "Fav",
+      status: "active",
+      isFavorite: true,
+    });
+    const notFavorite = minimalUser({
+      vrcUserId: "2",
+      displayName: "Plain",
+      status: "active",
+      isFavorite: false,
+    });
+    const wrapper = mount(FriendsListPanel, {
+      props: {
+        friends: [favorite, notFavorite],
+        selected: null,
+        loading: false,
+        emptyMessage: "empty",
+      },
+    });
+
+    const buttons = wrapper.findAll(".btn-favorite");
+    expect(buttons[0]!.attributes("title")).toBe("お気に入り解除");
+    expect(buttons[1]!.attributes("title")).toBe("お気に入り登録");
+  });
+});

--- a/frontend/src/wails/__tests__/app.spec.ts
+++ b/frontend/src/wails/__tests__/app.spec.ts
@@ -1,0 +1,1043 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import {
+  App,
+  callApp,
+  isWailsRuntime,
+  PRIORITY_OMIT,
+  type ActivityStatsDTO,
+  type AppBindings,
+  type AutomationRuleDTO,
+  type LaunchArgsParsedDTO,
+  type LaunchProfileDTO,
+  type LoginResultDTO,
+  type PathSettingsDTO,
+  type ScreenshotDTO,
+  type ScreenshotSearchDTO,
+  type UserCacheDTO,
+  type UserEncounterDTO,
+  type UserProfileNavigationDTO,
+  type VRChatConfigDTO,
+  type VRChatCurrentUserDTO,
+} from "../app";
+
+type MockAppBindings = {
+  [K in keyof AppBindings]: Mock<AppBindings[K]>;
+};
+
+function setWindowGoApp(mockBindings: MockAppBindings): void {
+  window.go = { main: { App: mockBindings as AppBindings } };
+}
+
+function createMockBindings(): MockAppBindings {
+  return {
+    Greet: vi.fn(),
+    LaunchProfiles: vi.fn(),
+    LaunchVRChat: vi.fn(),
+    LaunchVRChatWithArgs: vi.fn(),
+    ParseLaunchArgsForGUI: vi.fn(),
+    MergeLaunchArgsForGUI: vi.fn(),
+    JoinWorld: vi.fn(),
+    JoinWorldFromScreenshot: vi.fn(),
+    SaveLaunchProfile: vi.fn(),
+    DeleteLaunchProfile: vi.fn(),
+    GetLogRetentionDays: vi.fn(),
+    SetLogRetentionDays: vi.fn(),
+    GetLanguage: vi.fn(),
+    SetLanguage: vi.fn(),
+    GetSystemLocale: vi.fn(),
+    GetPathSettings: vi.fn(),
+    SetPathSettings: vi.fn(),
+    GetSuppressSleepWhileVRChat: vi.fn(),
+    SetSuppressSleepWhileVRChat: vi.fn(),
+    ValidatePath: vi.fn(),
+    ValidateOutputLogPath: vi.fn(),
+    OpenVRChatLogFolder: vi.fn(),
+    OpenFileDialog: vi.fn(),
+    OpenDirectoryDialog: vi.fn(),
+    Screenshots: vi.fn(),
+    SearchScreenshots: vi.fn(),
+    GetScreenshot: vi.fn(),
+    ScreenshotThumbnailDataURL: vi.fn(),
+    OpenScreenshotExternally: vi.fn(),
+    RevealScreenshotInFileManager: vi.fn(),
+    ScanScreenshotDir: vi.fn(),
+    IsGalleryScanning: vi.fn(),
+    ReindexScreenshotDir: vi.fn(),
+    Encounters: vi.fn(),
+    EncountersByVRCUserID: vi.fn(),
+    EncountersByWorldID: vi.fn(),
+    RotateEncounters: vi.fn(),
+    GetActivityStats: vi.fn(),
+    Friends: vi.fn(),
+    ResolveUserProfileNavigation: vi.fn(),
+    SetFavorite: vi.fn(),
+    SetStatus: vi.fn(),
+    SetStatusDescription: vi.fn(),
+    SetStatusAndDescription: vi.fn(),
+    Login: vi.fn(),
+    Logout: vi.fn(),
+    IsLoggedIn: vi.fn(),
+    HasStoredCredential: vi.fn(),
+    GetCredentialBlob: vi.fn(),
+    UnlockVRChatSession: vi.fn(),
+    PersistWrappedCredential: vi.fn(),
+    ClearStoredCredential: vi.fn(),
+    GetVRChatCurrentUser: vi.fn(),
+    RefreshFriends: vi.fn(),
+    ReconcileVRChatSocialCache: vi.fn(),
+    VacuumDb: vi.fn(),
+    ClearEncounters: vi.fn(),
+    ClearScreenshots: vi.fn(),
+    ClearFriendsCache: vi.fn(),
+    ListAutomationRules: vi.fn(),
+    SaveAutomationRule: vi.fn(),
+    DeleteAutomationRule: vi.fn(),
+    ToggleAutomationRule: vi.fn(),
+    VRChatConfigExists: vi.fn(),
+    GetVRChatConfig: vi.fn(),
+    SaveVRChatConfig: vi.fn(),
+    DeleteVRChatConfig: vi.fn(),
+    DefaultVRChatPictureFolder: vi.fn(),
+  };
+}
+
+const sampleLaunchProfile: LaunchProfileDTO = {
+  id: "lp-1",
+  name: "Default",
+  arguments: "-screen-fullscreen 1",
+  isDefault: true,
+};
+
+const sampleLaunchArgs: LaunchArgsParsedDTO = {
+  noVr: true,
+  screenMode: "windowed",
+  screenWidth: 1920,
+  screenHeight: 1080,
+  fps: 90,
+  skipRegistry: false,
+  processPriority: PRIORITY_OMIT,
+  mainThreadPriority: 1,
+  monitor: 1,
+  profile: 0,
+  enableDebugGui: false,
+  enableSDKLogLevels: false,
+  enableUdonDebugLogging: false,
+  midi: "",
+  watchWorlds: false,
+  watchAvatars: false,
+  ignoreTrackers: "",
+  videoDecoding: "hardware",
+  disableAMDStutterWorkaround: false,
+  osc: "",
+  affinity: "",
+  enforceWorldServerChecks: false,
+  custom: "",
+};
+
+const samplePathSettings: PathSettingsDTO = {
+  vrchatPathWindows: "C:\\VRChat\\VRChat.exe",
+  steamPathLinux: "/home/user/.steam",
+  outputLogPath: "C:\\VRChat\\output_log.txt",
+};
+
+const sampleScreenshot: ScreenshotDTO = {
+  id: "ss-1",
+  filePath: "/pics/shot.png",
+  worldId: "wrld_abc",
+  worldName: "Test World",
+};
+
+const sampleEncounter: UserEncounterDTO = {
+  id: "enc-1",
+  vrcUserId: "usr_abc",
+  displayName: "Alice",
+  instanceId: "inst_1",
+  joinedAt: "2025-01-01T00:00:00Z",
+};
+
+const sampleUser: UserCacheDTO = {
+  vrcUserId: "usr_abc",
+  displayName: "Alice",
+  status: "active",
+  isFavorite: false,
+  lastUpdated: "2025-01-01T00:00:00Z",
+};
+
+const sampleNavigation: UserProfileNavigationDTO = {
+  user: sampleUser,
+  openInFriendsView: true,
+};
+
+const sampleLoginResult: LoginResultDTO = {
+  ok: true,
+  plaintextToken: "token",
+};
+
+const sampleCurrentUser: VRChatCurrentUserDTO = {
+  id: "usr_abc",
+  displayName: "Alice",
+  username: "alice",
+  status: "active",
+  statusDescription: "hi",
+  state: "online",
+  currentAvatarThumbnailImageUrl: "https://example.com/a.png",
+  userIcon: "https://example.com/icon.png",
+  profilePicOverrideThumbnail: "",
+};
+
+const sampleActivityStats: ActivityStatsDTO = {
+  dailyPlaySeconds: [{ date: "2025-01-01", seconds: 3600 }],
+  topWorlds: [
+    { worldId: "wrld_abc", worldName: "Test", seconds: 3600, sessions: 1 },
+  ],
+};
+
+const sampleAutomationRule: AutomationRuleDTO = {
+  id: "rule-1",
+  name: "Rule",
+  triggerType: "on_launch",
+  conditionJson: "{}",
+  actionType: "noop",
+  actionPayload: "",
+  isEnabled: true,
+};
+
+const sampleVRChatConfig: VRChatConfigDTO = {
+  cameraResWidth: 1920,
+  cameraResHeight: 1080,
+  screenshotResWidth: 3840,
+  screenshotResHeight: 2160,
+  pictureOutputFolder: "/pics",
+  pictureOutputSplitByDate: true,
+  fpvSteadycamFov: 60,
+  cacheDirectory: "/cache",
+  cacheSize: 30,
+  cacheExpiryDelay: 7,
+  disableRichPresence: false,
+};
+
+describe("app exports", () => {
+  it("exports PRIORITY_OMIT as -999", () => {
+    expect(PRIORITY_OMIT).toBe(-999);
+  });
+});
+
+describe("isWailsRuntime", () => {
+  let mockBindings: MockAppBindings;
+  let prevGo: typeof window.go;
+
+  beforeEach(() => {
+    prevGo = window.go;
+    mockBindings = createMockBindings();
+    setWindowGoApp(mockBindings);
+  });
+
+  afterEach(() => {
+    window.go = prevGo;
+  });
+
+  it("returns true when window.go.main.App exists", () => {
+    expect(isWailsRuntime()).toBe(true);
+  });
+
+  it("returns false when bindings are missing", () => {
+    window.go = undefined;
+    expect(isWailsRuntime()).toBe(false);
+  });
+});
+
+describe("callApp", () => {
+  let mockBindings: MockAppBindings;
+  let prevGo: typeof window.go;
+
+  beforeEach(() => {
+    prevGo = window.go;
+    mockBindings = createMockBindings();
+    setWindowGoApp(mockBindings);
+  });
+
+  afterEach(() => {
+    window.go = prevGo;
+  });
+
+  it("returns fallback when bindings are missing (Vitest skips dev wait)", async () => {
+    window.go = undefined;
+    const out = await callApp(async () => "invoked", "fallback");
+    expect(out).toBe("fallback");
+  });
+
+  it("invokes fn with bindings and returns its result", async () => {
+    mockBindings.Greet.mockResolvedValue("from-go");
+    const out = await callApp((a) => a.Greet("Alice"), "fallback");
+    expect(mockBindings.Greet).toHaveBeenCalledWith("Alice");
+    expect(out).toBe("from-go");
+  });
+
+  it("propagates rejection from the binding", async () => {
+    mockBindings.Greet.mockRejectedValue(new Error("backend failed"));
+    await expect(callApp((a) => a.Greet("Bob"), "fallback")).rejects.toThrow(
+      "backend failed",
+    );
+  });
+});
+
+describe("App bindings", () => {
+  let mockBindings: MockAppBindings;
+  let prevGo: typeof window.go;
+
+  beforeEach(() => {
+    prevGo = window.go;
+    mockBindings = createMockBindings();
+    setWindowGoApp(mockBindings);
+  });
+
+  afterEach(() => {
+    window.go = prevGo;
+  });
+
+  describe("launcher", () => {
+    it("greet delegates to Greet", async () => {
+      mockBindings.Greet.mockResolvedValue("Hello Alice");
+      await expect(App.greet("Alice")).resolves.toBe("Hello Alice");
+      expect(mockBindings.Greet).toHaveBeenCalledWith("Alice");
+    });
+
+    it("launchProfiles delegates to LaunchProfiles", async () => {
+      mockBindings.LaunchProfiles.mockResolvedValue([sampleLaunchProfile]);
+      await expect(App.launchProfiles()).resolves.toEqual([
+        sampleLaunchProfile,
+      ]);
+      expect(mockBindings.LaunchProfiles).toHaveBeenCalled();
+    });
+
+    it("launchVRChat delegates to LaunchVRChat", async () => {
+      mockBindings.LaunchVRChat.mockResolvedValue(undefined);
+      await App.launchVRChat("lp-1");
+      expect(mockBindings.LaunchVRChat).toHaveBeenCalledWith("lp-1");
+    });
+
+    it("launchVRChatWithArgs delegates to LaunchVRChatWithArgs", async () => {
+      mockBindings.LaunchVRChatWithArgs.mockResolvedValue(undefined);
+      await App.launchVRChatWithArgs("-no-vr");
+      expect(mockBindings.LaunchVRChatWithArgs).toHaveBeenCalledWith("-no-vr");
+    });
+
+    it("parseLaunchArgsForGUI delegates to ParseLaunchArgsForGUI", async () => {
+      mockBindings.ParseLaunchArgsForGUI.mockResolvedValue(sampleLaunchArgs);
+      await expect(App.parseLaunchArgsForGUI("-no-vr")).resolves.toEqual(
+        sampleLaunchArgs,
+      );
+      expect(mockBindings.ParseLaunchArgsForGUI).toHaveBeenCalledWith("-no-vr");
+    });
+
+    it("mergeLaunchArgsForGUI delegates to MergeLaunchArgsForGUI", async () => {
+      mockBindings.MergeLaunchArgsForGUI.mockResolvedValue("-no-vr");
+      await expect(App.mergeLaunchArgsForGUI(sampleLaunchArgs)).resolves.toBe(
+        "-no-vr",
+      );
+      expect(mockBindings.MergeLaunchArgsForGUI).toHaveBeenCalledWith(
+        sampleLaunchArgs,
+      );
+    });
+
+    it("joinWorld delegates to JoinWorld", async () => {
+      mockBindings.JoinWorld.mockResolvedValue(undefined);
+      await App.joinWorld("wrld_abc");
+      expect(mockBindings.JoinWorld).toHaveBeenCalledWith("wrld_abc");
+    });
+
+    it("joinWorldFromScreenshot delegates to JoinWorldFromScreenshot", async () => {
+      mockBindings.JoinWorldFromScreenshot.mockResolvedValue(undefined);
+      await App.joinWorldFromScreenshot("ss-1");
+      expect(mockBindings.JoinWorldFromScreenshot).toHaveBeenCalledWith("ss-1");
+    });
+
+    it("saveLaunchProfile delegates to SaveLaunchProfile", async () => {
+      mockBindings.SaveLaunchProfile.mockResolvedValue(undefined);
+      await App.saveLaunchProfile(sampleLaunchProfile);
+      expect(mockBindings.SaveLaunchProfile).toHaveBeenCalledWith(
+        sampleLaunchProfile,
+      );
+    });
+
+    it("deleteLaunchProfile delegates to DeleteLaunchProfile", async () => {
+      mockBindings.DeleteLaunchProfile.mockResolvedValue(undefined);
+      await App.deleteLaunchProfile("lp-1");
+      expect(mockBindings.DeleteLaunchProfile).toHaveBeenCalledWith("lp-1");
+    });
+  });
+
+  describe("settings", () => {
+    it("getLogRetentionDays delegates to GetLogRetentionDays", async () => {
+      mockBindings.GetLogRetentionDays.mockResolvedValue(14);
+      await expect(App.getLogRetentionDays()).resolves.toBe(14);
+    });
+
+    it("setLogRetentionDays delegates to SetLogRetentionDays", async () => {
+      mockBindings.SetLogRetentionDays.mockResolvedValue(undefined);
+      await App.setLogRetentionDays(14);
+      expect(mockBindings.SetLogRetentionDays).toHaveBeenCalledWith(14);
+    });
+
+    it("getLanguage delegates to GetLanguage", async () => {
+      mockBindings.GetLanguage.mockResolvedValue("ja");
+      await expect(App.getLanguage()).resolves.toBe("ja");
+    });
+
+    it("setLanguage delegates to SetLanguage", async () => {
+      mockBindings.SetLanguage.mockResolvedValue(undefined);
+      await App.setLanguage("en");
+      expect(mockBindings.SetLanguage).toHaveBeenCalledWith("en");
+    });
+
+    it("getSystemLocale delegates to GetSystemLocale", async () => {
+      mockBindings.GetSystemLocale.mockResolvedValue("ja-JP");
+      await expect(App.getSystemLocale()).resolves.toBe("ja-JP");
+    });
+
+    it("getPathSettings delegates to GetPathSettings", async () => {
+      mockBindings.GetPathSettings.mockResolvedValue(samplePathSettings);
+      await expect(App.getPathSettings()).resolves.toEqual(samplePathSettings);
+    });
+
+    it("setPathSettings delegates to SetPathSettings", async () => {
+      mockBindings.SetPathSettings.mockResolvedValue(undefined);
+      await App.setPathSettings(samplePathSettings);
+      expect(mockBindings.SetPathSettings).toHaveBeenCalledWith(
+        samplePathSettings,
+      );
+    });
+
+    it("getSuppressSleepWhileVRChat delegates to GetSuppressSleepWhileVRChat", async () => {
+      mockBindings.GetSuppressSleepWhileVRChat.mockResolvedValue(true);
+      await expect(App.getSuppressSleepWhileVRChat()).resolves.toBe(true);
+    });
+
+    it("setSuppressSleepWhileVRChat delegates to SetSuppressSleepWhileVRChat", async () => {
+      mockBindings.SetSuppressSleepWhileVRChat.mockResolvedValue(undefined);
+      await App.setSuppressSleepWhileVRChat(true);
+      expect(mockBindings.SetSuppressSleepWhileVRChat).toHaveBeenCalledWith(
+        true,
+      );
+    });
+
+    it("validatePath delegates to ValidatePath", async () => {
+      mockBindings.ValidatePath.mockResolvedValue(true);
+      await expect(App.validatePath("/path")).resolves.toBe(true);
+      expect(mockBindings.ValidatePath).toHaveBeenCalledWith("/path");
+    });
+
+    it("validateOutputLogPath delegates to ValidateOutputLogPath", async () => {
+      mockBindings.ValidateOutputLogPath.mockResolvedValue(false);
+      await expect(App.validateOutputLogPath("/log.txt")).resolves.toBe(false);
+      expect(mockBindings.ValidateOutputLogPath).toHaveBeenCalledWith(
+        "/log.txt",
+      );
+    });
+
+    it("openVRChatLogFolder delegates to OpenVRChatLogFolder", async () => {
+      mockBindings.OpenVRChatLogFolder.mockResolvedValue(undefined);
+      await App.openVRChatLogFolder();
+      expect(mockBindings.OpenVRChatLogFolder).toHaveBeenCalled();
+    });
+  });
+
+  describe("dialogs", () => {
+    it("openFileDialog returns path when non-empty", async () => {
+      mockBindings.OpenFileDialog.mockResolvedValue("/file.txt");
+      await expect(
+        App.openFileDialog("Pick file", "/dir", "*.txt"),
+      ).resolves.toBe("/file.txt");
+      expect(mockBindings.OpenFileDialog).toHaveBeenCalledWith(
+        "Pick file",
+        "/dir",
+        "*.txt",
+      );
+    });
+
+    it("openFileDialog returns null when binding returns empty string", async () => {
+      mockBindings.OpenFileDialog.mockResolvedValue("");
+      await expect(
+        App.openFileDialog("Pick file", "/dir", "*.txt"),
+      ).resolves.toBeNull();
+    });
+
+    it("openDirectoryDialog returns path when non-empty", async () => {
+      mockBindings.OpenDirectoryDialog.mockResolvedValue("/dir");
+      await expect(App.openDirectoryDialog("Pick dir", "/start")).resolves.toBe(
+        "/dir",
+      );
+      expect(mockBindings.OpenDirectoryDialog).toHaveBeenCalledWith(
+        "Pick dir",
+        "/start",
+      );
+    });
+
+    it("openDirectoryDialog returns null when binding returns empty string", async () => {
+      mockBindings.OpenDirectoryDialog.mockResolvedValue("");
+      await expect(
+        App.openDirectoryDialog("Pick dir", "/start"),
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe("gallery", () => {
+    it("screenshots passes empty string when worldId omitted", async () => {
+      mockBindings.Screenshots.mockResolvedValue([sampleScreenshot]);
+      await expect(App.screenshots()).resolves.toEqual([sampleScreenshot]);
+      expect(mockBindings.Screenshots).toHaveBeenCalledWith("");
+    });
+
+    it("screenshots passes worldId when provided", async () => {
+      mockBindings.Screenshots.mockResolvedValue([]);
+      await App.screenshots("wrld_abc");
+      expect(mockBindings.Screenshots).toHaveBeenCalledWith("wrld_abc");
+    });
+
+    it("searchScreenshots delegates to SearchScreenshots", async () => {
+      const filter: ScreenshotSearchDTO = { worldName: "Test" };
+      mockBindings.SearchScreenshots.mockResolvedValue([sampleScreenshot]);
+      await expect(App.searchScreenshots(filter)).resolves.toEqual([
+        sampleScreenshot,
+      ]);
+      expect(mockBindings.SearchScreenshots).toHaveBeenCalledWith(filter);
+    });
+
+    it("getScreenshot delegates to GetScreenshot", async () => {
+      mockBindings.GetScreenshot.mockResolvedValue(sampleScreenshot);
+      await expect(App.getScreenshot("ss-1")).resolves.toEqual(
+        sampleScreenshot,
+      );
+      expect(mockBindings.GetScreenshot).toHaveBeenCalledWith("ss-1");
+    });
+
+    it("screenshotThumbnailDataURL delegates to ScreenshotThumbnailDataURL", async () => {
+      mockBindings.ScreenshotThumbnailDataURL.mockResolvedValue(
+        "data:image/png",
+      );
+      await expect(App.screenshotThumbnailDataURL("ss-1")).resolves.toBe(
+        "data:image/png",
+      );
+      expect(mockBindings.ScreenshotThumbnailDataURL).toHaveBeenCalledWith(
+        "ss-1",
+      );
+    });
+
+    it("openScreenshotExternally delegates to OpenScreenshotExternally", async () => {
+      mockBindings.OpenScreenshotExternally.mockResolvedValue(undefined);
+      await App.openScreenshotExternally("ss-1");
+      expect(mockBindings.OpenScreenshotExternally).toHaveBeenCalledWith(
+        "ss-1",
+      );
+    });
+
+    it("revealScreenshotInFileManager delegates to RevealScreenshotInFileManager", async () => {
+      mockBindings.RevealScreenshotInFileManager.mockResolvedValue(undefined);
+      await App.revealScreenshotInFileManager("ss-1");
+      expect(mockBindings.RevealScreenshotInFileManager).toHaveBeenCalledWith(
+        "ss-1",
+      );
+    });
+
+    it("scanScreenshotDir delegates to ScanScreenshotDir", async () => {
+      mockBindings.ScanScreenshotDir.mockResolvedValue(5);
+      await expect(App.scanScreenshotDir("/pics")).resolves.toBe(5);
+      expect(mockBindings.ScanScreenshotDir).toHaveBeenCalledWith("/pics");
+    });
+
+    it("isGalleryScanning delegates to IsGalleryScanning", async () => {
+      mockBindings.IsGalleryScanning.mockResolvedValue(true);
+      await expect(App.isGalleryScanning()).resolves.toBe(true);
+    });
+
+    it("reindexScreenshotDir delegates to ReindexScreenshotDir", async () => {
+      mockBindings.ReindexScreenshotDir.mockResolvedValue(3);
+      await expect(App.reindexScreenshotDir("/pics")).resolves.toBe(3);
+      expect(mockBindings.ReindexScreenshotDir).toHaveBeenCalledWith("/pics");
+    });
+
+    it("clearScreenshots delegates to ClearScreenshots", async () => {
+      mockBindings.ClearScreenshots.mockResolvedValue(10);
+      await expect(App.clearScreenshots()).resolves.toBe(10);
+    });
+  });
+
+  describe("encounters & activity", () => {
+    it("encounters delegates to Encounters", async () => {
+      mockBindings.Encounters.mockResolvedValue([sampleEncounter]);
+      await expect(App.encounters()).resolves.toEqual([sampleEncounter]);
+    });
+
+    it("encountersByVRCUserID delegates to EncountersByVRCUserID", async () => {
+      mockBindings.EncountersByVRCUserID.mockResolvedValue([sampleEncounter]);
+      await expect(App.encountersByVRCUserID("usr_abc")).resolves.toEqual([
+        sampleEncounter,
+      ]);
+      expect(mockBindings.EncountersByVRCUserID).toHaveBeenCalledWith(
+        "usr_abc",
+      );
+    });
+
+    it("encountersByWorldID delegates to EncountersByWorldID", async () => {
+      mockBindings.EncountersByWorldID.mockResolvedValue([]);
+      await App.encountersByWorldID("wrld_abc");
+      expect(mockBindings.EncountersByWorldID).toHaveBeenCalledWith("wrld_abc");
+    });
+
+    it("clearEncounters delegates to ClearEncounters", async () => {
+      mockBindings.ClearEncounters.mockResolvedValue(2);
+      await expect(App.clearEncounters()).resolves.toBe(2);
+    });
+
+    it("getActivityStats delegates to GetActivityStats", async () => {
+      mockBindings.GetActivityStats.mockResolvedValue(sampleActivityStats);
+      await expect(
+        App.getActivityStats("2025-01-01", "2025-01-31"),
+      ).resolves.toEqual(sampleActivityStats);
+      expect(mockBindings.GetActivityStats).toHaveBeenCalledWith(
+        "2025-01-01",
+        "2025-01-31",
+      );
+    });
+  });
+
+  describe("friends & social", () => {
+    it("friends delegates to Friends", async () => {
+      mockBindings.Friends.mockResolvedValue([sampleUser]);
+      await expect(App.friends()).resolves.toEqual([sampleUser]);
+    });
+
+    it("resolveUserProfileNavigation delegates to ResolveUserProfileNavigation", async () => {
+      mockBindings.ResolveUserProfileNavigation.mockResolvedValue(
+        sampleNavigation,
+      );
+      await expect(
+        App.resolveUserProfileNavigation("usr_abc"),
+      ).resolves.toEqual(sampleNavigation);
+      expect(mockBindings.ResolveUserProfileNavigation).toHaveBeenCalledWith(
+        "usr_abc",
+      );
+    });
+
+    it("setFavorite delegates to SetFavorite", async () => {
+      mockBindings.SetFavorite.mockResolvedValue(undefined);
+      await App.setFavorite("usr_abc", true);
+      expect(mockBindings.SetFavorite).toHaveBeenCalledWith("usr_abc", true);
+    });
+
+    it("setStatus delegates to SetStatus", async () => {
+      mockBindings.SetStatus.mockResolvedValue(undefined);
+      await App.setStatus("join me");
+      expect(mockBindings.SetStatus).toHaveBeenCalledWith("join me");
+    });
+
+    it("setStatusDescription delegates to SetStatusDescription", async () => {
+      mockBindings.SetStatusDescription.mockResolvedValue(undefined);
+      await App.setStatusDescription("hello");
+      expect(mockBindings.SetStatusDescription).toHaveBeenCalledWith("hello");
+    });
+
+    it("setStatusAndDescription delegates to SetStatusAndDescription", async () => {
+      mockBindings.SetStatusAndDescription.mockResolvedValue(undefined);
+      await App.setStatusAndDescription("active", "busy");
+      expect(mockBindings.SetStatusAndDescription).toHaveBeenCalledWith(
+        "active",
+        "busy",
+      );
+    });
+
+    it("refreshFriends delegates to RefreshFriends", async () => {
+      mockBindings.RefreshFriends.mockResolvedValue(undefined);
+      await App.refreshFriends();
+      expect(mockBindings.RefreshFriends).toHaveBeenCalled();
+    });
+
+    it("reconcileVRChatSocialCache delegates to ReconcileVRChatSocialCache", async () => {
+      mockBindings.ReconcileVRChatSocialCache.mockResolvedValue(undefined);
+      await App.reconcileVRChatSocialCache();
+      expect(mockBindings.ReconcileVRChatSocialCache).toHaveBeenCalled();
+    });
+
+    it("clearFriendsCache delegates to ClearFriendsCache", async () => {
+      mockBindings.ClearFriendsCache.mockResolvedValue(4);
+      await expect(App.clearFriendsCache()).resolves.toBe(4);
+    });
+  });
+
+  describe("auth", () => {
+    it("login passes empty twoFactorCode when omitted", async () => {
+      mockBindings.Login.mockResolvedValue(sampleLoginResult);
+      await expect(App.login("user", "pass")).resolves.toEqual(
+        sampleLoginResult,
+      );
+      expect(mockBindings.Login).toHaveBeenCalledWith("user", "pass", "");
+    });
+
+    it("login passes twoFactorCode when provided", async () => {
+      mockBindings.Login.mockResolvedValue(sampleLoginResult);
+      await App.login("user", "pass", "123456");
+      expect(mockBindings.Login).toHaveBeenCalledWith("user", "pass", "123456");
+    });
+
+    it("logout delegates to Logout", async () => {
+      mockBindings.Logout.mockResolvedValue(undefined);
+      await App.logout();
+      expect(mockBindings.Logout).toHaveBeenCalled();
+    });
+
+    it("isLoggedIn delegates to IsLoggedIn", async () => {
+      mockBindings.IsLoggedIn.mockResolvedValue(true);
+      await expect(App.isLoggedIn()).resolves.toBe(true);
+    });
+
+    it("hasStoredCredential delegates to HasStoredCredential", async () => {
+      mockBindings.HasStoredCredential.mockResolvedValue(true);
+      await expect(App.hasStoredCredential()).resolves.toBe(true);
+    });
+
+    it("getCredentialBlob delegates to GetCredentialBlob", async () => {
+      mockBindings.GetCredentialBlob.mockResolvedValue("blob");
+      await expect(App.getCredentialBlob()).resolves.toBe("blob");
+    });
+
+    it("unlockVRChatSession delegates to UnlockVRChatSession", async () => {
+      mockBindings.UnlockVRChatSession.mockResolvedValue(undefined);
+      await App.unlockVRChatSession("token");
+      expect(mockBindings.UnlockVRChatSession).toHaveBeenCalledWith("token");
+    });
+
+    it("persistWrappedCredential delegates to PersistWrappedCredential", async () => {
+      mockBindings.PersistWrappedCredential.mockResolvedValue(undefined);
+      await App.persistWrappedCredential("wrapped");
+      expect(mockBindings.PersistWrappedCredential).toHaveBeenCalledWith(
+        "wrapped",
+      );
+    });
+
+    it("clearStoredCredential delegates to ClearStoredCredential", async () => {
+      mockBindings.ClearStoredCredential.mockResolvedValue(undefined);
+      await App.clearStoredCredential();
+      expect(mockBindings.ClearStoredCredential).toHaveBeenCalled();
+    });
+
+    it("getVRChatCurrentUser defaults forceRefresh to false", async () => {
+      mockBindings.GetVRChatCurrentUser.mockResolvedValue(sampleCurrentUser);
+      await expect(App.getVRChatCurrentUser()).resolves.toEqual(
+        sampleCurrentUser,
+      );
+      expect(mockBindings.GetVRChatCurrentUser).toHaveBeenCalledWith(false);
+    });
+
+    it("getVRChatCurrentUser passes forceRefresh when provided", async () => {
+      mockBindings.GetVRChatCurrentUser.mockResolvedValue(sampleCurrentUser);
+      await App.getVRChatCurrentUser(true);
+      expect(mockBindings.GetVRChatCurrentUser).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("maintenance", () => {
+    it("vacuumDb delegates to VacuumDb", async () => {
+      mockBindings.VacuumDb.mockResolvedValue(undefined);
+      await App.vacuumDb();
+      expect(mockBindings.VacuumDb).toHaveBeenCalled();
+    });
+  });
+
+  describe("automation", () => {
+    it("listAutomationRules delegates to ListAutomationRules", async () => {
+      mockBindings.ListAutomationRules.mockResolvedValue([
+        sampleAutomationRule,
+      ]);
+      await expect(App.listAutomationRules()).resolves.toEqual([
+        sampleAutomationRule,
+      ]);
+    });
+
+    it("saveAutomationRule delegates to SaveAutomationRule", async () => {
+      mockBindings.SaveAutomationRule.mockResolvedValue(undefined);
+      await App.saveAutomationRule(sampleAutomationRule);
+      expect(mockBindings.SaveAutomationRule).toHaveBeenCalledWith(
+        sampleAutomationRule,
+      );
+    });
+
+    it("deleteAutomationRule delegates to DeleteAutomationRule", async () => {
+      mockBindings.DeleteAutomationRule.mockResolvedValue(undefined);
+      await App.deleteAutomationRule("rule-1");
+      expect(mockBindings.DeleteAutomationRule).toHaveBeenCalledWith("rule-1");
+    });
+
+    it("toggleAutomationRule delegates to ToggleAutomationRule", async () => {
+      mockBindings.ToggleAutomationRule.mockResolvedValue(undefined);
+      await App.toggleAutomationRule("rule-1", false);
+      expect(mockBindings.ToggleAutomationRule).toHaveBeenCalledWith(
+        "rule-1",
+        false,
+      );
+    });
+  });
+
+  describe("vrchat config", () => {
+    it("vrchatConfigExists delegates to VRChatConfigExists", async () => {
+      mockBindings.VRChatConfigExists.mockResolvedValue(true);
+      await expect(App.vrchatConfigExists()).resolves.toBe(true);
+    });
+
+    it("getVRChatConfig delegates to GetVRChatConfig", async () => {
+      mockBindings.GetVRChatConfig.mockResolvedValue(sampleVRChatConfig);
+      await expect(App.getVRChatConfig()).resolves.toEqual(sampleVRChatConfig);
+    });
+
+    it("saveVRChatConfig delegates to SaveVRChatConfig", async () => {
+      mockBindings.SaveVRChatConfig.mockResolvedValue(undefined);
+      await App.saveVRChatConfig(sampleVRChatConfig);
+      expect(mockBindings.SaveVRChatConfig).toHaveBeenCalledWith(
+        sampleVRChatConfig,
+      );
+    });
+
+    it("deleteVRChatConfig delegates to DeleteVRChatConfig", async () => {
+      mockBindings.DeleteVRChatConfig.mockResolvedValue(undefined);
+      await App.deleteVRChatConfig();
+      expect(mockBindings.DeleteVRChatConfig).toHaveBeenCalled();
+    });
+
+    it("defaultVRChatPictureFolder delegates to DefaultVRChatPictureFolder", async () => {
+      mockBindings.DefaultVRChatPictureFolder.mockResolvedValue("/Pictures");
+      await expect(App.defaultVRChatPictureFolder()).resolves.toBe("/Pictures");
+    });
+  });
+});
+
+describe("App fallbacks without bindings", () => {
+  let prevGo: typeof window.go;
+
+  beforeEach(() => {
+    prevGo = window.go;
+    window.go = undefined;
+  });
+
+  afterEach(() => {
+    window.go = prevGo;
+  });
+
+  it("greet returns Hello fallback", async () => {
+    await expect(App.greet("Bob")).resolves.toBe("Hello Bob, Welcome!");
+  });
+
+  it("parseLaunchArgsForGUI returns default DTO with PRIORITY_OMIT", async () => {
+    const dto = await App.parseLaunchArgsForGUI("");
+    expect(dto.processPriority).toBe(PRIORITY_OMIT);
+    expect(dto.mainThreadPriority).toBe(PRIORITY_OMIT);
+    expect(dto.fps).toBe(90);
+  });
+
+  it("login returns unavailable error", async () => {
+    await expect(App.login("u", "p")).resolves.toEqual({
+      ok: false,
+      error: "App not available",
+    });
+  });
+
+  it("openFileDialog returns null without bindings", async () => {
+    await expect(App.openFileDialog("t", "d", "*")).resolves.toBeNull();
+  });
+
+  it("getLogRetentionDays returns 30", async () => {
+    await expect(App.getLogRetentionDays()).resolves.toBe(30);
+  });
+});
+
+describe("callApp DEV binding race recovery", () => {
+  let prevGo: typeof window.go;
+  const injectedScripts: HTMLScriptElement[] = [];
+  let origCreateElement: typeof document.createElement;
+
+  function removeAllWailsScripts() {
+    for (const el of document.querySelectorAll('head script[src*="wails/"]')) {
+      el.remove();
+    }
+  }
+
+  function injectWailsScript(src = "/wails/runtime.js") {
+    const script = document.createElement("script");
+    script.setAttribute("src", src);
+    document.head.appendChild(script);
+    injectedScripts.push(script);
+    return script;
+  }
+
+  beforeEach(() => {
+    prevGo = window.go;
+    removeAllWailsScripts();
+    injectedScripts.length = 0;
+    vi.resetModules();
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("MODE", "development");
+    origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag, options) => {
+      const el = origCreateElement(tag, options);
+      if (String(tag).toLowerCase() === "script") {
+        queueMicrotask(() => {
+          el.dispatchEvent(new Event("load"));
+        });
+      }
+      return el;
+    });
+  });
+
+  afterEach(() => {
+    window.go = prevGo;
+    for (const script of injectedScripts.splice(0)) {
+      script.remove();
+    }
+    removeAllWailsScripts();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("waits for bindings via requestAnimationFrame when scripts expect Wails", async () => {
+    injectWailsScript();
+    window.go = undefined;
+
+    const mockBindings = createMockBindings();
+    mockBindings.Greet.mockResolvedValue("from-wait");
+
+    let frames = 0;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      frames += 1;
+      if (frames === 1) {
+        setWindowGoApp(mockBindings);
+      }
+      cb(0);
+      return frames;
+    });
+
+    const { callApp: freshCallApp } = await import("../app");
+    await expect(
+      freshCallApp((a) => a.Greet("Wait"), "fallback"),
+    ).resolves.toBe("from-wait");
+  });
+
+  it("returns fallback after exhausting rAF wait without bindings", async () => {
+    injectWailsScript();
+    window.go = undefined;
+
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 1;
+    });
+
+    const { callApp: freshCallApp } = await import("../app");
+    await expect(freshCallApp(async () => "never", "fallback")).resolves.toBe(
+      "fallback",
+    );
+  });
+
+  it("reloads wails scripts once then falls back when bindings never appear", async () => {
+    injectWailsScript("/wails/ipc.js");
+    window.go = undefined;
+
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 1;
+    });
+
+    const { callApp: freshCallApp } = await import("../app");
+    await expect(freshCallApp(async () => "never", "fallback")).resolves.toBe(
+      "fallback",
+    );
+    expect(
+      document.querySelector('script[src*="wails/ipc.js?wailsRetry="]'),
+    ).not.toBeNull();
+  });
+
+  it("falls back when dev script reload fails", async () => {
+    injectWailsScript("/wails/ipc.js");
+    window.go = undefined;
+
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 1;
+    });
+
+    vi.mocked(document.createElement).mockImplementation((tag, options) => {
+      const el = origCreateElement(tag, options);
+      if (String(tag).toLowerCase() === "script") {
+        queueMicrotask(() => {
+          el.dispatchEvent(new Event("error"));
+        });
+      }
+      return el;
+    });
+
+    const { callApp: freshCallApp } = await import("../app");
+    await expect(freshCallApp(async () => "never", "fallback")).resolves.toBe(
+      "fallback",
+    );
+  });
+
+  it("skips dev wait when head has no wails script tags", async () => {
+    window.go = undefined;
+    const raf = vi.spyOn(window, "requestAnimationFrame");
+
+    const { callApp: freshCallApp } = await import("../app");
+    await expect(freshCallApp(async () => "never", "fallback")).resolves.toBe(
+      "fallback",
+    );
+    expect(raf).not.toHaveBeenCalled();
+  });
+
+  it("treats page as not expecting Wails when document is unavailable", async () => {
+    window.go = undefined;
+    const doc = globalThis.document;
+    // @ts-expect-error test-only: exercise pageExpectsWailsBindings guard
+    delete globalThis.document;
+
+    try {
+      const { callApp: freshCallApp } = await import("../app");
+      await expect(freshCallApp(async () => "never", "fallback")).resolves.toBe(
+        "fallback",
+      );
+    } finally {
+      globalThis.document = doc;
+    }
+  });
+
+  it("rejects reload when runtime script fails to load", async () => {
+    injectWailsScript("/wails/ipc.js");
+    window.go = undefined;
+
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 1;
+    });
+
+    vi.mocked(document.createElement).mockImplementation((tag, options) => {
+      const el = origCreateElement(tag, options);
+      if (String(tag).toLowerCase() === "script") {
+        queueMicrotask(() => {
+          const src = el.getAttribute("src") ?? "";
+          el.dispatchEvent(
+            new Event(src.includes("runtime.js") ? "error" : "load"),
+          );
+        });
+      }
+      return el;
+    });
+
+    const { callApp: freshCallApp } = await import("../app");
+    await expect(freshCallApp(async () => "never", "fallback")).resolves.toBe(
+      "fallback",
+    );
+  });
+});

--- a/frontend/src/wails/app.ts
+++ b/frontend/src/wails/app.ts
@@ -191,7 +191,7 @@ export interface VRChatConfigDTO {
   disableRichPresence: boolean | null;
 }
 
-interface AppBindings {
+export interface AppBindings {
   Greet(name: string): Promise<string>;
   LaunchProfiles(): Promise<LaunchProfileDTO[]>;
   LaunchVRChat(profileID: string): Promise<void>;


### PR DESCRIPTION
## Summary

- フロントエンドの Vitest カバレッジを **71.5% → 92.99%**（Lines **94.33%**）に引き上げ
- `wails/app.ts` に包括的な binding テストを追加（98.95%）
- SettingsView / ConfigView / LauncherView など主要画面の振る舞いテストを拡充（各 90% 超）
- テスト用に `AppBindings` を export（型安全なモック用）

### 主な追加・拡張

| ファイル | 内容 |
|---------|------|
| `src/wails/__tests__/app.spec.ts` | `App.*` 全メソッド + `callApp` / DEV パス（新規 90 テスト） |
| `SettingsView.spec.ts` | パス設定・DB メンテ・ログイン周り |
| `ConfigView.spec.ts` | 保存・削除・参照ダイアログ |
| `LauncherView.spec.ts` / `useSessionUnlock.spec.ts` | 起動・セッションアンロック |
| `i18n/index.spec.ts` / `FriendsListPanel.spec.ts` | 新規 |

テスト数: **195 → 417**

## Test plan

- [x] `make fmt`
- [x] `make test-front`（417 tests PASS）
- [x] `make lint-front`（ESLint + vue-tsc）
- [x] `pnpm run test:coverage` — Statements **92.99%**, Lines **94.33%**


Made with [Cursor](https://cursor.com)