### PR TITLE
feat(activity): prioritize encounter log on Activity view

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,3 +113,57 @@ _Avoid_: 起動, Launch（Profile launch と区別できないため）
 **Profile launch**:
 Launcher から、選択中 Launch profile の引数で VRChat を起動する操作。Unsaved launch profile edits があっても保存を強制せず、その編集中の引数で起動してよい。セカンダリ導線。
 _Avoid_: このプロファイルで起動（UI 文言は可）, Quick launch（Default 固定ではないため）
+
+## Activity
+
+output_log から得た「誰と・どのワールドで会ったか」を振り返るための用語。
+
+### Language
+
+**Activity**:
+遭遇ログを一覧・絞り込み・深掘りする画面体験。主目的は、同一インスタンスで重なった他ユーザーの滞在区間を追うこと。Encounter log を画面上部に置き、Play time chart はその下に副次セクションとして置く（既定は折りたたみ）。
+_Avoid_: アクティビティ画面, ログ画面（output_log 生データやプレイ時間だけを指す語と混同しやすいため）
+
+**User encounter**:
+他ユーザーが同一インスタンスにいたひと区間の記録。入室時刻（joined-at）から退室時刻（left-at）まで。退室が未観測のとき left-at は空（滞在中）。
+_Avoid_: 遭遇, 出会い（単発イベントの印象を与えるため）, タイムライン行
+
+**Open encounter**:
+left-at が未確定の User encounter。ログ上まだ退室が取れていない滞在。Encounter log では退室列に「滞在中」ラベルで示す（欠損の `—` とは区別する）。
+_Avoid_: 未完了, アクティブ遭遇（実装状態と混同しやすいため）
+
+**Unidentified encounter**:
+VRC user ID が取れなかった User encounter。表示名は Encounter log に載せるが、プロフィールや Encounter history へのリンクは出さない（薄色テキスト）。
+_Avoid_: 匿名ユーザー, 不明ユーザー（VRChat の匿名インスタンス設定と混同しやすいため）
+
+**Encounter log**:
+Activity に並べる User encounter の時系列一覧。画面上の見出しは「遭遇ログ」。入室・退室・表示名・ワールド名の4列（インスタンス ID は含めない）。入室時刻の新しい順が既定。表示名での絞り込みと、ユーザー・ワールド別の深掘りへの導線を持つ。
+_Avoid_: 遭遇履歴（ユーザー／ワールド別の絞り込み画面全体を指す場合があるため）, ログ, タイムライン
+
+**Display name filter**:
+Encounter log 上の唯一の絞り込み。表示名の部分一致のみ（クライアント側）。ワールドや期間での絞り込みは Encounter history 側に任せる。
+_Avoid_: 検索, フィルタ（Gallery の World search や Date range filter と混同しやすいため）
+
+**Encounter retention**:
+遭遇ログの保存上限。設定の保存期間（日）を過ぎた User encounter は自動削除される。Activity ではフィルタ付近のヒント文で期間を示し、空状態だけに頼らない。
+_Avoid_: ログ保持, データ削除（プレイ時間やスクリーンショットと混同しやすいため）
+
+**Encounter log refresh**:
+遭遇ログ一覧の再取得。output_log 取り込み後は自動で行う。手動の更新操作も残し、取り込み漏れや不整合時にユーザーが再取得できる。
+_Avoid_: 同期, リロード（画面全体の再読み込みと混同しやすいため）
+
+**Encounter user navigation**:
+Encounter log で識別済みユーザー（VRC user ID あり）の表示名を選んだときの遷移。フレンドは Friends 画面へ、それ以外はユーザープロフィールへ。遭遇の深掘りはプロフィール内や Encounter history から行う。
+_Avoid_: プロフィール遷移, ユーザー詳細（Friends と区別できないため）
+
+**Encounter world navigation**:
+Encounter log でワールド名を選んだときの遷移。Encounter history（ワールド別）へ進み、そのワールドでの User encounter 一覧を見せる。VRChat への Join は行わない。
+_Avoid_: ワールド Join, ワールド起動（Gallery や Launcher の導線と混同しやすいため）
+
+**Encounter history**:
+特定のユーザーまたはワールドに絞った User encounter の一覧。Activity の表から遷移するか、ユーザープロフィールなど別導線から開く。Activity 本体とは画面を分ける。
+_Avoid_: 遭遇ログ（Activity 上の全体一覧と混同しやすいため）, 履歴画面
+
+**Play time chart**:
+Activity 上の副次セクション。ローカルユーザーの日別プレイ時間を直近 14 日分で示す。遭遇ログの補助情報であり、Activity の主目的ではない。既定では折りたたみ、遭遇ログより下に置く。
+_Avoid_: プレイ時間画面, アクティビティ統計（遭遇ログ全体を指す語と混同しやすいため）

--- a/frontend/e2e/activity.spec.ts
+++ b/frontend/e2e/activity.spec.ts
@@ -25,9 +25,10 @@ test.describe("Activity", () => {
       playtimeCard.getByText("プレイ時間（直近14日）"),
     ).toBeVisible();
     await expect(playtimeCard).toHaveClass(/section-card--collapsed/);
-    await expect(
-      playtimeCard.locator(".section-card__toggle"),
-    ).toHaveAttribute("aria-expanded", "false");
+    await expect(playtimeCard.locator(".section-card__toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
 
     const encounterTable = encounterCard.locator(".el-table");
     await expect(encounterTable).toBeVisible();

--- a/frontend/e2e/activity.spec.ts
+++ b/frontend/e2e/activity.spec.ts
@@ -13,23 +13,21 @@ test.describe("Activity", () => {
     await page.goto("/#/activity");
     await expect(page.locator("h1")).toContainText("アクティビティ");
 
-    const playtimeCard = page.locator(".section-card--playtime");
-    await expect(playtimeCard.getByText("読み込み中")).toBeHidden({
-      timeout: 15_000,
-    });
-
-    await expect(
-      playtimeCard.getByText("プレイ時間（直近14日）"),
-    ).toBeVisible();
-    await expect(
-      playtimeCard.locator(".playtime-chart-wrap canvas"),
-    ).toBeVisible();
-
     const encounterCard = page.locator(".section-card--encounters");
     await expect(encounterCard.getByText("読み込み中")).toBeHidden({
       timeout: 15_000,
     });
-    await expect(encounterCard.getByText("遭遇ログ（滞在区間）")).toBeVisible();
+    await expect(encounterCard.getByText("遭遇ログ")).toBeVisible();
+    await expect(encounterCard.locator(".retention-hint")).toContainText("30");
+
+    const playtimeCard = page.locator(".section-card--playtime");
+    await expect(
+      playtimeCard.getByText("プレイ時間（直近14日）"),
+    ).toBeVisible();
+    await expect(playtimeCard).toHaveClass(/section-card--collapsed/);
+    await expect(
+      playtimeCard.locator(".section-card__toggle"),
+    ).toHaveAttribute("aria-expanded", "false");
 
     const encounterTable = encounterCard.locator(".el-table");
     await expect(encounterTable).toBeVisible();

--- a/frontend/scripts/write-locale-json.mjs
+++ b/frontend/scripts/write-locale-json.mjs
@@ -68,6 +68,7 @@ const en = {
     refresh: "Refresh",
     updating: "Updating…",
     dash: "—",
+    stillPresent: "Present",
     yes: "Yes",
     no: "No",
   },
@@ -196,8 +197,9 @@ const en = {
   activity: {
     title: "Activity",
     playtimeSection: "Play time (last 14 days)",
-    encounterSection: "Encounter log (stays)",
+    encounterSection: "Encounter log",
     searchDisplayName: "Search by display name",
+    retentionHint: "Records older than {days} days are deleted automatically",
     noData: "No data",
     noEncounters: "No encounter logs.",
     colJoin: "Joined",
@@ -469,6 +471,7 @@ const ja = deepMerge(en, {
     refresh: "更新",
     updating: "更新中...",
     dash: "—",
+    stillPresent: "滞在中",
   },
   chart: {
     hour: "時間",
@@ -595,8 +598,9 @@ const ja = deepMerge(en, {
   activity: {
     title: "アクティビティ",
     playtimeSection: "プレイ時間（直近14日）",
-    encounterSection: "遭遇ログ（滞在区間）",
+    encounterSection: "遭遇ログ",
     searchDisplayName: "表示名で検索",
+    retentionHint: "保存期間 {days} 日を超えた記録は自動削除されます",
     noData: "データがありません",
     noEncounters: "遭遇ログがありません。",
     colJoin: "入室",
@@ -862,6 +866,8 @@ const ko = deepMerge(en, {
     done: "완료했습니다",
     refresh: "새로 고침",
     updating: "업데이트 중...",
+    dash: "—",
+    stillPresent: "체류 중",
   },
   chart: {
     hour: "시간",
@@ -983,8 +989,9 @@ const ko = deepMerge(en, {
   activity: {
     title: "활동",
     playtimeSection: "플레이 시간 (최근 14일)",
-    encounterSection: "조우 로그 (체류 구간)",
+    encounterSection: "조우 로그",
     searchDisplayName: "표시 이름으로 검색",
+    retentionHint: "보관 기간 {days}일이 지난 기록은 자동으로 삭제됩니다",
     noData: "데이터가 없습니다",
     noEncounters: "조우 로그가 없습니다.",
     colJoin: "입장",
@@ -1231,6 +1238,8 @@ const zhTW = deepMerge(en, {
     done: "完成",
     refresh: "重新整理",
     updating: "更新中...",
+    dash: "—",
+    stillPresent: "停留中",
   },
   chart: {
     hour: "小時",
@@ -1352,8 +1361,9 @@ const zhTW = deepMerge(en, {
   activity: {
     title: "活動",
     playtimeSection: "遊玩時間（近 14 天）",
-    encounterSection: "相遇紀錄（停留區間）",
+    encounterSection: "相遇紀錄",
     searchDisplayName: "以顯示名稱搜尋",
+    retentionHint: "超過保存期 {days} 天的紀錄將自動刪除",
     noData: "沒有資料",
     noEncounters: "沒有相遇紀錄。",
     colJoin: "進入",
@@ -1597,6 +1607,8 @@ const zhCN = deepMerge(en, {
     done: "完成",
     refresh: "刷新",
     updating: "更新中...",
+    dash: "—",
+    stillPresent: "停留中",
   },
   chart: {
     hour: "小时",
@@ -1717,8 +1729,9 @@ const zhCN = deepMerge(en, {
   activity: {
     title: "活动",
     playtimeSection: "游玩时间（近 14 天）",
-    encounterSection: "相遇记录（停留区间）",
+    encounterSection: "相遇记录",
     searchDisplayName: "按显示名称搜索",
+    retentionHint: "超过保存期 {days} 天的记录将自动删除",
     noData: "没有数据",
     noEncounters: "没有相遇记录。",
     colJoin: "进入",

--- a/frontend/src/components/EncounterHistoryList.vue
+++ b/frontend/src/components/EncounterHistoryList.vue
@@ -21,7 +21,9 @@
         <el-table-column :label="t('encounterHistory.colLeave')" width="155">
           <template #default="{ row }">
             {{
-              row.leftAt ? formatEncounterLocal(row.leftAt) : t("common.dash")
+              row.leftAt
+                ? formatEncounterLocal(row.leftAt)
+                : t("common.stillPresent")
             }}
           </template>
         </el-table-column>

--- a/frontend/src/components/__tests__/EncounterHistoryList.spec.ts
+++ b/frontend/src/components/__tests__/EncounterHistoryList.spec.ts
@@ -84,6 +84,22 @@ describe("EncounterHistoryList", () => {
     expect(headerTexts.some((t) => t.includes("ワールド名"))).toBe(true);
   });
 
+  it("shows still-present label when leftAt is empty", async () => {
+    vi.mocked(wailsApp.App.encountersByVRCUserID).mockResolvedValue([
+      {
+        ...sampleEncounter,
+        leftAt: "",
+      },
+    ]);
+
+    const wrapper = mount(EncounterHistoryList, {
+      props: { mode: "user", userId: "u1" },
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("滞在中");
+  });
+
   it("shows error alert when fetch fails", async () => {
     vi.mocked(wailsApp.App.encountersByVRCUserID).mockRejectedValue(
       new Error("network down"),

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -37,6 +37,7 @@
     "refresh": "Refresh",
     "updating": "Updating…",
     "dash": "—",
+    "stillPresent": "Present",
     "yes": "Yes",
     "no": "No"
   },
@@ -161,8 +162,9 @@
   "activity": {
     "title": "Activity",
     "playtimeSection": "Play time (last 14 days)",
-    "encounterSection": "Encounter log (stays)",
+    "encounterSection": "Encounter log",
     "searchDisplayName": "Search by display name",
+    "retentionHint": "Records older than {days} days are deleted automatically",
     "noData": "No data",
     "noEncounters": "No encounter logs.",
     "colJoin": "Joined",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -37,6 +37,7 @@
     "refresh": "更新",
     "updating": "更新中...",
     "dash": "—",
+    "stillPresent": "滞在中",
     "yes": "Yes",
     "no": "No"
   },
@@ -161,8 +162,9 @@
   "activity": {
     "title": "アクティビティ",
     "playtimeSection": "プレイ時間（直近14日）",
-    "encounterSection": "遭遇ログ（滞在区間）",
+    "encounterSection": "遭遇ログ",
     "searchDisplayName": "表示名で検索",
+    "retentionHint": "保存期間 {days} 日を超えた記録は自動削除されます",
     "noData": "データがありません",
     "noEncounters": "遭遇ログがありません。",
     "colJoin": "入室",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -37,6 +37,7 @@
     "refresh": "새로 고침",
     "updating": "업데이트 중...",
     "dash": "—",
+    "stillPresent": "체류 중",
     "yes": "Yes",
     "no": "No"
   },
@@ -161,8 +162,9 @@
   "activity": {
     "title": "활동",
     "playtimeSection": "플레이 시간 (최근 14일)",
-    "encounterSection": "조우 로그 (체류 구간)",
+    "encounterSection": "조우 로그",
     "searchDisplayName": "표시 이름으로 검색",
+    "retentionHint": "보관 기간 {days}일이 지난 기록은 자동으로 삭제됩니다",
     "noData": "데이터가 없습니다",
     "noEncounters": "조우 로그가 없습니다.",
     "colJoin": "입장",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -37,6 +37,7 @@
     "refresh": "刷新",
     "updating": "更新中...",
     "dash": "—",
+    "stillPresent": "停留中",
     "yes": "Yes",
     "no": "No"
   },
@@ -161,8 +162,9 @@
   "activity": {
     "title": "活动",
     "playtimeSection": "游玩时间（近 14 天）",
-    "encounterSection": "相遇记录（停留区间）",
+    "encounterSection": "相遇记录",
     "searchDisplayName": "按显示名称搜索",
+    "retentionHint": "超过保存期 {days} 天的记录将自动删除",
     "noData": "没有数据",
     "noEncounters": "没有相遇记录。",
     "colJoin": "进入",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -37,6 +37,7 @@
     "refresh": "重新整理",
     "updating": "更新中...",
     "dash": "—",
+    "stillPresent": "停留中",
     "yes": "Yes",
     "no": "No"
   },
@@ -161,8 +162,9 @@
   "activity": {
     "title": "活動",
     "playtimeSection": "遊玩時間（近 14 天）",
-    "encounterSection": "相遇紀錄（停留區間）",
+    "encounterSection": "相遇紀錄",
     "searchDisplayName": "以顯示名稱搜尋",
+    "retentionHint": "超過保存期 {days} 天的紀錄將自動刪除",
     "noData": "沒有資料",
     "noEncounters": "沒有相遇紀錄。",
     "colJoin": "進入",

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -2,20 +2,9 @@
   <div class="activity-view">
     <h1 class="page-title">{{ t("activity.title") }}</h1>
 
-    <!-- 統計セクション（直近14日） -->
+    <!-- 遭遇ログ（主セクション） -->
     <CollapsibleSectionCard
-      class="section-card--playtime"
-      :title="t('activity.playtimeSection')"
-    >
-      <div v-if="statsLoading" class="loading">{{ t("common.loading") }}</div>
-      <div v-else-if="!statsRangeFrom" class="empty-stats">
-        {{ t("activity.noData") }}
-      </div>
-      <PlayTimeChart v-else :series="dailyPlayChartSeries" />
-    </CollapsibleSectionCard>
-
-    <!-- タイムラインセクション -->
-    <CollapsibleSectionCard
+      v-model="encountersExpanded"
       class="section-card--encounters"
       :title="t('activity.encounterSection')"
     >
@@ -33,6 +22,9 @@
         </el-input>
         <el-button @click="loadEncounters">{{ t("common.refresh") }}</el-button>
       </div>
+      <p class="retention-hint">
+        {{ t("activity.retentionHint", { days: logRetentionDays }) }}
+      </p>
 
       <div class="encounter-log-scroll">
         <div v-if="encountersLoading" class="loading">
@@ -59,7 +51,9 @@
           <el-table-column :label="t('activity.colLeave')" width="150">
             <template #default="{ row }">
               <span class="timeline-time">{{
-                row.leftAt ? formatEncounterLocal(row.leftAt) : t("common.dash")
+                row.leftAt
+                  ? formatEncounterLocal(row.leftAt)
+                  : t("common.stillPresent")
               }}</span>
             </template>
           </el-table-column>
@@ -100,6 +94,19 @@
         </el-table>
       </div>
     </CollapsibleSectionCard>
+
+    <!-- プレイ時間（副次・既定折りたたみ） -->
+    <CollapsibleSectionCard
+      v-model="playtimeExpanded"
+      class="section-card--playtime"
+      :title="t('activity.playtimeSection')"
+    >
+      <div v-if="statsLoading" class="loading">{{ t("common.loading") }}</div>
+      <div v-else-if="!statsRangeFrom" class="empty-stats">
+        {{ t("activity.noData") }}
+      </div>
+      <PlayTimeChart v-else :series="dailyPlayChartSeries" />
+    </CollapsibleSectionCard>
   </div>
 </template>
 
@@ -130,6 +137,10 @@ const { t, locale } = useI18n();
 function formatEncounterLocal(iso: string): string {
   return formatEncounteredAt(iso, appLocaleToBcp47(String(locale.value)));
 }
+
+const encountersExpanded = ref(true);
+const playtimeExpanded = ref(false);
+const logRetentionDays = ref(30);
 
 const encounters = ref<UserEncounterDTO[]>([]);
 const encountersLoading = ref(false);
@@ -257,6 +268,9 @@ onMounted(() => {
   }
   void loadEncounters();
   void loadStats();
+  void App.getLogRetentionDays().then((days) => {
+    logRetentionDays.value = days;
+  });
 });
 
 onUnmounted(() => {
@@ -384,8 +398,15 @@ onUnmounted(() => {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
+.retention-hint {
+  margin: 0 0 1rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 

--- a/frontend/src/views/__tests__/ActivityView.spec.ts
+++ b/frontend/src/views/__tests__/ActivityView.spec.ts
@@ -6,6 +6,7 @@ import ActivityView from "../ActivityView.vue";
 const {
   mockEncounters,
   mockGetActivityStats,
+  mockGetLogRetentionDays,
   mockResolveUserProfileNavigation,
 } = vi.hoisted(() => ({
   mockEncounters: vi.fn().mockResolvedValue([]),
@@ -13,6 +14,7 @@ const {
     dailyPlaySeconds: [],
     topWorlds: [],
   }),
+  mockGetLogRetentionDays: vi.fn().mockResolvedValue(30),
   mockResolveUserProfileNavigation: vi.fn().mockResolvedValue({
     openInFriendsView: false,
     user: {
@@ -48,6 +50,7 @@ vi.mock("../../wails/app", async (importOriginal) => {
       ...actual.App,
       encounters: mockEncounters,
       getActivityStats: mockGetActivityStats,
+      getLogRetentionDays: mockGetLogRetentionDays,
       resolveUserProfileNavigation: mockResolveUserProfileNavigation,
     },
   };
@@ -75,6 +78,7 @@ describe("ActivityView", () => {
       dailyPlaySeconds: [],
       topWorlds: [],
     });
+    mockGetLogRetentionDays.mockResolvedValue(30);
   });
 
   async function mountActivity() {
@@ -126,9 +130,26 @@ describe("ActivityView", () => {
 
     const encountersCard = wrapper.find(".section-card--encounters");
     expect(encountersCard.exists()).toBe(true);
+
+    const cards = wrapper.findAll(".collapsible-section-card");
+    expect(cards[0]!.classes()).toContain("section-card--encounters");
+    expect(cards[1]!.classes()).toContain("section-card--playtime");
   });
 
-  it("collapses playtime section when header toggle is clicked", async () => {
+  it("starts with playtime section collapsed and encounters expanded", async () => {
+    const { wrapper } = await mountActivity();
+    const playtimeCard = wrapper.find(".section-card--playtime");
+    const encountersCard = wrapper.find(".section-card--encounters");
+
+    expect(
+      playtimeCard.find(".section-card__toggle").attributes("aria-expanded"),
+    ).toBe("false");
+    expect(
+      encountersCard.find(".section-card__toggle").attributes("aria-expanded"),
+    ).toBe("true");
+  });
+
+  it("expands playtime section when header toggle is clicked", async () => {
     const router = createRouter({
       history: createWebHashHistory(),
       routes: [{ path: "/activity", component: ActivityView }],
@@ -144,11 +165,11 @@ describe("ActivityView", () => {
 
     const playtimeCard = wrapper.find(".section-card--playtime");
     const toggle = playtimeCard.find(".section-card__toggle");
-    expect(toggle.attributes("aria-expanded")).toBe("true");
+    expect(toggle.attributes("aria-expanded")).toBe("false");
 
     await toggle.trigger("click");
-    expect(playtimeCard.classes()).toContain("section-card--collapsed");
-    expect(toggle.attributes("aria-expanded")).toBe("false");
+    expect(playtimeCard.classes()).not.toContain("section-card--collapsed");
+    expect(toggle.attributes("aria-expanded")).toBe("true");
   });
 
   it("display name click pushes friends route when resolve says friend", async () => {
@@ -311,18 +332,29 @@ describe("ActivityView", () => {
     });
   });
 
-  it("loads encounters and stats on mount", async () => {
+  it("loads encounters, stats, and retention days on mount", async () => {
     await mountActivity();
     expect(mockEncounters).toHaveBeenCalled();
     expect(mockGetActivityStats).toHaveBeenCalled();
+    expect(mockGetLogRetentionDays).toHaveBeenCalled();
   });
 
-  it("shows playtime chart when stats are available", async () => {
+  it("shows retention hint with configured days", async () => {
+    mockGetLogRetentionDays.mockResolvedValue(45);
+    const { wrapper } = await mountActivity();
+    expect(wrapper.find(".retention-hint").text()).toContain("45");
+  });
+
+  it("shows playtime chart when stats are available and section is expanded", async () => {
     mockGetActivityStats.mockResolvedValue({
       dailyPlaySeconds: [{ date: "2026-06-01", seconds: 3600 }],
       topWorlds: [],
     });
     const { wrapper } = await mountActivity();
+    await wrapper
+      .find(".section-card--playtime .section-card__toggle")
+      .trigger("click");
+    await wrapper.vm.$nextTick();
     expect(wrapper.find(".playtime-chart-stub").exists()).toBe(true);
   });
 
@@ -380,7 +412,7 @@ describe("ActivityView", () => {
     expect(wrapper.find(".timeline-link").exists()).toBe(false);
   });
 
-  it("shows dash for missing leave time", async () => {
+  it("shows still-present label for open encounter", async () => {
     mockEncounters.mockResolvedValue([
       {
         id: "1",
@@ -392,7 +424,7 @@ describe("ActivityView", () => {
       },
     ]);
     const { wrapper } = await mountActivity();
-    expect(wrapper.text()).toContain("—");
+    expect(wrapper.text()).toContain("滞在中");
   });
 
   it("opens world encounter history when world link is clicked", async () => {

--- a/frontend/src/views/activityViewStoryDecorator.ts
+++ b/frontend/src/views/activityViewStoryDecorator.ts
@@ -20,6 +20,7 @@ export function activityViewWailsDecorator(
               Encounters: () => Promise.resolve(encounters),
               GetActivityStats: (_from: string, _to: string) =>
                 Promise.resolve(stats),
+              GetLogRetentionDays: () => Promise.resolve(30),
               ResolveUserProfileNavigation: (id: string) =>
                 Promise.resolve({
                   user: {


### PR DESCRIPTION
## Summary

- Refocus the Activity screen on the encounter log: encounters section moves to the top, playtime chart moves below and starts collapsed
- Add retention-period hint near the display-name filter, show「滞在中」for open stays (no leave time), and simplify the section title to「遭遇ログ」
- Document Activity domain language in `CONTEXT.md` (Encounter log, User encounter, navigation, retention, etc.)
- Update unit tests, Storybook decorator, and Playwright E2E for the new layout and copy

## Test plan

- [x] `make fmt`
- [x] `make test`
- [x] `make lint`
- [x] `pnpm run test:e2e -- activity.spec.ts`


Made with [Cursor](https://cursor.com)