### PR TITLE
docs(gallery): align feature docs with CONTEXT and implementation (#102)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,61 @@
+# VRChat Tweaker — Media (Gallery)
+
+VRChat のスクリーンショットを閲覧・検索するためのドメイン用語。
+
+## Language
+
+**Gallery**:
+スクリーンショットを一覧・詳細表示する画面体験。主に「いつ撮ったか」で写真を思い出す。
+_Avoid_: ギャラリー画面, Photo library
+
+**Screenshot**:
+アプリがインデックスした VRChat スクリーンショット。ディスク上の画像ファイルと、抽出済みメタデータ（あれば）をひとまとめにした記録。
+_Avoid_: Image, Photo, スクショファイル
+
+**Date grouping**:
+Gallery でスクリーンショットを並べる既定の見分け方。撮影日時（taken-at）に基づく年 → 月 → 日の階層。
+_Avoid_: Timeline, カレンダー表示
+
+**Taken-at**:
+スクリーンショットを「いつ撮ったか」とみなす日時。画像メタデータの撮影日時を優先し、取れないときはファイルの更新日時で代用する。Date grouping の基準になる。
+_Avoid_: 作成日時, ファイル日付（代用ルールを含意しないため）
+
+**World search**:
+日付グループを補う絞り込み。検索ボックス 1 つで、入力が `wrld_` で始まれば World ID の完全一致、それ以外はワールド表示名の部分一致として扱う。Date range filter と併用できる。
+_Avoid_: ワールドフィルタ, World ID 検索（名前検索を含意しないため）
+
+**Date range filter**:
+Taken-at に基づき Gallery の Screenshot 一覧を期間で絞り込むフィルタ。開始日・終了日（from/to）を指定し、World search と組み合わせて使う。有効時も Date grouping（年→月→日）は維持する。
+_Avoid_: 日付検索, カレンダーフィルタ（Date grouping と混同しやすいため）
+
+**Picture folder**:
+VRChat がスクリーンショットを保存するフォルダ。`config.json` の `picture_output_folder`、未設定時は OS 既定の VRChat Picture パス。Gallery に載せる Screenshot はこのフォルダ配下に限定する。
+_Avoid_: スキャン先, 保存先パス（Launcher 設定全般と混同しやすいため）
+
+**Gallery scope**:
+Gallery に表示する Screenshot の集合。常に現行の Picture folder 配下に限定する。
+_Avoid_: インデックス全体, DB 全件
+
+**Out-of-scope screenshot**:
+Picture folder 外にあり、Gallery には出さない Screenshot 記録。DB には残してよい（フォルダを戻したときの再表示などに備える）。
+_Avoid_: 削除済み, アーカイブ（自動削除を連想させるため）
+
+**Missing screenshot file**:
+インデックスはあるがディスク上の画像ファイルが存在しない Screenshot。Gallery には表示しない（DB 行の去就は別判断）。一覧を取得するたびに存在を確認し、欠損は表示から除外する。
+_Avoid_: 壊れたサムネ, 欠損ファイル（ユーザー向け用語として曖昧なため）
+
+**World join**:
+Gallery の詳細から、Screenshot に紐づくワールドへ VRChat を起動して入る操作。`world_id` が無い Screenshot では行えない。起動はデフォルトの Launch profile を用いる。
+_Avoid_: Join ボタン, ワールド起動（Launcher 全般と混同しやすいため）
+
+**Picture folder sync**:
+現行 Picture folder と Gallery のインデックスを揃える操作。新規画像の取り込み、メタデータの再抽出（新規取込分、ソースファイルの更新があった行、`world_id` が空の行）をまとめて行う。欠損ファイルの Gallery 非表示は一覧 API が一覧取得のたびに担う（sync で DB 削除はしない）。
+_Avoid_: フォルダをスキャン, 再インデックス（一部だけを指す語と混同しやすいため）
+
+**Automatic ingest**:
+Picture folder に追加された新規画像を、ウォッチャー経由でインデックスへ取り込むこと。欠損整理やメタ再抽出は含まない。
+_Avoid_: 自動スキャン, リアルタイム同期（フル同期と混同しやすいため）
+
+**Manual sync**:
+ユーザーが Gallery 上の操作で Picture folder sync を明示的に開始すること。
+_Avoid_: 手動スキャン, 更新ボタン（一覧再取得だけを指す場合があるため）

--- a/docs/adr/0001-gallery-scope-and-listing.md
+++ b/docs/adr/0001-gallery-scope-and-listing.md
@@ -1,0 +1,39 @@
+# ADR 0001: Gallery scope と一覧時の欠損除外
+
+## Status
+
+Accepted（[#99](https://github.com/JO3QMA/vrctweaker/issues/99) で実装）
+
+## Context
+
+- スクリーンショットは DB に広くインデックスされるが、Gallery は「今の VRChat Picture folder の写真を思い出す」体験に限定したい
+- Picture folder を変更したあとも、過去パスの行を DB に残し、フォルダを戻したときに再表示できるようにしたい
+- ユーザーが手動で画像を削除した場合、壊れたサムネより「一覧に出さない」方が望ましい
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) を正本とする。
+
+## Decision
+
+1. **Gallery scope**: 一覧・検索 API は常に現行 Picture folder 配下（`FilePathPrefix`）に限定する
+2. **Out-of-scope screenshot**: フォルダ外の DB 行は残すが Gallery には返さない
+3. **Missing screenshot file**: 一覧取得のたび `os.Stat` で regular file を確認し、欠損行は返さない（DB 削除はしない）
+4. **Taken-at**: メタデータの撮影日時を優先し、無ければファイル更新日時で Date grouping する
+
+## Consequences
+
+### 正
+
+- Gallery とディスクの体感が一致しやすい
+- フォルダ変更・復帰シナリオで再表示可能
+- `ListScreenshotsInGalleryScope` に scope + stat を集約できる
+
+### 負
+
+- 一覧のたびに stat が走る（件数が極端に多い場合は将来キャッシュ検討）
+- DB に残る out-of-scope / missing 行の整理は別操作（Manual sync では削除しない）
+
+## Implementation
+
+- `internal/domain/media/gallery_scope.go` — `PictureFolderPathPrefix`
+- `internal/usecase/media_gallery_list.go` — `ListScreenshotsInGalleryScope`
+- `app.go` — `listGalleryScreenshotDTOs` 経由で `Screenshots` / `SearchScreenshots`

--- a/docs/features/media-world-join-from-screenshot.md
+++ b/docs/features/media-world-join-from-screenshot.md
@@ -1,0 +1,67 @@
+# World join（スクリーンショットからワールドへ入る）
+
+## 概要
+
+`CONTEXT.md` の **World join**: Gallery 詳細から、Screenshot の `world_id` を使って VRChat を起動し対象ワールドへ入る。
+
+US 1.2「このワールドへ Join」に対応。**実装済み**。
+
+## ゴール
+
+- `world_id`（例: `wrld_...`）がある Screenshot でワンクリック起動
+- `world_id` が無い場合はボタン無効（または API エラー）
+- **常にデフォルト Launch profile** の引数に join 引数を連結（`CONTEXT.md`）
+
+## 仕様
+
+### 入力
+
+- UI: `JoinWorldFromScreenshot(screenshotId)`
+- 内部: `world_id` を DB から解決 → `JoinWorld(worldId)`
+
+### 起動
+
+- `LauncherUseCase.LaunchToWorld(ctx, profileID="", worldID, ...)`
+  - `profileID` 空 → デフォルトプロファイル
+- join 引数: `BuildJoinWorldArgs(baseArgs, worldID)` → 末尾に `vrchat://launch?id=<worldID>`
+
+### プラットフォーム
+
+- Windows / Linux: Steam 経由起動（`steam -applaunch 438100` + 引数）
+- 詳細は `internal/usecase/launcher_usecase.go` と `docs/ai_dlc/VRChat 起動引数調査ガイド.md`（ローカル参照）
+
+## コード配置
+
+| 層 | ファイル |
+|----|----------|
+| Wails | `app.go` — `JoinWorldFromScreenshot`, `JoinWorld` |
+| Use case | `internal/usecase/launcher_usecase.go` — `LaunchToWorld`, `BuildJoinWorldArgs` |
+| UI | `frontend/src/views/GalleryView.vue` — 詳細パネルの Join ボタン |
+
+## Wails API
+
+```text
+JoinWorldFromScreenshot(screenshotId: string) -> error
+JoinWorld(worldId: string) -> error   // 直接 worldId 指定（Launcher 連携）
+```
+
+エラー例:
+
+- screenshot 未存在
+- `screenshot has no world_id`
+
+## 受け入れ条件（DoD）
+
+- [x] `world_id` ありで Join 押下 → VRChat 起動プロセス開始
+- [x] `world_id` なしでボタン無効
+- [x] デフォルト Launch profile の引数が使われる
+
+## テスト
+
+- `internal/usecase/launcher_usecase_test.go` — `TestBuildJoinWorldArgs`, `TestLauncherUseCase_LaunchToWorld_*`
+- `frontend/src/views/__tests__/GalleryView.spec.ts` — Join ボタン有効/無効
+
+## 関連
+
+- Gallery UI: [`ui-gallery-view.md`](./ui-gallery-view.md)
+- 用語: [`CONTEXT.md`](../../CONTEXT.md) — **World join**

--- a/docs/features/ui-gallery-view.md
+++ b/docs/features/ui-gallery-view.md
@@ -1,0 +1,104 @@
+# Gallery（スクリーンショット一覧 UI）
+
+## 概要
+
+`CONTEXT.md` の **Gallery** ドメイン用語に沿ったスクリーンショット閲覧画面。実装は `frontend/src/views/GalleryView.vue`。
+
+用語の正本: リポジトリルート [`CONTEXT.md`](../../CONTEXT.md)
+
+## ゴール
+
+- **Date grouping**（年 → 月 → 日）で Screenshot を一覧表示する
+- **World search** と **Date range filter** で絞り込みつつ、グルーピングを維持する
+- 詳細プレビューで taken-at / ワールド名 / `world_id` / ファイルパスを表示する
+- **World join**（`world_id` がある場合のみ）— 別機能 [`media-world-join-from-screenshot.md`](./media-world-join-from-screenshot.md)
+- **Manual sync**（Picture folder sync）でフォルダとインデックスを揃える
+
+## 仕様
+
+### 一覧の主軸
+
+- **Date grouping** を既定とする（`galleryDateGroups.ts` の仮想行）
+- Taken-at はメタデータ優先、無ければファイル更新日時（`CONTEXT.md` **Taken-at**）
+
+### Gallery scope と欠損
+
+- 一覧 API は **Gallery scope**（現行 Picture folder 配下）のみ返す（[#99](https://github.com/JO3QMA/vrctweaker/issues/99)）
+- **Missing screenshot file** は一覧取得のたび `stat` で除外する（DB 行は削除しない）
+- Picture folder 外の **Out-of-scope screenshot** も Gallery には出さない
+
+### World search
+
+検索ボックス 1 つ（`CONTEXT.md` **World search**）:
+
+| 入力 | バックエンド |
+|------|----------------|
+| `wrld_` で始まる | `worldId` 完全一致 |
+| それ以外 | `worldName` 部分一致 |
+
+- UI の自動判定: [#100](https://github.com/JO3QMA/vrctweaker/pull/104)（マージ前は `worldId` のみ送信）
+- debounce + Enter で `SearchScreenshots` を呼ぶ
+
+### Date range filter
+
+- `dateFrom` / `dateTo`（Taken-at 基準）で `SearchScreenshots` に渡す
+- 有効時も Date grouping を維持
+- UI: [#100](https://github.com/JO3QMA/vrctweaker/pull/104)
+
+### グリッド・詳細
+
+- サムネイルは `ScreenshotThumbnailDataURL`（WebView 向け data URL）
+- 詳細パネル: takenAt / worldName / worldId / filePath、外部アプリで開く・フォルダ表示
+- `world_id` が空なら World join ボタン無効
+
+### 同期
+
+| 操作 | 用語 | 実装 |
+|------|------|------|
+| ウォッチャー | **Automatic ingest** | 新規ファイルのみ取込、`gallery:screenshots-changed` |
+| 「フォルダを同期」ボタン | **Manual sync** → **Picture folder sync** | `ScanScreenshotDir` |
+
+**Picture folder sync** の内容（[#101](https://github.com/JO3QMA/vrctweaker/pull/105)）:
+
+1. 新規画像の取込
+2. 選択的メタ再抽出（新規、`world_id` 空、ファイルサイズ変更、サムネイル stale）
+3. 欠損の Gallery 非表示は一覧 API 側（sync で DB 削除はしない）
+
+進捗イベント: `gallery:scan-progress` / `gallery:scan-done`
+
+## Wails API（実装済み）
+
+| メソッド | 用途 |
+|----------|------|
+| `Screenshots(worldId?)` | フィルタなし or worldId のみ（後方互換） |
+| `SearchScreenshots(filter)` | worldId / worldName / dateFrom / dateTo + Gallery scope |
+| `GetScreenshot(id)` | 詳細 |
+| `ScreenshotThumbnailDataURL(id)` | グリッド用サムネ |
+| `ScanScreenshotDir(path)` | Manual sync（[#101](https://github.com/JO3QMA/vrctweaker/pull/105) で `SyncPictureFolder` に委譲予定） |
+| `IsGalleryScanning()` | 同期中フラグ |
+| `OpenScreenshotExternally` / `RevealScreenshotInFileManager` | OS 連携 |
+
+`ReindexScreenshotDir` は開発・メンテ用（Gallery UI からは呼ばない）。
+
+## 実装状況
+
+| 項目 | 状態 |
+|------|------|
+| Date grouping UI | 実装済み |
+| Gallery scope + 欠損除外 | 実装済み ([#99](https://github.com/JO3QMA/vrctweaker/issues/99)) |
+| World search 自動判定 | PR [#104](https://github.com/JO3QMA/vrctweaker/pull/104) |
+| Date range filter UI | PR [#104](https://github.com/JO3QMA/vrctweaker/pull/104) |
+| Picture folder sync | PR [#105](https://github.com/JO3QMA/vrctweaker/pull/105) |
+| World join | 実装済み |
+
+## 受け入れ条件（DoD）
+
+- Date grouping で一覧が表示され、クリックで詳細が開く
+- Gallery scope 外・欠損ファイルが一覧に含まれない
+- `world_id` が空のとき World join が無効
+- World search / Date range / Manual sync は上表の Issue・PR と一致
+
+## テスト
+
+- Vitest: `galleryDateGroups.spec.ts`, `GalleryView.spec.ts`（[#100](https://github.com/JO3QMA/vrctweaker/pull/104) で `gallerySearchFilter` 追加）
+- E2E: `frontend/e2e/gallery.spec.ts`


### PR DESCRIPTION
## Summary

- Add `CONTEXT.md` as the canonical Gallery domain glossary (grill-with-docs decisions).
- Add tracked `docs/features/ui-gallery-view.md` and `media-world-join-from-screenshot.md` aligned with current code on `main`.
- Add `docs/adr/0001-gallery-scope-and-listing.md` for gallery scope and missing-file exclusion (#99).
- Clarify that missing-file exclusion is handled by list APIs, not sync (CONTEXT **Picture folder sync**).
- Open items (#100 world search + date UI, #101 picture folder sync) link to their PRs.

Closes #102

## Test plan

- [x] Docs only — no code changes
- [x] Cross-check against `main` APIs (`SearchScreenshots`, `JoinWorldFromScreenshot`, `ListScreenshotsInGalleryScope`)


Made with [Cursor](https://cursor.com)