### PR TITLE
feat(gallery): scope list to picture folder and hide missing files (#99)

### DIFF
--- a/app.go
+++ b/app.go
@@ -691,23 +691,24 @@ func (a *App) OpenDirectoryDialog(title, defaultDir string) (string, error) {
 
 // --- Media bindings ---
 
-// Screenshots returns screenshots (optional worldId filter).
+// Screenshots returns screenshots (optional worldId filter) within the current picture folder.
 func (a *App) Screenshots(worldId string) ([]ScreenshotDTO, error) {
 	filter := &media.ScreenshotFilter{}
 	if worldId != "" {
 		filter.WorldID = worldId
 	}
-	list, err := a.media.ListScreenshots(a.ctx, filter)
-	if err != nil {
-		return nil, err
-	}
-	return toScreenshotDTOs(list), nil
+	return a.listGalleryScreenshotDTOs(filter)
 }
 
 // SearchScreenshots returns screenshots matching the filter (worldId, worldName, dateFrom, dateTo).
 func (a *App) SearchScreenshots(filter ScreenshotSearchDTO) ([]ScreenshotDTO, error) {
 	f := toScreenshotFilter(filter)
-	list, err := a.media.ListScreenshots(a.ctx, f)
+	return a.listGalleryScreenshotDTOs(f)
+}
+
+func (a *App) listGalleryScreenshotDTOs(filter *media.ScreenshotFilter) ([]ScreenshotDTO, error) {
+	root := a.resolveVRChatPictureWatchRoot()
+	list, err := a.media.ListScreenshotsInGalleryScope(a.ctx, root, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/media/gallery_scope.go
+++ b/internal/domain/media/gallery_scope.go
@@ -1,0 +1,20 @@
+package media
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// PictureFolderPathPrefix returns the FilePathPrefix value for listing screenshots
+// under pictureFolderRoot without matching sibling paths (e.g. VRChat vs VRChat_old).
+func PictureFolderPathPrefix(pictureFolderRoot string) string {
+	pictureFolderRoot = strings.TrimSpace(pictureFolderRoot)
+	if pictureFolderRoot == "" {
+		return ""
+	}
+	pictureFolderRoot = filepath.Clean(pictureFolderRoot)
+	if pictureFolderRoot == "." {
+		return ""
+	}
+	return pictureFolderRoot + string(filepath.Separator)
+}

--- a/internal/domain/media/gallery_scope_test.go
+++ b/internal/domain/media/gallery_scope_test.go
@@ -1,0 +1,33 @@
+package media
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPictureFolderPathPrefix(t *testing.T) {
+	root := filepath.Join("C:", "Pictures", "VRChat")
+	got := PictureFolderPathPrefix(root)
+	want := root + string(filepath.Separator)
+	if got != want {
+		t.Fatalf("PictureFolderPathPrefix() = %q, want %q", got, want)
+	}
+
+	if PictureFolderPathPrefix("") != "" {
+		t.Fatal("empty root should yield empty prefix")
+	}
+}
+
+func TestPictureFolderPathPrefix_doesNotMatchSiblingFolderNames(t *testing.T) {
+	root := filepath.Join("C:", "Pictures", "VRChat")
+	prefix := filepath.ToSlash(PictureFolderPathPrefix(root))
+	sibling := filepath.ToSlash(filepath.Join("C:", "Pictures", "VRChat_old", "shot.png"))
+	if strings.HasPrefix(sibling, prefix) {
+		t.Fatalf("prefix %q should not match sibling path %q", prefix, sibling)
+	}
+	inScope := filepath.ToSlash(filepath.Join(root, "shot.png"))
+	if !strings.HasPrefix(inScope, prefix) {
+		t.Fatalf("prefix %q should match in-scope path %q", prefix, inScope)
+	}
+}

--- a/internal/infrastructure/sqlite/media_repo_test.go
+++ b/internal/infrastructure/sqlite/media_repo_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -197,5 +198,38 @@ func TestScreenshotRepository_GetByID_GetByFilePath_ListFilters(t *testing.T) {
 	missThumb, err := repo.GetThumbnail(ctx, "s_b")
 	if err != nil || missThumb != nil {
 		t.Fatalf("GetThumbnail missing: %#v err=%v", missThumb, err)
+	}
+}
+
+func TestScreenshotRepository_List_FilePathPrefix_excludesSiblingFolder(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if schemaErr := applySchema(db); schemaErr != nil {
+		t.Fatal(schemaErr)
+	}
+	ctx := context.Background()
+	repo := NewScreenshotRepository(db)
+
+	inRoot := filepath.Join(dir, "VRChat", "in.png")
+	outRoot := filepath.Join(dir, "VRChat_old", "out.png")
+	for _, p := range []string{inRoot, outRoot} {
+		if mkdirErr := os.MkdirAll(filepath.Dir(p), 0o755); mkdirErr != nil {
+			t.Fatal(mkdirErr)
+		}
+	}
+	_ = repo.Save(ctx, &media.Screenshot{ID: "in", FilePath: inRoot})
+	_ = repo.Save(ctx, &media.Screenshot{ID: "out", FilePath: outRoot})
+
+	prefix := media.PictureFolderPathPrefix(filepath.Join(dir, "VRChat"))
+	list, err := repo.List(ctx, &media.ScreenshotFilter{FilePathPrefix: prefix})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].ID != "in" {
+		t.Fatalf("List with prefix %q: %#v", prefix, list)
 	}
 }

--- a/internal/usecase/media_gallery_list.go
+++ b/internal/usecase/media_gallery_list.go
@@ -1,0 +1,57 @@
+package usecase
+
+import (
+	"context"
+	"os"
+
+	"vrchat-tweaker/internal/domain/media"
+)
+
+// ListScreenshotsInGalleryScope returns screenshots for Gallery listing: limited to
+// pictureFolderRoot and excluding rows whose files are missing on disk.
+// When pictureFolderRoot is empty, returns an empty list.
+func (uc *MediaUseCase) ListScreenshotsInGalleryScope(ctx context.Context, pictureFolderRoot string, filter *media.ScreenshotFilter) ([]*media.Screenshot, error) {
+	prefix := media.PictureFolderPathPrefix(pictureFolderRoot)
+	if prefix == "" {
+		return nil, nil
+	}
+	scoped := cloneScreenshotFilter(filter)
+	scoped.FilePathPrefix = prefix
+	list, err := uc.repo.List(ctx, scoped)
+	if err != nil {
+		return nil, err
+	}
+	return filterScreenshotsWithExistingFiles(list), nil
+}
+
+func cloneScreenshotFilter(f *media.ScreenshotFilter) *media.ScreenshotFilter {
+	if f == nil {
+		return &media.ScreenshotFilter{}
+	}
+	cp := *f
+	return &cp
+}
+
+func filterScreenshotsWithExistingFiles(list []*media.Screenshot) []*media.Screenshot {
+	if len(list) == 0 {
+		return list
+	}
+	out := make([]*media.Screenshot, 0, len(list))
+	for _, s := range list {
+		if s == nil {
+			continue
+		}
+		if screenshotFileExists(s.FilePath) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func screenshotFileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}

--- a/internal/usecase/media_usecase_test.go
+++ b/internal/usecase/media_usecase_test.go
@@ -77,9 +77,16 @@ func (m *mockScreenshotRepo) List(ctx context.Context, filter *media.ScreenshotF
 }
 
 func hasPathPrefix(path, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
 	normPath := filepath.ToSlash(path)
 	normPrefix := filepath.ToSlash(prefix)
-	return normPath == normPrefix || strings.HasPrefix(normPath, normPrefix)
+	likePrefix := normPrefix
+	if !strings.HasSuffix(likePrefix, "/") {
+		likePrefix += "/"
+	}
+	return normPath == strings.TrimSuffix(normPrefix, "/") || strings.HasPrefix(normPath, likePrefix)
 }
 
 func (m *mockScreenshotRepo) GetByID(ctx context.Context, id string) (*media.Screenshot, error) {
@@ -641,6 +648,88 @@ func TestMediaUseCase_ScanDirectory_ContextCancelDuringImport(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ScanDirectory: err = %v, want context.Canceled", err)
+	}
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_emptyRoot(t *testing.T) {
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "s1", FilePath: "/any.png"})
+	uc := NewMediaUseCase(repo, nil, nil, nil)
+
+	list, err := uc.ListScreenshotsInGalleryScope(context.Background(), "", nil)
+	if err != nil {
+		t.Fatalf("ListScreenshotsInGalleryScope: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("want empty list, got %d", len(list))
+	}
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_excludesOutOfScopePaths(t *testing.T) {
+	base := t.TempDir()
+	inScope := filepath.Join(base, "shot.png")
+	if err := os.WriteFile(inScope, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outScope := filepath.Join(filepath.Dir(base), "other-root", "other.png")
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "in", FilePath: inScope})
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "out", FilePath: outScope})
+
+	uc := NewMediaUseCase(repo, nil, nil, nil)
+	list, err := uc.ListScreenshotsInGalleryScope(context.Background(), base, nil)
+	if err != nil {
+		t.Fatalf("ListScreenshotsInGalleryScope: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "in" {
+		t.Fatalf("list = %#v, want only in-scope row", list)
+	}
+	if repo.listFilter == nil || repo.listFilter.FilePathPrefix != media.PictureFolderPathPrefix(base) {
+		t.Fatalf("FilePathPrefix = %q, want %q", repo.listFilter.FilePathPrefix, media.PictureFolderPathPrefix(base))
+	}
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_excludesMissingFiles(t *testing.T) {
+	base := t.TempDir()
+	existing := filepath.Join(base, "here.png")
+	if err := os.WriteFile(existing, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(base, "gone.png")
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "here", FilePath: existing})
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "gone", FilePath: missing})
+
+	uc := NewMediaUseCase(repo, nil, nil, nil)
+	list, err := uc.ListScreenshotsInGalleryScope(context.Background(), base, nil)
+	if err != nil {
+		t.Fatalf("ListScreenshotsInGalleryScope: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "here" {
+		t.Fatalf("list = %#v, want only existing file", list)
+	}
+	if repo.screenshots["gone"] == nil {
+		t.Fatal("missing-file row should remain in DB")
+	}
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_preservesWorldFilter(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "a.png")
+	_ = os.WriteFile(path, []byte("x"), 0o644)
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "a", FilePath: path, WorldID: "wrld_a"})
+	uc := NewMediaUseCase(repo, nil, nil, nil)
+
+	_, err := uc.ListScreenshotsInGalleryScope(context.Background(), base, &media.ScreenshotFilter{WorldID: "wrld_a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.listFilter == nil || repo.listFilter.WorldID != "wrld_a" {
+		t.Fatalf("WorldID filter not passed: %#v", repo.listFilter)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Gallery 一覧 API（`Screenshots` / `SearchScreenshots`）を現行 Picture folder 配下に限定
- ディスク上に存在しない Screenshot 行を一覧から除外（DB 行は削除しない）
- `GetScreenshot` 等の単体取得は従来どおり

## Test plan
- [x] `make fmt` / `make test` / `make lint`
- [ ] 実機で Picture folder 外のインデックス行がギャラリーに出ないこと
- [ ] ファイル削除後に「更新」で行が消えること

Closes #99

Made with [Cursor](https://cursor.com)