### PR TITLE
feat(gallery): picture folder sync with selective reindex (#101)

### DIFF
--- a/app.go
+++ b/app.go
@@ -810,7 +810,7 @@ func (e *scanProgressEmitter) flush() {
 	e.hasPending = false
 }
 
-// ScanScreenshotDir scans a directory for screenshots.
+// ScanScreenshotDir synchronizes a picture folder (ingest new files + selective reindex).
 func (a *App) ScanScreenshotDir(path string) (int, error) {
 	a.galleryScanMu.Lock()
 	for a.galleryScanCancel != nil {
@@ -848,7 +848,7 @@ func (a *App) ScanScreenshotDir(path string) (int, error) {
 		runtime.EventsEmit(a.ctx, galleryScanDoneEvent, dto)
 	}()
 
-	count, err = a.media.ScanDirectory(scanCtx, path, em.emit)
+	count, err = a.media.SyncPictureFolder(scanCtx, path, em.emit)
 	return count, err
 }
 

--- a/frontend/scripts/write-locale-json.mjs
+++ b/frontend/scripts/write-locale-json.mjs
@@ -155,8 +155,8 @@ const en = {
   gallery: {
     title: "Gallery",
     searchPlaceholder: "Search by World ID (auto / Enter)",
-    scanFolder: "Scan folder",
-    scanning: "Scanning…",
+    scanFolder: "Sync folder",
+    scanning: "Syncing…",
     detail: "Details",
     fileName: "File name",
     fileSize: "File size",
@@ -542,8 +542,8 @@ const ja = deepMerge(en, {
   gallery: {
     title: "ギャラリー",
     searchPlaceholder: "World ID で検索（入力で自動検索 / Enter）",
-    scanFolder: "Scan Folder",
-    scanning: "スキャン中…",
+    scanFolder: "フォルダを同期",
+    scanning: "同期中…",
     detail: "詳細",
     fileName: "ファイル名",
     fileSize: "ファイルサイズ",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -122,8 +122,8 @@
   "gallery": {
     "title": "Gallery",
     "searchPlaceholder": "Search by World ID (auto / Enter)",
-    "scanFolder": "Scan folder",
-    "scanning": "Scanning…",
+    "scanFolder": "Sync folder",
+    "scanning": "Syncing…",
     "detail": "Details",
     "fileName": "File name",
     "fileSize": "File size",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -122,8 +122,8 @@
   "gallery": {
     "title": "ギャラリー",
     "searchPlaceholder": "World ID で検索（入力で自動検索 / Enter）",
-    "scanFolder": "Scan Folder",
-    "scanning": "スキャン中…",
+    "scanFolder": "フォルダを同期",
+    "scanning": "同期中…",
     "detail": "詳細",
     "fileName": "ファイル名",
     "fileSize": "ファイルサイズ",

--- a/internal/usecase/media_picture_sync.go
+++ b/internal/usecase/media_picture_sync.go
@@ -1,0 +1,189 @@
+package usecase
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"vrchat-tweaker/internal/domain/media"
+)
+
+// SyncPictureFolder ingests new screenshots under basePath and selectively reindexes
+// existing rows (metadata when world_id is empty or the file changed; thumbnails when stale).
+// Returns the number of newly ingested plus updated rows.
+func (uc *MediaUseCase) SyncPictureFolder(ctx context.Context, basePath string, onProgress func(ScanProgress)) (int, error) {
+	ingested, created, err := uc.ingestImagePathsInDir(ctx, basePath, onProgress)
+	if err != nil {
+		return ingested, err
+	}
+	updated, err := uc.reindexScreenshotsUnderPath(ctx, basePath, created, nil)
+	if err != nil {
+		return ingested, err
+	}
+	return ingested + updated, nil
+}
+
+// ingestImagePathsInDir walks basePath for images and ingests new paths only.
+func (uc *MediaUseCase) ingestImagePathsInDir(ctx context.Context, basePath string, onProgress func(ScanProgress)) (int, map[string]struct{}, error) {
+	basePath = filepath.Clean(basePath)
+	created := make(map[string]struct{})
+	info, err := os.Stat(basePath)
+	if err != nil {
+		return 0, created, err
+	}
+	if !info.IsDir() {
+		return 0, created, nil
+	}
+
+	var paths []string
+	err = filepath.Walk(basePath, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".png", ".jpg", ".jpeg":
+		default:
+			return nil
+		}
+		paths = append(paths, path)
+		if onProgress != nil && len(paths)%scanListingProgressEvery == 0 {
+			onProgress(ScanProgress{Phase: ScanPhaseListing, Current: len(paths), Total: 0})
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, created, err
+	}
+
+	if onProgress != nil {
+		onProgress(ScanProgress{Phase: ScanPhaseListing, Current: len(paths), Total: 0})
+		onProgress(ScanProgress{Phase: ScanPhaseImporting, Current: 0, Total: len(paths), Item: ""})
+	}
+
+	count := 0
+	for i, path := range paths {
+		if ctx.Err() != nil {
+			return count, created, ctx.Err()
+		}
+		_, wasCreated, ingestErr := uc.IngestScreenshotFile(ctx, path)
+		if ingestErr != nil {
+			// Same as ScanDirectory: skip file on ingest error.
+		} else if wasCreated {
+			count++
+			created[filepath.Clean(path)] = struct{}{}
+		}
+		if onProgress != nil {
+			onProgress(ScanProgress{
+				Phase:   ScanPhaseImporting,
+				Current: i + 1,
+				Total:   len(paths),
+				Item:    filepath.Base(path),
+			})
+		}
+	}
+	return count, created, nil
+}
+
+// reindexScreenshotsUnderPath updates existing screenshots under basePath.
+// Paths in skipIngested are skipped (freshly ingested in the same sync).
+func (uc *MediaUseCase) reindexScreenshotsUnderPath(ctx context.Context, basePath string, skipIngested map[string]struct{}, onProgress func(ScanProgress)) (int, error) {
+	basePath = filepath.Clean(basePath)
+	prefix := media.PictureFolderPathPrefix(basePath)
+	filter := &media.ScreenshotFilter{FilePathPrefix: prefix}
+	list, err := uc.repo.List(ctx, filter)
+	if err != nil {
+		return 0, err
+	}
+	updated := 0
+	for _, s := range list {
+		if ctx.Err() != nil {
+			return updated, ctx.Err()
+		}
+		if skipIngested != nil {
+			if _, skip := skipIngested[filepath.Clean(s.FilePath)]; skip {
+				continue
+			}
+		}
+		didUpdate, err := uc.reindexScreenshotFile(ctx, s)
+		if err != nil {
+			return updated, err
+		}
+		if didUpdate {
+			updated++
+		}
+	}
+	return updated, nil
+}
+
+func (uc *MediaUseCase) reindexScreenshotFile(ctx context.Context, s *media.Screenshot) (bool, error) {
+	info, err := os.Stat(s.FilePath)
+	if err != nil {
+		return false, nil
+	}
+	size := info.Size()
+	modUnix := info.ModTime().Unix()
+
+	thumb, errThumb := uc.repo.GetThumbnail(ctx, s.ID)
+	if errThumb != nil {
+		return false, errThumb
+	}
+	thumbnailStale := thumb == nil
+	if thumb != nil && (thumb.SourceSize != size || thumb.SourceModUnix != modUnix) {
+		if err := uc.repo.DeleteThumbnail(ctx, s.ID); err != nil {
+			return false, err
+		}
+		thumbnailStale = true
+	}
+
+	sizeChanged := s.FileSizeBytes == nil || *s.FileSizeBytes != size
+	needsMetaExtract := s.WorldID == "" || sizeChanged || thumbnailStale
+
+	metaChanged := false
+	var meta media.ScreenshotMetadata
+	if needsMetaExtract && uc.extractor != nil {
+		var exErr error
+		meta, exErr = uc.extractor.Extract(s.FilePath)
+		if exErr != nil {
+			meta = media.ScreenshotMetadata{}
+		}
+		metaChanged = meta.WorldID != s.WorldID || meta.AuthorVRCUserID != s.AuthorVRCUserID
+		if meta.TakenAt != nil && (s.TakenAt == nil || !meta.TakenAt.Equal(*s.TakenAt)) {
+			metaChanged = true
+		}
+		if metaChanged {
+			s.WorldID = meta.WorldID
+			s.AuthorVRCUserID = meta.AuthorVRCUserID
+			if meta.TakenAt != nil {
+				s.TakenAt = meta.TakenAt
+			}
+			s.WorldName = meta.WorldDisplayName
+		}
+	}
+
+	if !sizeChanged && !metaChanged && !thumbnailStale {
+		return false, nil
+	}
+	fsz := size
+	s.FileSizeBytes = &fsz
+	if err := uc.repo.Save(ctx, s); err != nil {
+		return false, nil
+	}
+	if metaChanged {
+		at := info.ModTime()
+		if s.TakenAt != nil {
+			at = *s.TakenAt
+		}
+		uc.upsertWorldInfo(ctx, meta.WorldID, meta.WorldDisplayName, at)
+		uc.upsertAuthorFromScreenshot(ctx, meta.AuthorVRCUserID, meta.AuthorDisplayName, at)
+	}
+	_ = uc.EnsureScreenshotThumbnail(ctx, s.ID)
+	return true, nil
+}

--- a/internal/usecase/media_usecase.go
+++ b/internal/usecase/media_usecase.go
@@ -143,68 +143,8 @@ func (uc *MediaUseCase) IngestScreenshotFile(ctx context.Context, path string) (
 // ScanDirectory scans a directory for screenshots and indexes them.
 // onProgress is optional; when non-nil it receives listing/importing snapshots.
 func (uc *MediaUseCase) ScanDirectory(ctx context.Context, basePath string, onProgress func(ScanProgress)) (int, error) {
-	basePath = filepath.Clean(basePath)
-	info, err := os.Stat(basePath)
-	if err != nil {
-		return 0, err
-	}
-	if !info.IsDir() {
-		return 0, nil
-	}
-
-	var paths []string
-	err = filepath.Walk(basePath, func(path string, fi os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return nil
-		}
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		if fi.IsDir() {
-			return nil
-		}
-		ext := strings.ToLower(filepath.Ext(path))
-		switch ext {
-		case ".png", ".jpg", ".jpeg":
-		default:
-			return nil
-		}
-		paths = append(paths, path)
-		if onProgress != nil && len(paths)%scanListingProgressEvery == 0 {
-			onProgress(ScanProgress{Phase: ScanPhaseListing, Current: len(paths), Total: 0})
-		}
-		return nil
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	if onProgress != nil {
-		onProgress(ScanProgress{Phase: ScanPhaseListing, Current: len(paths), Total: 0})
-		onProgress(ScanProgress{Phase: ScanPhaseImporting, Current: 0, Total: len(paths), Item: ""})
-	}
-
-	count := 0
-	for i, path := range paths {
-		if ctx.Err() != nil {
-			return count, ctx.Err()
-		}
-		_, created, ingestErr := uc.IngestScreenshotFile(ctx, path)
-		if ingestErr != nil {
-			// Same as previous Walk behavior: skip file on ingest error.
-		} else if created {
-			count++
-		}
-		if onProgress != nil {
-			onProgress(ScanProgress{
-				Phase:   ScanPhaseImporting,
-				Current: i + 1,
-				Total:   len(paths),
-				Item:    filepath.Base(path),
-			})
-		}
-	}
-	return count, nil
+	count, _, err := uc.ingestImagePathsInDir(ctx, basePath, onProgress)
+	return count, err
 }
 
 // IngestUnderPictureRootSince walks basePath for image files whose ModTime is strictly after since
@@ -262,76 +202,7 @@ func (uc *MediaUseCase) DeleteScreenshot(ctx context.Context, id string) error {
 // ReindexScreenshots re-extracts metadata for existing screenshots under basePath and updates them.
 // Returns the number of updated records.
 func (uc *MediaUseCase) ReindexScreenshots(ctx context.Context, basePath string) (int, error) {
-	basePath = filepath.Clean(basePath)
-	prefix := basePath + string(filepath.Separator)
-	filter := &media.ScreenshotFilter{FilePathPrefix: prefix}
-	list, err := uc.repo.List(ctx, filter)
-	if err != nil {
-		return 0, err
-	}
-	updated := 0
-	for _, s := range list {
-		info, err := os.Stat(s.FilePath)
-		if err != nil {
-			continue
-		}
-		size := info.Size()
-		modUnix := info.ModTime().Unix()
-
-		thumb, errThumb := uc.repo.GetThumbnail(ctx, s.ID)
-		if errThumb != nil {
-			return 0, errThumb
-		}
-		thumbnailStale := thumb == nil
-		if thumb != nil && (thumb.SourceSize != size || thumb.SourceModUnix != modUnix) {
-			if err := uc.repo.DeleteThumbnail(ctx, s.ID); err != nil {
-				return 0, err
-			}
-			thumbnailStale = true
-		}
-
-		sizeChanged := s.FileSizeBytes == nil || *s.FileSizeBytes != size
-		metaChanged := false
-		var meta media.ScreenshotMetadata
-		if uc.extractor != nil {
-			var exErr error
-			meta, exErr = uc.extractor.Extract(s.FilePath)
-			if exErr != nil {
-				meta = media.ScreenshotMetadata{}
-			}
-			metaChanged = meta.WorldID != s.WorldID || meta.AuthorVRCUserID != s.AuthorVRCUserID
-			if meta.TakenAt != nil && (s.TakenAt == nil || !meta.TakenAt.Equal(*s.TakenAt)) {
-				metaChanged = true
-			}
-			if metaChanged {
-				s.WorldID = meta.WorldID
-				s.AuthorVRCUserID = meta.AuthorVRCUserID
-				if meta.TakenAt != nil {
-					s.TakenAt = meta.TakenAt
-				}
-				s.WorldName = meta.WorldDisplayName
-			}
-		}
-		if !sizeChanged && !metaChanged && !thumbnailStale {
-			continue
-		}
-		fsz := size
-		s.FileSizeBytes = &fsz
-		if err := uc.repo.Save(ctx, s); err != nil {
-			continue
-		}
-		if metaChanged {
-			at := info.ModTime()
-			if s.TakenAt != nil {
-				at = *s.TakenAt
-			}
-			uc.upsertWorldInfo(ctx, meta.WorldID, meta.WorldDisplayName, at)
-			uc.upsertAuthorFromScreenshot(ctx, meta.AuthorVRCUserID, meta.AuthorDisplayName, at)
-		}
-		_ = uc.EnsureScreenshotThumbnail(ctx, s.ID)
-		updated++
-	}
-	return updated, nil
+	return uc.reindexScreenshotsUnderPath(ctx, basePath, nil, nil)
 }
 
 func timePtr(t time.Time) *time.Time {

--- a/internal/usecase/media_usecase_test.go
+++ b/internal/usecase/media_usecase_test.go
@@ -137,6 +137,19 @@ func (m *mockMetadataExtractor) Extract(path string) (media.ScreenshotMetadata, 
 	}, nil
 }
 
+type countingMetadataExtractor struct {
+	inner   *mockMetadataExtractor
+	extract []string
+}
+
+func (c *countingMetadataExtractor) Extract(path string) (media.ScreenshotMetadata, error) {
+	c.extract = append(c.extract, path)
+	if c.inner != nil {
+		return c.inner.Extract(path)
+	}
+	return media.ScreenshotMetadata{}, nil
+}
+
 // mockWorldInfoRepo records WorldInfoRepository calls for tests.
 type mockWorldInfoRepo struct {
 	upsertDisplayCalls []struct {
@@ -890,5 +903,85 @@ func TestMediaUseCase_ReindexScreenshots_skipsMissingFileOnDisk(t *testing.T) {
 	updated, err := uc.ReindexScreenshots(context.Background(), basePath)
 	if err != nil || updated != 0 {
 		t.Fatalf("updated = %d err=%v", updated, err)
+	}
+}
+
+func TestMediaUseCase_ReindexScreenshots_skipsExtractWhenMetadataCurrent(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "shots")
+	_ = os.MkdirAll(basePath, 0755)
+	path := filepath.Join(basePath, "ok.png")
+	_ = os.WriteFile(path, []byte("same"), 0o644)
+	info, _ := os.Stat(path)
+	size := info.Size()
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{
+		ID: "ok", FilePath: path, WorldID: "wrld_ok", FileSizeBytes: &size,
+	})
+	_ = repo.UpsertThumbnail(context.Background(), "ok", &media.ScreenshotThumbnail{
+		JpegBlob:      []byte{0xff, 0xd8},
+		SourceSize:    size,
+		SourceModUnix: info.ModTime().Unix(),
+	})
+
+	counter := &countingMetadataExtractor{inner: &mockMetadataExtractor{worldID: "wrld_other"}}
+	uc := NewMediaUseCase(repo, counter, nil, nil)
+	updated, err := uc.ReindexScreenshots(context.Background(), basePath)
+	if err != nil {
+		t.Fatalf("ReindexScreenshots: %v", err)
+	}
+	if updated != 0 {
+		t.Fatalf("updated = %d, want 0", updated)
+	}
+	if len(counter.extract) != 0 {
+		t.Fatalf("Extract calls = %d, want 0", len(counter.extract))
+	}
+}
+
+func TestMediaUseCase_SyncPictureFolder_ingestsAndReindexesEmptyWorldID(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "shots")
+	_ = os.MkdirAll(basePath, 0755)
+
+	existingPath := filepath.Join(basePath, "old.png")
+	_ = os.WriteFile(existingPath, []byte("old"), 0o644)
+	newPath := filepath.Join(basePath, "new.png")
+	_ = os.WriteFile(newPath, []byte("new"), 0o644)
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{
+		ID: "old", FilePath: existingPath, WorldID: "",
+	})
+
+	counter := &countingMetadataExtractor{
+		inner: &mockMetadataExtractor{worldID: "wrld_sync", worldName: "Sync World"},
+	}
+	uc := NewMediaUseCase(repo, counter, nil, nil)
+
+	total, err := uc.SyncPictureFolder(context.Background(), basePath, nil)
+	if err != nil {
+		t.Fatalf("SyncPictureFolder: %v", err)
+	}
+	if total < 2 {
+		t.Fatalf("total = %d, want at least 2 (1 ingest + 1 reindex)", total)
+	}
+
+	gotOld, _ := repo.GetByID(context.Background(), "old")
+	if gotOld.WorldID != "wrld_sync" {
+		t.Errorf("old WorldID = %q", gotOld.WorldID)
+	}
+	if _, ok := repo.byPath[newPath]; !ok {
+		t.Fatal("expected new file ingested")
+	}
+	// New file: extract once on ingest only, not again on reindex skip list.
+	newExtracts := 0
+	for _, p := range counter.extract {
+		if p == filepath.Clean(newPath) {
+			newExtracts++
+		}
+	}
+	if newExtracts != 1 {
+		t.Fatalf("Extract on new file = %d, want 1", newExtracts)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `MediaUseCase.SyncPictureFolder` to ingest new images and selectively reindex existing rows (empty `world_id`, stale file size, or stale thumbnail).
- Refactor `ScanDirectory` / `ReindexScreenshots` to share ingest and selective extract logic.
- Wire `App.ScanScreenshotDir` to `SyncPictureFolder`; update ja/en i18n for sync wording.

Closes #101

## Test plan

- [x] `make fmt`
- [x] `make test`
- [x] `make lint`
- [x] `TestMediaUseCase_SyncPictureFolder_ingestsAndReindexesEmptyWorldID`
- [x] `TestMediaUseCase_ReindexScreenshots_skipsExtractWhenMetadataCurrent`


Made with [Cursor](https://cursor.com)