### PR TITLE
feat(self-profile): add /me route and unify User detail

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,7 +157,7 @@ Activity 画面の遭遇ログ一覧と Play time chart 用データの再取得
 _Avoid_: Encounter log refresh（遭遇ログだけを指す印象）, 同期, リロード（画面全体の再読み込みと混同しやすいため）
 
 **Encounter user navigation**:
-Encounter log で識別済みユーザー（VRC user ID あり）の表示名を選んだときの遷移。フレンドは Friends 画面へ、それ以外はユーザープロフィールへ。遭遇の深掘りはプロフィール内や Encounter history から行う。
+Encounter log で識別済みユーザー（VRC user ID あり）の表示名を選んだときの遷移。対象がログイン中の自分なら Self profile へ。フレンドなら Friends へ。それ以外は User profile へ。遭遇の深掘りはプロフィール内や Encounter history から行う。
 _Avoid_: プロフィール遷移, ユーザー詳細（Friends と区別できないため）
 
 **Encounter world navigation**:
@@ -183,3 +183,45 @@ _Avoid_: プレイ時間（UI セクション名だけを指すとき）, 滞在
 **Play time chart**:
 Activity 上の副次セクション。Play time の日別合計を棒グラフで示す。表示する暦日数は 14 日と Activity retention の日数の小さい方（保存期間が 14 日未満のときは軸も短くする）。見出しもその日数（例: 直近7日）を反映する。遭遇ログの補助情報であり、Activity の主目的ではない。既定では折りたたみ、遭遇ログより下に置く。
 _Avoid_: プレイ時間画面, アクティビティ統計（遭遇ログ全体を指す語と混同しやすいため）
+
+## User detail
+
+VRChat 上の人物（自分・フレンド・非フレンド）のプロフィールを閲覧する共通体験の用語。
+
+### Language
+
+**User detail**:
+VRChat ユーザーのキャッシュ済みプロフィールを閲覧する共通体験。ヒーロー（バナー・アバター）、詳細タブ、遭遇履歴タブなどを含む。Friends の詳細ペイン、User profile 画面、Self profile で同じ表面を使う。
+_Avoid_: ユーザープロフィール（User profile 画面体験と混同しやすいため）, プロフィール画面（Launch profile と混同しやすいため）
+
+**Friends**:
+フレンド一覧と User detail のマスター／ディテール画面体験。サイドバーから開く。一覧でユーザーを選ぶと右ペインに User detail を示す。
+_Avoid_: フレンド画面, ユーザー一覧（Activity の遭遇ログ一覧と混同しやすいため）
+
+**User profile**:
+フレンド以外のユーザーを `vrcUserId` で開く単独画面体験。User detail を主コンテンツとして全面に示す。Activity の Encounter user navigation や外部導線から遷移する。
+_Avoid_: ユーザープロフィール画面（User detail 全体と混同しやすいため）, プロフィール詳細
+
+**Self profile**:
+ログイン中のローカルユーザー自身の User detail。他ユーザーと同じ閲覧表面を使うが、お気に入りと遭遇履歴タブは出さない。詳細タブに Self profile refresh を置く。専用ルート `/me` で全面表示する。サイドバーに常時表示する項目があり、未ログインでもクリックで `/me` のログイン必要空状態へ進める。Settings profile summary の「詳細を見る」からも開ける。未ログインで `/me` を直接開いたときも Settings へリダイレクトせず、同じ空状態と Settings 導線を示す。表示データの正は Cached VRChat user（`users_cache` の self 行）。Settings のログイン確認用要約も同じ self 行の一部フィールドから派生する。
+_Avoid_: 自分のアカウント, マイプロフィール（Dashboard や VRChat profile slot と混同しやすいため）
+
+**Settings profile summary**:
+Settings のログイン済みブロックに示す、Self profile の要約。アバター・表示名・ユーザー名・ステータスなど最小限の確認用情報。Cached VRChat user（self 行）の投影であり、User detail の代替ではない。「詳細を見る」で Self profile へ進む。
+_Avoid_: 自己プロフィール（Self profile 本体と混同しやすいため）, プロフィールカード（User detail 全体と混同しやすいため）
+
+**Self profile refresh**:
+Self profile の詳細タブから、VRChat API 経由で Cached VRChat user（self 行）を再取得・更新する操作。Settings のプロフィール更新と同等の効果。Self profile 上で完結し、User detail 共通表面の自己向け差分として置く。
+_Avoid_: プロフィール同期, 再読み込み（画面全体のリロードと混同しやすいため）
+
+**Cached VRChat user**:
+User detail の表示元となる、Tweaker が保持する VRChat ユーザー情報のスナップショット。表示名、ステータス、バイオ、ロケーション、お気に入りフラグなど。API 取得後に users_cache に保存される。
+_Avoid_: UserCache, DTO（実装型名）, フレンド（Friends 画面体験と混同しやすいため）
+
+**Self profile navigation**:
+`vrcUserId` でユーザーを開く導線（Encounter user navigation、Friends の deep link、User profile への直リンクなど）のうち、対象がログイン中の自分のとき Self profile（`/me`）へ進めること。Friends や User profile にはフォールバックしない。
+_Avoid_: Encounter user navigation（Activity 上の表示名クリックに限定した印象）, マイページ遷移
+
+**Self profile nav**:
+サイドバーで `/me` を開く常設項目の表示ラベル。i18n キー `nav.me` を用い、日本語は「自分」、英語は「Me」などロケールごとに短い呼び方にする。Friends や Settings の項目名とは別キーとする。
+_Avoid_: プロフィール（Launch profile・User profile と混同しやすいため）, マイプロフィール（Self profile 画面体験の Avoid 語と重なるため）

--- a/app.go
+++ b/app.go
@@ -1153,14 +1153,24 @@ func (a *App) Friends() ([]UserCacheDTO, error) {
 
 // ResolveUserProfileForNavigation refreshes users_cache when logged in (GET /users/{id}) and returns routing hints.
 func (a *App) ResolveUserProfileNavigation(vrcUserID string) (UserProfileNavigationDTO, error) {
-	u, openFriends, err := a.identity.ResolveUserProfileForNavigation(a.ctx, vrcUserID)
+	u, openFriends, openSelf, err := a.identity.ResolveUserProfileForNavigation(a.ctx, vrcUserID)
 	if err != nil {
 		return UserProfileNavigationDTO{}, err
 	}
 	return UserProfileNavigationDTO{
 		User:              toUserCacheDTO(u),
 		OpenInFriendsView: openFriends,
+		OpenInSelfProfile: openSelf,
 	}, nil
+}
+
+// GetSelfProfile returns the logged-in user's cached profile row (users_cache user_kind=self).
+func (a *App) GetSelfProfile(forceRefresh bool) (UserCacheDTO, error) {
+	u, err := a.identity.GetSelfProfile(a.ctx, forceRefresh)
+	if err != nil {
+		return UserCacheDTO{}, err
+	}
+	return toUserCacheDTO(u), nil
 }
 
 // SetFavorite updates a friend's favorite flag.

--- a/bindings.go
+++ b/bindings.go
@@ -324,6 +324,7 @@ type UserCacheDTO struct {
 type UserProfileNavigationDTO struct {
 	User              UserCacheDTO `json:"user"`
 	OpenInFriendsView bool         `json:"openInFriendsView"`
+	OpenInSelfProfile bool         `json:"openInSelfProfile"`
 }
 
 func toUserCacheDTO(f *identity.UserCache) UserCacheDTO {

--- a/docs/adr/0003-user-detail-and-self-profile.md
+++ b/docs/adr/0003-user-detail-and-self-profile.md
@@ -1,0 +1,54 @@
+# ADR 0003: User detail 共通化と Self profile（`/me`）
+
+## Status
+
+Accepted（grill-with-docs セッションで合意）
+
+## Context
+
+- Friends（マスター／ディテール）、User profile（`/user-profile`）、Settings のログイン済みブロックが、それぞれ別 UI・別データ経路でユーザープロフィールを示していた
+- User detail の共有コンポーネント（`VrcUserCacheDetail`）は Friends / User profile で使われるが、Settings は `VRChatCurrentUserDTO` の簡易カードのみ
+- バックエンドには `users_cache` の `user_kind=self` 行と `GetCurrentUser` による upsert がある一方、フロントは二系統の DTO を参照していた
+- Activity の **Encounter user navigation** はフレンド／非フレンドの二択のみで、自分自身の行き先が未定義だった
+- `user_encounters` は他ユーザーの滞在区間のみを記録するため、自分の VRC user ID で絞った遭遇履歴タブは常に空になる
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **User detail** セクションを正本とする。
+
+## Decision
+
+1. **User detail** を傘用語とし、Friends・User profile・Self profile はいずれも同じ閲覧表面（ヒーロー・詳細タブ等）を共有する
+2. **Self profile** は専用ルート **`/me`** で全面表示する。サイドバー常設（`nav.me`、日本語「自分」／英語「Me」）と Settings profile summary の「詳細を見る」の両方から開ける
+3. **Cached VRChat user**（`users_cache`、self 行含む）を User detail のデータの正とする。Settings profile summary は同じ self 行の最小投影とし、`VRChatCurrentUserDTO` 専用経路への依存をやめる方向とする
+4. **Self profile の UI 差分**: お気に入り非表示、遭遇履歴タブ非表示、詳細タブに **Self profile refresh**（Settings のプロフィール更新と同等）を置く
+5. **Self profile navigation**: `vrcUserId` 導線で対象がログイン中の自分なら常に `/me` へ。Friends / User profile へフォールバックしない。Encounter user navigation も同ルールに従う
+6. **未ログイン時の `/me`**: Settings へリダイレクトせず、Friends と同型のログイン必要空状態＋Settings 導線を `/me` 上に示す。サイドバーの「自分」は未ログインでも表示し、同じ空状態へ進める
+
+## Considered Options
+
+| 論点 | 採用 | 却下した案 |
+|------|------|------------|
+| Self profile の入口 | 専用ルート `/me` + Settings 要約リンク | Friends 一覧に「自分」行、Settings 内への User detail 埋め込み |
+| Self のデータ源 | Cached VRChat user（self 行）に一本化 | Self だけ `GetVRChatCurrentUser` を継続 |
+| Self の遭遇履歴タブ | 非表示 | 他ユーザーと同一タブ（常に空）、Activity への導線に置換のみ |
+| 自分への deep link | `/me` に統一 | `/user-profile?vrcUserId=自分` のまま |
+| 未ログイン `/me` | 画面上の空状態 | Settings リダイレクト、`/me` 内ログインフォーム |
+| ルートパス | `/me` | `/self-profile`、`/profile/me` |
+
+## Consequences
+
+### 正
+
+- Friends / User profile / Self profile の体験とデータモデルが揃う
+- 自分のプロフィールは常に `/me` と覚えやすい
+- 意味のない空の遭遇履歴タブを Self profile から排除できる
+- Encounter user navigation の三分岐（自分／フレンド／その他）が明確になる
+
+### 負
+
+- `ResolveUserProfileNavigation`（または同等）に self 判定の第三分岐が必要
+- Settings のプロフィール表示を self 行ベースに寄せるリファクタが発生する
+- User detail 共有コンポーネントに self 向け props／分岐（お気に入り・タブ・refresh）が増える
+
+## Implementation
+
+Implemented per ADR 0003.

--- a/frontend/e2e/fixtures/app-routes.ts
+++ b/frontend/e2e/fixtures/app-routes.ts
@@ -14,7 +14,7 @@ const encounterHistoryUserQuery = new URLSearchParams({
   vrcUserId: E2E_TEST_USER_ID,
 }).toString();
 
-/** frontend/src/main.ts の全 11 ルート（hash ルーター。Playwright では /#/path 形式で遷移） */
+/** frontend/src/main.ts の全 12 ルート（hash ルーター。Playwright では /#/path 形式で遷移） */
 export const APP_ROUTES = [
   { path: "/", name: "dashboard", titleJa: "ダッシュボード" },
   { path: "/launcher", name: "launcher", titleJa: "ランチャー" },
@@ -25,6 +25,7 @@ export const APP_ROUTES = [
     name: "encounter-history",
     titleJa: "遭遇履歴",
   },
+  { path: "/me", name: "me", titleJa: "自分" },
   { path: "/friends", name: "friends", titleJa: "フレンド" },
   {
     path: `/user-profile?${userProfileQuery}`,

--- a/frontend/e2e/fixtures/mock-wails.ts
+++ b/frontend/e2e/fixtures/mock-wails.ts
@@ -11,6 +11,7 @@
  */
 
 import {
+  E2E_SELF_USER_ID,
   E2E_TEST_USER_ID,
   SEED_ACTIVITY_STATS,
   SEED_AUTOMATION_RULES,
@@ -19,12 +20,19 @@ import {
   SEED_LAUNCH_PROFILES,
   SEED_PATH_SETTINGS,
   SEED_SCREENSHOTS,
+  SEED_SELF_PROFILE,
   SEED_VRCHAT_CONFIG,
   seedUserProfileNavigation,
 } from "./seed-data";
 
+export interface MockWailsOptions {
+  /** true のとき IsLoggedIn / GetSelfProfile がログイン済みを返す */
+  loggedIn?: boolean;
+}
+
 /** ページ読み込み前に注入する window.go スタブの初期化スクリプトを返す（中身はブラウザでそのまま実行されるため TypeScript 構文不可） */
-export function getMockWailsInitScript(): string {
+export function getMockWailsInitScript(options: MockWailsOptions = {}): string {
+  const loggedIn = options.loggedIn ?? false;
   const profilesJson = JSON.stringify(SEED_LAUNCH_PROFILES);
   const pathSettingsJson = JSON.stringify(SEED_PATH_SETTINGS);
   const screenshotsJson = JSON.stringify(SEED_SCREENSHOTS);
@@ -34,9 +42,15 @@ export function getMockWailsInitScript(): string {
   const automationRulesJson = JSON.stringify(SEED_AUTOMATION_RULES);
   const vrchatConfigJson = JSON.stringify(SEED_VRCHAT_CONFIG);
   const e2eTestUserIdJson = JSON.stringify(E2E_TEST_USER_ID);
+  const e2eSelfUserIdJson = JSON.stringify(E2E_SELF_USER_ID);
+  const selfProfileJson = JSON.stringify(SEED_SELF_PROFILE);
   const resolveUserProfileSeedJson = JSON.stringify(
     seedUserProfileNavigation(E2E_TEST_USER_ID),
   );
+  const resolveSelfProfileSeedJson = JSON.stringify(
+    seedUserProfileNavigation(E2E_SELF_USER_ID),
+  );
+  const loggedInJson = JSON.stringify(loggedIn);
 
   return `
     (function() {
@@ -51,7 +65,13 @@ export function getMockWailsInitScript(): string {
       const automationRules = ${automationRulesJson};
       const vrchatConfig = ${vrchatConfigJson};
       const e2eTestUserId = ${e2eTestUserIdJson};
+      const e2eSelfUserId = ${e2eSelfUserIdJson};
+      const selfProfileSeed = ${selfProfileJson};
       const resolveUserProfileSeed = ${resolveUserProfileSeedJson};
+      const resolveSelfProfileSeed = ${resolveSelfProfileSeedJson};
+      const loggedIn = ${loggedInJson};
+      var selfProfile = Object.assign({}, selfProfileSeed);
+      var selfProfileRefreshCount = 0;
 
       function filterScreenshotsByWorldId(list, worldId) {
         if (!worldId || !String(worldId).trim()) return list;
@@ -94,6 +114,13 @@ export function getMockWailsInitScript(): string {
       }
 
       function resolveUserProfileNavigation(vrcUserId) {
+        if (vrcUserId === e2eSelfUserId) {
+          return {
+            user: resolveSelfProfileSeed.user,
+            openInFriendsView: resolveSelfProfileSeed.openInFriendsView,
+            openInSelfProfile: resolveSelfProfileSeed.openInSelfProfile,
+          };
+        }
         if (vrcUserId === e2eTestUserId) {
           return {
             user: resolveUserProfileSeed.user,
@@ -232,16 +259,39 @@ export function getMockWailsInitScript(): string {
         SetStatusAndDescription: () => Promise.resolve(),
         Login: () => Promise.resolve({ ok: false, error: 'E2E mock' }),
         Logout: () => Promise.resolve(),
-        IsLoggedIn: () => Promise.resolve(false),
-        HasStoredCredential: () => Promise.resolve(false),
+        IsLoggedIn: () => Promise.resolve(loggedIn),
+        HasStoredCredential: () => Promise.resolve(loggedIn),
         GetCredentialBlob: () => Promise.resolve(''),
         UnlockVRChatSession: (_token) => Promise.resolve(),
         PersistWrappedCredential: (_blob) => Promise.resolve(),
         ClearStoredCredential: () => Promise.resolve(),
         GetVRChatCurrentUser: (_forceRefresh) =>
-          Promise.reject(new Error('E2E mock: not logged in')),
-        GetSelfProfile: (_forceRefresh) =>
-          Promise.reject(new Error('E2E mock: not logged in')),
+          loggedIn
+            ? Promise.resolve({
+                id: selfProfile.vrcUserId,
+                displayName: selfProfile.displayName,
+                username: selfProfile.username || '',
+                status: selfProfile.status || '',
+                statusDescription: selfProfile.statusDescription || '',
+                state: selfProfile.state || '',
+                currentAvatarThumbnailImageUrl: '',
+                userIcon: '',
+                profilePicOverrideThumbnail: '',
+              })
+            : Promise.reject(new Error('E2E mock: not logged in')),
+        GetSelfProfile: (forceRefresh) => {
+          if (!loggedIn) {
+            return Promise.reject(new Error('E2E mock: not logged in'));
+          }
+          if (forceRefresh) {
+            selfProfileRefreshCount += 1;
+            selfProfile = Object.assign({}, selfProfileSeed, {
+              statusDescription:
+                'E2E refreshed ' + String(selfProfileRefreshCount),
+            });
+          }
+          return Promise.resolve(selfProfile);
+        },
         RefreshFriends: () => Promise.resolve(),
         ReconcileVRChatSocialCache: () => Promise.resolve(),
         VacuumDb: () => Promise.resolve(),

--- a/frontend/e2e/fixtures/mock-wails.ts
+++ b/frontend/e2e/fixtures/mock-wails.ts
@@ -98,6 +98,7 @@ export function getMockWailsInitScript(): string {
           return {
             user: resolveUserProfileSeed.user,
             openInFriendsView: resolveUserProfileSeed.openInFriendsView,
+            openInSelfProfile: resolveUserProfileSeed.openInSelfProfile,
           };
         }
         return {
@@ -109,6 +110,7 @@ export function getMockWailsInitScript(): string {
             lastUpdated: '',
           },
           openInFriendsView: false,
+          openInSelfProfile: false,
         };
       }
 
@@ -237,6 +239,8 @@ export function getMockWailsInitScript(): string {
         PersistWrappedCredential: (_blob) => Promise.resolve(),
         ClearStoredCredential: () => Promise.resolve(),
         GetVRChatCurrentUser: (_forceRefresh) =>
+          Promise.reject(new Error('E2E mock: not logged in')),
+        GetSelfProfile: (_forceRefresh) =>
           Promise.reject(new Error('E2E mock: not logged in')),
         RefreshFriends: () => Promise.resolve(),
         ReconcileVRChatSocialCache: () => Promise.resolve(),

--- a/frontend/e2e/fixtures/seed-data.ts
+++ b/frontend/e2e/fixtures/seed-data.ts
@@ -84,10 +84,15 @@ export interface SeedUserProfileNavigation {
 /** ResolveUserProfileNavigation / user-profile ルート用の代表ユーザー ID */
 export const E2E_TEST_USER_ID = "usr_e2e_test";
 
+/** Self profile（/me）・ログイン済みモック用の自分ユーザー ID */
+export const E2E_SELF_USER_ID = "usr_e2e_self";
+
 /** ギャラリー・遭遇履歴（ワールド別）で共有するワールド ID */
 export const E2E_WORLD_ID = "wrld_e2e_gallery";
 
 export const E2E_TEST_USER_DISPLAY_NAME = "E2E Test User";
+
+export const E2E_SELF_DISPLAY_NAME = "E2E Self User";
 
 export const SEED_LAUNCH_PROFILES: SeedLaunchProfile[] = [
   {
@@ -213,6 +218,23 @@ export const SEED_ACTIVITY_STATS: SeedActivityStats = {
   ],
 };
 
+/** GetSelfProfile / Self profile 画面用（ログイン済み E2E モック） */
+export const SEED_SELF_PROFILE: SeedFriend & {
+  username: string;
+  state: string;
+  bio: string;
+} = {
+  vrcUserId: E2E_SELF_USER_ID,
+  displayName: E2E_SELF_DISPLAY_NAME,
+  username: "e2e_self",
+  status: "active",
+  state: "online",
+  isFavorite: false,
+  lastUpdated: "2025-06-01T09:00:00Z",
+  statusDescription: "E2E 自己プロフィール",
+  bio: "E2E ログイン中ユーザーです。",
+};
+
 export const SEED_AUTOMATION_RULES: SeedAutomationRule[] = [
   {
     id: "rule_e2e_001",
@@ -239,10 +261,17 @@ export const SEED_VRCHAT_CONFIG = {
   disableRichPresence: null,
 };
 
-/** usr_e2e_test 向け ResolveUserProfileNavigation の戻り値 */
+/** usr_e2e_test / usr_e2e_self 向け ResolveUserProfileNavigation の戻り値 */
 export function seedUserProfileNavigation(
   vrcUserId: string,
 ): SeedUserProfileNavigation {
+  if (vrcUserId === E2E_SELF_USER_ID) {
+    return {
+      user: { ...SEED_SELF_PROFILE },
+      openInFriendsView: false,
+      openInSelfProfile: true,
+    };
+  }
   if (vrcUserId === E2E_TEST_USER_ID) {
     return {
       user: {

--- a/frontend/e2e/fixtures/seed-data.ts
+++ b/frontend/e2e/fixtures/seed-data.ts
@@ -78,6 +78,7 @@ export interface SeedAutomationRule {
 export interface SeedUserProfileNavigation {
   user: SeedFriend;
   openInFriendsView: boolean;
+  openInSelfProfile: boolean;
 }
 
 /** ResolveUserProfileNavigation / user-profile ルート用の代表ユーザー ID */
@@ -254,6 +255,7 @@ export function seedUserProfileNavigation(
         bio: "E2E テスト用ユーザーです。",
       },
       openInFriendsView: false,
+      openInSelfProfile: false,
     };
   }
   return {
@@ -265,6 +267,7 @@ export function seedUserProfileNavigation(
       lastUpdated: "",
     },
     openInFriendsView: false,
+    openInSelfProfile: false,
   };
 }
 

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -13,13 +13,14 @@ const MAIN_SIDEBAR_PATHS = [
   "/gallery",
   "/activity",
   "/friends",
+  "/me",
   "/automation",
   "/config",
 ] as const;
 
 /**
- * navigation.spec.ts + gallery.spec.ts で専用のナビ／ロードテストを持つルート名。
- * APP_ROUTES 11 件のうち 10 件以上（90%）を E2E でカバーする目標。
+ * navigation.spec.ts + gallery.spec.ts + self-profile.spec.ts で専用のナビ／ロードテストを持つルート名。
+ * APP_ROUTES 12 件のうち 10 件以上（90%）を E2E でカバーする目標。
  */
 const ROUTES_WITH_DEDICATED_E2E_TESTS = new Set([
   "dashboard",
@@ -27,6 +28,7 @@ const ROUTES_WITH_DEDICATED_E2E_TESTS = new Set([
   "gallery",
   "activity",
   "friends",
+  "me",
   "automation",
   "config",
   "settings",
@@ -109,6 +111,6 @@ test.describe("Navigation", () => {
       covered.length,
       `expected >= ${minCovered}/${total} routes covered, got ${covered.length}: ${covered.map((r) => r.name).join(", ")}`,
     ).toBeGreaterThanOrEqual(minCovered);
-    expect(covered.length).toBeGreaterThanOrEqual(10);
+    expect(covered.length).toBeGreaterThanOrEqual(11);
   });
 });

--- a/frontend/e2e/self-profile.spec.ts
+++ b/frontend/e2e/self-profile.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+import { getMockWailsInitScript } from "./fixtures/mock-wails";
+import { E2E_SELF_DISPLAY_NAME, E2E_SELF_USER_ID } from "./fixtures/seed-data";
+
+test.describe("Self profile (not logged in)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(getMockWailsInitScript());
+  });
+
+  test("shows login hint at /me", async ({ page }) => {
+    await page.goto("/#/me");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("自分");
+    await expect(page.locator(".login-hint")).toContainText(
+      "ログインが必要です",
+    );
+  });
+
+  test("login hint links to settings", async ({ page }) => {
+    await page.goto("/#/me");
+    await page.locator(".settings-link").click();
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("設定");
+  });
+
+  test("sidebar navigates to /me", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("menuitem", { name: "自分" }).click();
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("自分");
+    await expect(page.locator(".login-hint")).toBeVisible();
+  });
+});
+
+test.describe("Self profile (logged in)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(getMockWailsInitScript({ loggedIn: true }));
+  });
+
+  test("shows self profile display name", async ({ page }) => {
+    await page.goto("/#/me");
+    await expect(page.getByText("読み込み中")).toBeHidden({ timeout: 15_000 });
+    await expect(page.locator(".profile-display-name")).toHaveText(
+      E2E_SELF_DISPLAY_NAME,
+    );
+  });
+
+  test("hides favorite and encounters tab in self variant", async ({
+    page,
+  }) => {
+    await page.goto("/#/me");
+    await expect(page.getByText("読み込み中")).toBeHidden({ timeout: 15_000 });
+    await expect(page.getByText("お気に入り")).toBeHidden();
+    await expect(page.getByRole("tab", { name: "遭遇履歴" })).toBeHidden();
+    await expect(page.getByTestId("self-profile-refresh")).toBeVisible();
+  });
+
+  test("refresh button updates profile", async ({ page }) => {
+    await page.goto("/#/me");
+    await expect(page.getByText("読み込み中")).toBeHidden({ timeout: 15_000 });
+    await expect(page.locator(".profile-status-desc")).toContainText(
+      "E2E 自己プロフィール",
+    );
+    await page.getByTestId("self-profile-refresh").click();
+    await expect(page.locator(".profile-status-desc")).toContainText(
+      "E2E refreshed 1",
+    );
+  });
+
+  test("settings view details navigates to /me", async ({ page }) => {
+    await page.goto("/#/settings");
+    await expect(page.getByTestId("settings-view-self-profile")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByTestId("settings-view-self-profile").click();
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("自分");
+    await expect(page.locator(".profile-display-name")).toHaveText(
+      E2E_SELF_DISPLAY_NAME,
+    );
+  });
+
+  test("user-profile redirects to /me for self vrcUserId", async ({ page }) => {
+    const qs = new URLSearchParams({
+      vrcUserId: E2E_SELF_USER_ID,
+      displayName: E2E_SELF_DISPLAY_NAME,
+    });
+    await page.goto(`/#/user-profile?${qs}`);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("自分");
+    await expect(page.locator(".profile-display-name")).toHaveText(
+      E2E_SELF_DISPLAY_NAME,
+    );
+  });
+});

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -34,6 +34,7 @@ const menuItems = computed(() => [
   { path: "/launcher", icon: "🚀", label: t("nav.launcher") },
   { path: "/gallery", icon: "🖼️", label: t("nav.gallery") },
   { path: "/activity", icon: "📊", label: t("nav.activity") },
+  { path: "/me", icon: "👤", label: t("nav.me") },
   { path: "/friends", icon: "👥", label: t("nav.friends") },
   { path: "/automation", icon: "🤖", label: t("nav.automation") },
   { path: "/config", icon: "📝", label: t("nav.configOther") },

--- a/frontend/src/components/VrcUserCacheDetail.vue
+++ b/frontend/src/components/VrcUserCacheDetail.vue
@@ -48,7 +48,7 @@
             />
             <div v-else class="profile-avatar profile-avatar--placeholder" />
           </div>
-          <div class="profile-toolbar-actions">
+          <div v-if="variant !== 'self'" class="profile-toolbar-actions">
             <el-checkbox
               :model-value="selected.isFavorite"
               @update:model-value="onFavoriteUpdate"
@@ -97,8 +97,22 @@
       </div>
 
       <div class="profile-details-wrap">
-        <el-tabs v-model="detailTab" class="profile-detail-tabs">
+        <el-tabs
+          v-model="detailTab"
+          class="profile-detail-tabs"
+          :class="{ 'profile-detail-tabs--self': variant === 'self' }"
+        >
           <el-tab-pane :label="t('userDetail.tabDetail')" name="detail">
+            <div v-if="variant === 'self'" class="self-profile-actions">
+              <el-button
+                type="primary"
+                data-testid="self-profile-refresh"
+                :loading="refreshLoading"
+                @click="emit('refresh')"
+              >
+                {{ t("selfProfile.refresh") }}
+              </el-button>
+            </div>
             <el-descriptions :column="1" border size="small">
               <el-descriptions-item
                 v-if="selected.state"
@@ -244,6 +258,7 @@
             </el-descriptions>
           </el-tab-pane>
           <el-tab-pane
+            v-if="variant !== 'self'"
             :label="t('userDetail.tabEncounters')"
             name="encounters"
             lazy
@@ -277,9 +292,17 @@ import {
 
 const { t } = useI18n();
 
-const props = defineProps<{
-  selected: UserCacheDTO | null;
-}>();
+const props = withDefaults(
+  defineProps<{
+    selected: UserCacheDTO | null;
+    variant?: "default" | "self";
+    refreshLoading?: boolean;
+  }>(),
+  {
+    variant: "default",
+    refreshLoading: false,
+  },
+);
 
 const detailTab = ref<"detail" | "encounters">("detail");
 
@@ -310,6 +333,7 @@ function attachCardBodyScroll() {
 
 const emit = defineEmits<{
   favoriteChange: [user: UserCacheDTO, isFavorite: boolean];
+  refresh: [];
 }>();
 
 const bannerSrc = computed(() =>
@@ -609,6 +633,14 @@ onUnmounted(() => {
 
 .profile-detail-tabs {
   min-height: 0;
+}
+
+.profile-detail-tabs--self :deep(.el-tabs__header) {
+  display: none;
+}
+
+.self-profile-actions {
+  margin-bottom: 0.75rem;
 }
 
 .profile-detail-tabs :deep(.el-tabs__header) {

--- a/frontend/src/components/__tests__/VrcUserCacheDetail.spec.ts
+++ b/frontend/src/components/__tests__/VrcUserCacheDetail.spec.ts
@@ -260,4 +260,29 @@ describe("VrcUserCacheDetail", () => {
     expect(wrapper.find(".profile-avatar--placeholder").exists()).toBe(true);
     expect(wrapper.find(".profile-banner-fallback").exists()).toBe(true);
   });
+
+  it("self variant hides favorite and encounters tab", async () => {
+    const wrapper = mount(VrcUserCacheDetail, {
+      props: { selected: minimalUser(), variant: "self" },
+      global: { stubs: { EncounterHistoryList: true } },
+    });
+    await flushPromises();
+
+    expect(wrapper.find(".profile-toolbar-actions").exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("遭遇履歴");
+    expect(wrapper.find('[data-testid="self-profile-refresh"]').exists()).toBe(
+      true,
+    );
+  });
+
+  it("self variant emits refresh when refresh button clicked", async () => {
+    const wrapper = mount(VrcUserCacheDetail, {
+      props: { selected: minimalUser(), variant: "self" },
+      global: { stubs: { EncounterHistoryList: true } },
+    });
+    await flushPromises();
+
+    await wrapper.find('[data-testid="self-profile-refresh"]').trigger("click");
+    expect(wrapper.emitted("refresh")).toHaveLength(1);
+  });
 });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
     "activity": "Activity",
     "encounterHistory": "Encounter history",
     "friends": "Friends",
+    "me": "Me",
     "user": "User",
     "automation": "Automation",
     "configOther": "Other settings",
@@ -21,6 +22,7 @@
     "gallery": "Gallery",
     "activity": "Activity",
     "friends": "Friends",
+    "me": "Me",
     "automation": "Automation",
     "configOther": "Other settings",
     "settings": "Settings"
@@ -210,6 +212,14 @@
     "idMissing": "No user ID specified.",
     "loadFailed": "Could not load profile. Check cache or login state."
   },
+  "selfProfile": {
+    "title": "Me",
+    "loading": "Loading…",
+    "loginRequired": "Log in to view your profile.",
+    "openSettings": "Log in in Settings",
+    "loadFailed": "Could not load profile.",
+    "refresh": "Refresh profile"
+  },
   "automation": {
     "title": "Automation",
     "intro": "IF–THEN rules run actions when a trigger fires.",
@@ -257,6 +267,7 @@
     "statusLine": "Status:",
     "loggedInTag": "Logged in",
     "refreshProfile": "Refresh profile",
+    "viewSelfProfile": "View details",
     "refreshFriends": "Refresh friends list",
     "logout": "Log out",
     "username": "Username",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -9,6 +9,7 @@
     "activity": "アクティビティ",
     "encounterHistory": "遭遇履歴",
     "friends": "フレンド",
+    "me": "自分",
     "user": "ユーザー",
     "automation": "オートメーション",
     "configOther": "その他の設定",
@@ -21,6 +22,7 @@
     "gallery": "ギャラリー",
     "activity": "アクティビティ",
     "friends": "フレンド",
+    "me": "自分",
     "automation": "オートメーション",
     "configOther": "その他の設定",
     "settings": "設定"
@@ -210,6 +212,14 @@
     "idMissing": "ユーザー ID が指定されていません。",
     "loadFailed": "プロフィールを取得できませんでした。キャッシュまたはログイン状態を確認してください。"
   },
+  "selfProfile": {
+    "title": "自分",
+    "loading": "読み込み中…",
+    "loginRequired": "プロフィールを表示するにはログインが必要です。",
+    "openSettings": "設定画面でログイン",
+    "loadFailed": "プロフィールを取得できませんでした。",
+    "refresh": "プロフィール再取得"
+  },
   "automation": {
     "title": "オートメーション",
     "intro": "IF-THEN 形式のルールで、トリガー発生時にアクションを実行します。",
@@ -257,6 +267,7 @@
     "statusLine": "ステータス:",
     "loggedInTag": "ログイン済み",
     "refreshProfile": "プロフィール再取得",
+    "viewSelfProfile": "詳細を見る",
     "refreshFriends": "フレンド一覧を更新",
     "logout": "ログアウト",
     "username": "ユーザー名",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -9,6 +9,7 @@
     "activity": "활동",
     "encounterHistory": "조우 기록",
     "friends": "친구",
+    "me": "나",
     "user": "사용자",
     "automation": "자동화",
     "configOther": "기타 설정",
@@ -21,6 +22,7 @@
     "gallery": "갤러리",
     "activity": "활동",
     "friends": "친구",
+    "me": "나",
     "automation": "자동화",
     "configOther": "기타 설정",
     "settings": "설정"
@@ -210,6 +212,14 @@
     "idMissing": "사용자 ID가 지정되지 않았습니다.",
     "loadFailed": "프로필을 가져올 수 없습니다. 캐시 또는 로그인 상태를 확인하세요."
   },
+  "selfProfile": {
+    "title": "나",
+    "loading": "불러오는 중…",
+    "loginRequired": "프로필을 보려면 로그인이 필요합니다.",
+    "openSettings": "설정에서 로그인",
+    "loadFailed": "프로필을 가져올 수 없습니다.",
+    "refresh": "프로필 새로고침"
+  },
   "automation": {
     "title": "자동화",
     "intro": "IF–THEN 규칙으로 트리거 시 동작을 실행합니다.",
@@ -257,6 +267,7 @@
     "statusLine": "상태:",
     "loggedInTag": "로그인됨",
     "refreshProfile": "프로필 다시 가져오기",
+    "viewSelfProfile": "자세히 보기",
     "refreshFriends": "친구 목록 새로 고침",
     "logout": "로그아웃",
     "username": "사용자 이름",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -9,6 +9,7 @@
     "activity": "活动",
     "encounterHistory": "相遇记录",
     "friends": "好友",
+    "me": "我",
     "user": "用户",
     "automation": "自动化",
     "configOther": "其他设置",
@@ -21,6 +22,7 @@
     "gallery": "相册",
     "activity": "活动",
     "friends": "好友",
+    "me": "我",
     "automation": "自动化",
     "configOther": "其他设置",
     "settings": "设置"
@@ -210,6 +212,14 @@
     "idMissing": "未指定用户 ID。",
     "loadFailed": "无法加载个人资料。请检查缓存或登录状态。"
   },
+  "selfProfile": {
+    "title": "我",
+    "loading": "加载中…",
+    "loginRequired": "查看个人资料需要先登录。",
+    "openSettings": "前往设置登录",
+    "loadFailed": "无法加载个人资料。",
+    "refresh": "重新获取个人资料"
+  },
   "automation": {
     "title": "自动化",
     "intro": "使用 IF–THEN 规则在触发时执行操作。",
@@ -257,6 +267,7 @@
     "statusLine": "状态：",
     "loggedInTag": "已登录",
     "refreshProfile": "重新获取个人资料",
+    "viewSelfProfile": "查看详情",
     "refreshFriends": "更新好友列表",
     "logout": "退出登录",
     "username": "用户名",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -9,6 +9,7 @@
     "activity": "活動",
     "encounterHistory": "相遇紀錄",
     "friends": "好友",
+    "me": "我",
     "user": "使用者",
     "automation": "自動化",
     "configOther": "其他設定",
@@ -21,6 +22,7 @@
     "gallery": "相簿",
     "activity": "活動",
     "friends": "好友",
+    "me": "我",
     "automation": "自動化",
     "configOther": "其他設定",
     "settings": "設定"
@@ -210,6 +212,14 @@
     "idMissing": "未指定使用者 ID。",
     "loadFailed": "無法載入個人資料。請檢查快取或登入狀態。"
   },
+  "selfProfile": {
+    "title": "我",
+    "loading": "載入中…",
+    "loginRequired": "檢視個人資料需要先登入。",
+    "openSettings": "前往設定登入",
+    "loadFailed": "無法載入個人資料。",
+    "refresh": "重新取得個人資料"
+  },
   "automation": {
     "title": "自動化",
     "intro": "使用 IF–THEN 規則在觸發時執行動作。",
@@ -257,6 +267,7 @@
     "statusLine": "狀態：",
     "loggedInTag": "已登入",
     "refreshProfile": "重新取得個人資料",
+    "viewSelfProfile": "查看詳情",
     "refreshFriends": "更新好友列表",
     "logout": "登出",
     "username": "使用者名稱",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -49,6 +49,12 @@ const routes: RouteRecordRaw[] = [
     meta: { titleKey: "routes.encounterHistory", bare: true },
   },
   {
+    path: "/me",
+    name: "me",
+    component: () => import("./views/SelfProfileView.vue"),
+    meta: { titleKey: "routes.me" },
+  },
+  {
     path: "/friends",
     name: "friends",
     component: () => import("./views/FriendsView.vue"),

--- a/frontend/src/utils/__tests__/userProfileNavigation.spec.ts
+++ b/frontend/src/utils/__tests__/userProfileNavigation.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRouter, createWebHashHistory } from "vue-router";
+import { navigateToUserProfile } from "../userProfileNavigation";
+import { App } from "../../wails/app";
+
+describe("navigateToUserProfile", () => {
+  let router: ReturnType<typeof createRouter>;
+
+  beforeEach(async () => {
+    router = createRouter({
+      history: createWebHashHistory(),
+      routes: [
+        { path: "/me", name: "me", component: { template: "<div/>" } },
+        {
+          path: "/friends",
+          name: "friends",
+          component: { template: "<div/>" },
+        },
+        {
+          path: "/user-profile",
+          name: "user-profile",
+          component: { template: "<div/>" },
+        },
+      ],
+    });
+    await router.push("/");
+    await router.isReady();
+    vi.spyOn(router, "push");
+  });
+
+  it("navigates to me when openInSelfProfile", async () => {
+    vi.spyOn(App, "resolveUserProfileNavigation").mockResolvedValue({
+      openInFriendsView: false,
+      openInSelfProfile: true,
+      user: {
+        vrcUserId: "usr_me",
+        displayName: "Me",
+        status: "",
+        isFavorite: false,
+        lastUpdated: "",
+      },
+    });
+
+    await navigateToUserProfile(router, "usr_me", "Me");
+    expect(router.push).toHaveBeenCalledWith({ name: "me" });
+  });
+
+  it("navigates to friends when openInFriendsView", async () => {
+    vi.spyOn(App, "resolveUserProfileNavigation").mockResolvedValue({
+      openInFriendsView: true,
+      openInSelfProfile: false,
+      user: {
+        vrcUserId: "u1",
+        displayName: "Friend",
+        status: "",
+        isFavorite: false,
+        lastUpdated: "",
+      },
+    });
+
+    await navigateToUserProfile(router, "u1");
+    expect(router.push).toHaveBeenCalledWith({
+      name: "friends",
+      query: { vrcUserId: "u1" },
+    });
+  });
+});

--- a/frontend/src/utils/userProfileNavigation.ts
+++ b/frontend/src/utils/userProfileNavigation.ts
@@ -1,0 +1,30 @@
+import type { Router } from "vue-router";
+import { App } from "../wails/app";
+
+export async function navigateToUserProfile(
+  router: Router,
+  vrcUserId: string,
+  displayName = "",
+): Promise<void> {
+  if (!vrcUserId) return;
+  try {
+    const nav = await App.resolveUserProfileNavigation(vrcUserId);
+    if (nav.openInSelfProfile) {
+      await router.push({ name: "me" });
+      return;
+    }
+    if (nav.openInFriendsView) {
+      await router.push({ name: "friends", query: { vrcUserId } });
+      return;
+    }
+    await router.push({
+      name: "user-profile",
+      query: { vrcUserId, displayName },
+    });
+  } catch {
+    await router.push({
+      name: "user-profile",
+      query: { vrcUserId, displayName },
+    });
+  }
+}

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -127,6 +127,7 @@ import PlayTimeChart, {
   type PlayTimeDayPoint,
 } from "../components/PlayTimeChart.vue";
 import { openEncounterHistoryWindow } from "../utils/openEncounterHistoryWindow";
+import { navigateToUserProfile } from "../utils/userProfileNavigation";
 import {
   addLocalDays,
   eachLocalDateISO,
@@ -208,23 +209,7 @@ function formatDateShort(dateStr: string): string {
 async function openUserFromEncounter(row: UserEncounterDTO): Promise<void> {
   const vrcUserId = row.vrcUserId;
   if (!vrcUserId) return;
-  const displayName = row.displayName ?? "";
-  try {
-    const nav = await App.resolveUserProfileNavigation(vrcUserId);
-    if (nav.openInFriendsView) {
-      await router.push({ name: "friends", query: { vrcUserId } });
-    } else {
-      await router.push({
-        name: "user-profile",
-        query: { vrcUserId, displayName },
-      });
-    }
-  } catch {
-    await router.push({
-      name: "user-profile",
-      query: { vrcUserId, displayName },
-    });
-  }
+  await navigateToUserProfile(router, vrcUserId, row.displayName ?? "");
 }
 
 function openWorldHistory(worldId: string): void {

--- a/frontend/src/views/FriendsView.vue
+++ b/frontend/src/views/FriendsView.vue
@@ -135,6 +135,16 @@ async function stripVrcUserIdFromQuery(): Promise<void> {
 async function applyVrcUserIdFromQuery(): Promise<void> {
   const id = firstQueryString(route.query.vrcUserId).trim();
   if (!id) return;
+  try {
+    const nav = await App.resolveUserProfileNavigation(id);
+    if (nav.openInSelfProfile) {
+      await router.push({ name: "me" });
+      await stripVrcUserIdFromQuery();
+      return;
+    }
+  } catch {
+    /* fall through to friends list lookup */
+  }
   let f = friends.value.find((x) => x.vrcUserId === id);
   if (!f) {
     await loadFriends();

--- a/frontend/src/views/SelfProfileView.vue
+++ b/frontend/src/views/SelfProfileView.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="self-profile-view">
+    <h1 class="page-title">{{ t("selfProfile.title") }}</h1>
+    <el-alert
+      v-if="!isLoggedIn"
+      :title="t('selfProfile.loginRequired')"
+      type="info"
+      :closable="false"
+      show-icon
+      class="login-hint"
+    >
+      <template #default>
+        <router-link class="settings-link" :to="{ name: 'settings' }">
+          {{ t("selfProfile.openSettings") }}
+        </router-link>
+      </template>
+    </el-alert>
+    <div v-else-if="loading" class="msg">{{ t("selfProfile.loading") }}</div>
+    <el-alert
+      v-else-if="loadError && !selected"
+      :title="loadError"
+      type="warning"
+      :closable="false"
+      show-icon
+    />
+    <div v-else-if="selected" class="detail-wrap">
+      <VrcUserCacheDetail
+        variant="self"
+        :selected="selected"
+        :refresh-loading="refreshLoading"
+        @refresh="onRefresh"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import VrcUserCacheDetail from "../components/VrcUserCacheDetail.vue";
+import { useSessionUnlock } from "../composables/useSessionUnlock";
+import { App } from "../wails/app";
+import type { UserCacheDTO } from "../wails/app";
+
+const { t } = useI18n();
+const { beginStartupUnlock } = useSessionUnlock();
+
+const isLoggedIn = ref(false);
+const loading = ref(true);
+const refreshLoading = ref(false);
+const loadError = ref<string | null>(null);
+const selected = ref<UserCacheDTO | null>(null);
+
+function formatBackendError(e: unknown, fallback: string): string {
+  if (e instanceof Error && e.message) return e.message;
+  if (typeof e === "string" && e) return e;
+  return fallback;
+}
+
+async function load(forceRefresh = false): Promise<void> {
+  if (!isLoggedIn.value) {
+    loading.value = false;
+    selected.value = null;
+    loadError.value = null;
+    return;
+  }
+  loadError.value = null;
+  if (forceRefresh) {
+    refreshLoading.value = true;
+  } else {
+    loading.value = true;
+  }
+  try {
+    selected.value = await App.getSelfProfile(forceRefresh);
+  } catch (e) {
+    selected.value = null;
+    loadError.value = formatBackendError(e, t("selfProfile.loadFailed"));
+  } finally {
+    loading.value = false;
+    refreshLoading.value = false;
+  }
+}
+
+async function onRefresh(): Promise<void> {
+  await load(true);
+}
+
+onMounted(async () => {
+  await beginStartupUnlock().catch(() => undefined);
+  isLoggedIn.value = await App.isLoggedIn();
+  await load();
+});
+</script>
+
+<style scoped>
+.self-profile-view {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.login-hint {
+  margin-bottom: 1rem;
+}
+
+.settings-link {
+  color: var(--el-color-primary);
+  text-decoration: none;
+}
+
+.settings-link:hover {
+  text-decoration: underline;
+}
+
+.msg {
+  padding: 1rem;
+  color: var(--text-secondary);
+}
+
+.detail-wrap {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  width: 100%;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -29,10 +29,10 @@
         <span>{{ t("settings.loginSection") }}</span>
       </template>
       <div v-if="isLoggedIn" class="login-status">
-        <div v-if="profileLoading && !currentUser" class="profile-loading">
+        <div v-if="profileLoading && !selfProfile" class="profile-loading">
           {{ t("settings.profileLoading") }}
         </div>
-        <div v-else-if="currentUser" class="current-user-card">
+        <div v-else-if="selfProfile" class="current-user-card">
           <img
             v-if="avatarDisplayUrl"
             :src="avatarDisplayUrl"
@@ -43,25 +43,32 @@
           />
           <div class="current-user-details">
             <p class="current-user-display-name">
-              {{ currentUser.displayName || t("settings.noDisplayName") }}
+              {{ selfProfile.displayName || t("settings.noDisplayName") }}
             </p>
-            <p v-if="currentUser.username" class="current-user-line">
-              @{{ currentUser.username }}
+            <p v-if="selfProfile.username" class="current-user-line">
+              @{{ selfProfile.username }}
             </p>
-            <p v-if="currentUser.id" class="current-user-line muted">
-              {{ currentUser.id }}
+            <p v-if="selfProfile.vrcUserId" class="current-user-line muted">
+              {{ selfProfile.vrcUserId }}
             </p>
             <p class="current-user-line">
               {{ t("settings.statusLine") }}
-              {{ currentUser.status || t("common.dash") }} /
-              {{ currentUser.state || t("common.dash") }}
+              {{ selfProfile.status || t("common.dash") }} /
+              {{ selfProfile.state || t("common.dash") }}
             </p>
             <p
-              v-if="currentUser.statusDescription"
+              v-if="selfProfile.statusDescription"
               class="current-user-line muted"
             >
-              {{ currentUser.statusDescription }}
+              {{ selfProfile.statusDescription }}
             </p>
+            <router-link
+              :to="{ name: 'me' }"
+              class="self-profile-link"
+              data-testid="settings-view-self-profile"
+            >
+              {{ t("settings.viewSelfProfile") }}
+            </router-link>
           </div>
         </div>
         <el-alert
@@ -78,7 +85,7 @@
           <el-button
             type="primary"
             :loading="profileLoading"
-            @click="loadCurrentUser(true)"
+            @click="loadSelfProfileSummary(true)"
           >
             {{ t("settings.refreshProfile") }}
           </el-button>
@@ -312,7 +319,8 @@ import { ref, reactive, computed, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { ElMessageBox, ElMessage } from "element-plus";
 import { App } from "../wails/app";
-import type { PathSettingsDTO, VRChatCurrentUserDTO } from "../wails/app";
+import type { PathSettingsDTO, UserCacheDTO } from "../wails/app";
+import { friendThumbUrl } from "../utils/vrcUserCacheDisplay";
 import { useSessionUnlock } from "../composables/useSessionUnlock";
 import { isAppLocale, setLanguage } from "../i18n";
 
@@ -327,19 +335,14 @@ const {
 const { t, locale } = useI18n();
 
 const isLoggedIn = ref(false);
-const currentUser = ref<VRChatCurrentUserDTO | null>(null);
+const selfProfile = ref<UserCacheDTO | null>(null);
 const profileLoading = ref(false);
 const profileError = ref("");
 
 const avatarDisplayUrl = computed(() => {
-  const u = currentUser.value;
+  const u = selfProfile.value;
   if (!u) return "";
-  return (
-    u.profilePicOverrideThumbnail ||
-    u.currentAvatarThumbnailImageUrl ||
-    u.userIcon ||
-    ""
-  );
+  return friendThumbUrl(u) ?? "";
 });
 
 function formatBackendError(e: unknown, fallback: string): string {
@@ -449,7 +452,7 @@ onMounted(async () => {
     isLoggedIn.value = false;
   }
   if (isLoggedIn.value) {
-    await loadCurrentUser();
+    await loadSelfProfileSummary();
   }
   logRetentionDays.value = await App.getLogRetentionDays();
   suppressSleepWhileVRChat.value = await App.getSuppressSleepWhileVRChat();
@@ -459,13 +462,13 @@ onMounted(async () => {
   pathSettings.outputLogPath = ps.outputLogPath;
 });
 
-async function loadCurrentUser(forceRefresh = false) {
+async function loadSelfProfileSummary(forceRefresh = false) {
   profileError.value = "";
   profileLoading.value = true;
   try {
-    currentUser.value = await App.getVRChatCurrentUser(forceRefresh);
+    selfProfile.value = await App.getSelfProfile(forceRefresh);
   } catch (e) {
-    currentUser.value = null;
+    selfProfile.value = null;
     profileError.value = formatBackendError(e, t("settings.errProfile"));
   } finally {
     profileLoading.value = false;
@@ -491,7 +494,7 @@ async function login() {
       if (result.plaintextToken) {
         await persistAfterLogin(result.plaintextToken);
       }
-      await loadCurrentUser();
+      await loadSelfProfileSummary();
     } else {
       loginError.value = result.error || t("settings.errLogin");
     }
@@ -503,7 +506,7 @@ async function login() {
 async function logout() {
   loginError.value = "";
   profileError.value = "";
-  currentUser.value = null;
+  selfProfile.value = null;
   try {
     await App.logout();
   } catch (e) {
@@ -675,7 +678,7 @@ function doClearFriendsCache() {
     t("settings.clearFriendsConfirm"),
     async () => App.clearFriendsCache(),
     (n) => {
-      currentUser.value = null;
+      selfProfile.value = null;
       profileError.value = "";
       return t("settings.clearFriendsDone", { n: String(n ?? 0) });
     },
@@ -745,6 +748,18 @@ function doClearFriendsCache() {
 
 .current-user-line.muted {
   color: var(--text-secondary);
+}
+
+.self-profile-link {
+  display: inline-block;
+  margin-top: 0.65rem;
+  color: var(--el-color-primary);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.self-profile-link:hover {
+  text-decoration: underline;
 }
 
 .login-actions {

--- a/frontend/src/views/UserProfileDetailView.vue
+++ b/frontend/src/views/UserProfileDetailView.vue
@@ -20,13 +20,14 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import VrcUserCacheDetail from "../components/VrcUserCacheDetail.vue";
 import { App } from "../wails/app";
 import type { UserCacheDTO } from "../wails/app";
 
 const route = useRoute();
+const router = useRouter();
 const { t } = useI18n();
 
 const loading = ref(true);
@@ -70,6 +71,10 @@ async function load(): Promise<void> {
   }
   try {
     const nav = await App.resolveUserProfileNavigation(vrcUserId);
+    if (nav.openInSelfProfile) {
+      await router.replace({ name: "me" });
+      return;
+    }
     selected.value = nav.user;
     if (!selected.value?.vrcUserId) {
       selected.value = minimalFromQuery(vrcUserId, hint);

--- a/frontend/src/views/__tests__/ActivityView.spec.ts
+++ b/frontend/src/views/__tests__/ActivityView.spec.ts
@@ -17,6 +17,7 @@ const {
   mockGetLogRetentionDays: vi.fn().mockResolvedValue(30),
   mockResolveUserProfileNavigation: vi.fn().mockResolvedValue({
     openInFriendsView: false,
+    openInSelfProfile: false,
     user: {
       vrcUserId: "stub",
       displayName: "Stub",
@@ -184,6 +185,7 @@ describe("ActivityView", () => {
     ]);
     mockResolveUserProfileNavigation.mockResolvedValue({
       openInFriendsView: true,
+      openInSelfProfile: false,
       user: {
         vrcUserId: "u1",
         displayName: "EncUser",
@@ -241,6 +243,7 @@ describe("ActivityView", () => {
     ]);
     mockResolveUserProfileNavigation.mockResolvedValue({
       openInFriendsView: false,
+      openInSelfProfile: false,
       user: {
         vrcUserId: "u2",
         displayName: "Stranger",
@@ -283,6 +286,50 @@ describe("ActivityView", () => {
       name: "user-profile",
       query: { vrcUserId: "u2", displayName: "Stranger" },
     });
+  });
+
+  it("display name click pushes me route when resolve says self", async () => {
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "usr_self",
+        displayName: "Me",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+      },
+    ]);
+    mockResolveUserProfileNavigation.mockResolvedValue({
+      openInFriendsView: false,
+      openInSelfProfile: true,
+      user: {
+        vrcUserId: "usr_self",
+        displayName: "Me",
+        status: "active",
+        isFavorite: false,
+        lastUpdated: "",
+      },
+    });
+
+    const router = createRouter({
+      history: createWebHashHistory(),
+      routes: [
+        { path: "/activity", component: ActivityView },
+        { path: "/me", name: "me", component: { template: "<div/>" } },
+      ],
+    });
+    await router.push("/activity");
+    await router.isReady();
+    const pushSpy = vi.spyOn(router, "push");
+
+    const wrapper = mount(ActivityView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+
+    await wrapper.find(".timeline-link").trigger("click");
+    await flushPromises();
+
+    expect(pushSpy).toHaveBeenCalledWith({ name: "me" });
   });
 
   it("display name click falls back to user-profile when resolve rejects", async () => {

--- a/frontend/src/views/__tests__/SelfProfileView.spec.ts
+++ b/frontend/src/views/__tests__/SelfProfileView.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createRouter, createWebHashHistory } from "vue-router";
+import SelfProfileView from "../SelfProfileView.vue";
+import { App } from "../../wails/app";
+import { resetSessionUnlockForStorybook } from "../../composables/useSessionUnlock";
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: "/me", component: SelfProfileView },
+    { path: "/settings", name: "settings", component: { template: "<div/>" } },
+  ],
+});
+
+const sampleSelf = {
+  vrcUserId: "usr_me",
+  displayName: "Self User",
+  status: "active",
+  isFavorite: false,
+  lastUpdated: "2025-01-01T00:00:00Z",
+};
+
+describe("SelfProfileView", () => {
+  beforeEach(async () => {
+    resetSessionUnlockForStorybook();
+    await router.push("/me");
+    await router.isReady();
+    vi.spyOn(App, "isLoggedIn").mockResolvedValue(false);
+    vi.spyOn(App, "getSelfProfile").mockResolvedValue(sampleSelf);
+  });
+
+  it("shows login hint when not logged in", async () => {
+    const wrapper = mount(SelfProfileView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("ログインが必要");
+    expect(wrapper.find(".settings-link").attributes("href")).toBe(
+      "#/settings",
+    );
+  });
+
+  it("loads self profile when logged in", async () => {
+    vi.mocked(App.isLoggedIn).mockResolvedValue(true);
+    const wrapper = mount(SelfProfileView, {
+      global: { plugins: [router] },
+    });
+    await flushPromises();
+
+    expect(App.getSelfProfile).toHaveBeenCalledWith(false);
+    expect(wrapper.text()).toContain("Self User");
+  });
+});

--- a/frontend/src/views/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsView.spec.ts
@@ -11,6 +11,7 @@ const router = createRouter({
   history: createWebHashHistory(),
   routes: [
     { path: "/settings", component: SettingsView },
+    { path: "/me", name: "me", component: { template: "<div>Me</div>" } },
     { path: "/licenses", component: { template: "<div>Licenses</div>" } },
   ],
 });
@@ -417,12 +418,14 @@ describe("SettingsView", () => {
 
 describe("SettingsView login and profile", () => {
   const sampleUser = {
-    id: "usr_abc",
+    vrcUserId: "usr_abc",
     displayName: "Test User",
     username: "testuser",
     status: "active",
     statusDescription: "Hello",
     state: "online",
+    isFavorite: false,
+    lastUpdated: "2025-01-01T00:00:00Z",
     currentAvatarThumbnailImageUrl: "https://example.com/avatar.png",
     userIcon: "",
     profilePicOverrideThumbnail: "",
@@ -445,7 +448,7 @@ describe("SettingsView login and profile", () => {
 
   function mountLoggedIn(user = sampleUser) {
     vi.mocked(App.isLoggedIn).mockResolvedValue(true);
-    vi.spyOn(App, "getVRChatCurrentUser").mockResolvedValue(user);
+    vi.spyOn(App, "getSelfProfile").mockResolvedValue(user);
     return mountSettings();
   }
 
@@ -459,11 +462,14 @@ describe("SettingsView login and profile", () => {
     expect(wrapper.find(".current-user-avatar").attributes("src")).toBe(
       "https://example.com/avatar.png",
     );
+    expect(
+      wrapper.find('[data-testid="settings-view-self-profile"]').text(),
+    ).toBe("詳細を見る");
   });
 
-  it("shows profile error when getVRChatCurrentUser fails", async () => {
+  it("shows profile error when getSelfProfile fails", async () => {
     vi.mocked(App.isLoggedIn).mockResolvedValue(true);
-    vi.spyOn(App, "getVRChatCurrentUser").mockRejectedValue(
+    vi.spyOn(App, "getSelfProfile").mockRejectedValue(
       new Error("profile unavailable"),
     );
     const wrapper = mountSettings();
@@ -476,7 +482,7 @@ describe("SettingsView login and profile", () => {
 
   it("refreshes profile when refresh button is clicked", async () => {
     const getUser = vi
-      .spyOn(App, "getVRChatCurrentUser")
+      .spyOn(App, "getSelfProfile")
       .mockResolvedValue(sampleUser);
     const wrapper = mountLoggedIn();
     await flushPromises();
@@ -493,7 +499,7 @@ describe("SettingsView login and profile", () => {
 
   it("logs in successfully and loads profile", async () => {
     vi.mocked(App.login).mockResolvedValue({ ok: true });
-    vi.spyOn(App, "getVRChatCurrentUser").mockResolvedValue(sampleUser);
+    vi.spyOn(App, "getSelfProfile").mockResolvedValue(sampleUser);
     const wrapper = mountSettings();
     await flushPromises();
 

--- a/frontend/src/views/__tests__/UserProfileDetailView.spec.ts
+++ b/frontend/src/views/__tests__/UserProfileDetailView.spec.ts
@@ -26,6 +26,7 @@ describe("UserProfileDetailView", () => {
     vi.clearAllMocks();
     mockResolve.mockResolvedValue({
       openInFriendsView: false,
+      openInSelfProfile: false,
       user: {
         vrcUserId: "u1",
         displayName: "Resolved",
@@ -67,6 +68,41 @@ describe("UserProfileDetailView", () => {
     expect(detail.props("selected")?.displayName).toBe("Resolved");
   });
 
+  it("redirects to me when resolve says self profile", async () => {
+    mockResolve.mockResolvedValue({
+      openInFriendsView: false,
+      openInSelfProfile: true,
+      user: {
+        vrcUserId: "usr_me",
+        displayName: "Me",
+        status: "",
+        isFavorite: false,
+        lastUpdated: "",
+      },
+    });
+    const router = createRouter({
+      history: createWebHashHistory(),
+      routes: [
+        {
+          path: "/user-profile",
+          name: "user-profile",
+          component: UserProfileDetailView,
+        },
+        { path: "/me", name: "me", component: { template: "<div/>" } },
+      ],
+    });
+    const replaceSpy = vi.spyOn(router, "replace");
+    await router.push({
+      path: "/user-profile",
+      query: { vrcUserId: "usr_me" },
+    });
+    await router.isReady();
+    mount(UserProfileDetailView, { global: { plugins: [router] } });
+    await flushPromises();
+
+    expect(replaceSpy).toHaveBeenCalledWith({ name: "me" });
+  });
+
   it("uses query displayName as fallback detail when resolve fails", async () => {
     mockResolve.mockRejectedValue(new Error("network"));
     const wrapper = await mountWithQuery({
@@ -89,6 +125,7 @@ describe("UserProfileDetailView", () => {
   it("uses vrcUserId as display name when resolve omits user id", async () => {
     mockResolve.mockResolvedValue({
       openInFriendsView: false,
+      openInSelfProfile: false,
       user: {
         vrcUserId: "",
         displayName: "",
@@ -156,6 +193,7 @@ describe("UserProfileDetailView", () => {
     mockResolve.mockClear();
     mockResolve.mockResolvedValue({
       openInFriendsView: false,
+      openInSelfProfile: false,
       user: {
         vrcUserId: "second-id",
         displayName: "Second",

--- a/frontend/src/views/activityViewStoryDecorator.ts
+++ b/frontend/src/views/activityViewStoryDecorator.ts
@@ -31,6 +31,7 @@ export function activityViewWailsDecorator(
                     lastUpdated: "",
                   },
                   openInFriendsView: false,
+                  openInSelfProfile: false,
                 }),
             } as unknown as NonNullable<
               NonNullable<typeof window.go>["main"]

--- a/frontend/src/views/settingsViewStoryDecorator.ts
+++ b/frontend/src/views/settingsViewStoryDecorator.ts
@@ -1,4 +1,4 @@
-import type { PathSettingsDTO, VRChatCurrentUserDTO } from "../wails/app";
+import type { PathSettingsDTO, UserCacheDTO } from "../wails/app";
 import { resetSessionUnlockForStorybook } from "../composables/useSessionUnlock";
 
 export type SettingsViewWailsPreset =
@@ -15,28 +15,26 @@ const emptyPaths: PathSettingsDTO = {
   outputLogPath: "",
 };
 
-const sampleCurrentUser: VRChatCurrentUserDTO = {
-  id: "usr_storybook_vrc",
+const sampleSelfProfile: UserCacheDTO = {
+  vrcUserId: "usr_storybook_vrc",
   displayName: "ストーリー花子",
   username: "story_hanako",
   status: "join me",
   statusDescription: "Storybook 用の表示です",
   state: "active",
+  isFavorite: false,
+  lastUpdated: "2025-01-01T00:00:00Z",
   currentAvatarThumbnailImageUrl: "",
   userIcon: "",
   profilePicOverrideThumbnail: "",
 };
 
-const emptyCurrentUser: VRChatCurrentUserDTO = {
-  id: "",
+const emptySelfProfile: UserCacheDTO = {
+  vrcUserId: "",
   displayName: "",
-  username: "",
   status: "",
-  statusDescription: "",
-  state: "",
-  currentAvatarThumbnailImageUrl: "",
-  userIcon: "",
-  profilePicOverrideThumbnail: "",
+  isFavorite: false,
+  lastUpdated: "",
 };
 
 /**
@@ -77,9 +75,9 @@ export function settingsViewWailsDecorator(preset: SettingsViewWailsPreset) {
               PersistWrappedCredential: () => Promise.resolve(),
               ClearStoredCredential: () => Promise.resolve(),
               IsLoggedIn: () => Promise.resolve(loggedIn),
-              GetVRChatCurrentUser: (_force?: boolean) =>
+              GetSelfProfile: (_force?: boolean) =>
                 Promise.resolve(
-                  loggedIn ? sampleCurrentUser : emptyCurrentUser,
+                  loggedIn ? sampleSelfProfile : emptySelfProfile,
                 ),
               GetLogRetentionDays: () => Promise.resolve(30),
               SetLogRetentionDays: (_days: number) => Promise.resolve(),

--- a/frontend/src/views/userProfileDetailViewStoryDecorator.ts
+++ b/frontend/src/views/userProfileDetailViewStoryDecorator.ts
@@ -53,6 +53,7 @@ export function userProfileDetailWailsDecorator(
           lastUpdated: "",
         },
         openInFriendsView: false,
+        openInSelfProfile: false,
       }));
 
   return (story: () => unknown) => {

--- a/frontend/src/wails/__tests__/app.spec.ts
+++ b/frontend/src/wails/__tests__/app.spec.ts
@@ -78,6 +78,7 @@ function createMockBindings(): MockAppBindings {
     GetActivityStats: vi.fn(),
     Friends: vi.fn(),
     ResolveUserProfileNavigation: vi.fn(),
+    GetSelfProfile: vi.fn(),
     SetFavorite: vi.fn(),
     SetStatus: vi.fn(),
     SetStatusDescription: vi.fn(),
@@ -174,6 +175,7 @@ const sampleUser: UserCacheDTO = {
 const sampleNavigation: UserProfileNavigationDTO = {
   user: sampleUser,
   openInFriendsView: true,
+  openInSelfProfile: false,
 };
 
 const sampleLoginResult: LoginResultDTO = {
@@ -625,6 +627,18 @@ describe("App bindings", () => {
       expect(mockBindings.ResolveUserProfileNavigation).toHaveBeenCalledWith(
         "usr_abc",
       );
+    });
+
+    it("getSelfProfile delegates to GetSelfProfile", async () => {
+      mockBindings.GetSelfProfile.mockResolvedValue(sampleUser);
+      await expect(App.getSelfProfile()).resolves.toEqual(sampleUser);
+      expect(mockBindings.GetSelfProfile).toHaveBeenCalledWith(false);
+    });
+
+    it("getSelfProfile passes forceRefresh when provided", async () => {
+      mockBindings.GetSelfProfile.mockResolvedValue(sampleUser);
+      await App.getSelfProfile(true);
+      expect(mockBindings.GetSelfProfile).toHaveBeenCalledWith(true);
     });
 
     it("setFavorite delegates to SetFavorite", async () => {

--- a/frontend/src/wails/app.ts
+++ b/frontend/src/wails/app.ts
@@ -118,10 +118,11 @@ export interface UserCacheDTO {
   tagsJson?: string;
 }
 
-/** ResolveUserProfileNavigation の戻り値（フレンド画面 vs ユーザープロフィール画面）。 */
+/** ResolveUserProfileNavigation の戻り値（フレンド画面 vs ユーザープロフィール画面 vs Self profile）。 */
 export interface UserProfileNavigationDTO {
   user: UserCacheDTO;
   openInFriendsView: boolean;
+  openInSelfProfile: boolean;
 }
 
 export interface PathSettingsDTO {
@@ -238,6 +239,7 @@ export interface AppBindings {
   ResolveUserProfileNavigation(
     vrcUserID: string,
   ): Promise<UserProfileNavigationDTO>;
+  GetSelfProfile(forceRefresh?: boolean): Promise<UserCacheDTO>;
   SetFavorite(vrcUserId: string, favorite: boolean): Promise<void>;
   SetStatus(status: string): Promise<void>;
   SetStatusDescription(description: string): Promise<void>;
@@ -574,6 +576,16 @@ export const App = {
         lastUpdated: "",
       },
       openInFriendsView: false,
+      openInSelfProfile: false,
+    });
+  },
+  async getSelfProfile(forceRefresh?: boolean): Promise<UserCacheDTO> {
+    return callApp((a) => a.GetSelfProfile(forceRefresh ?? false), {
+      vrcUserId: "",
+      displayName: "",
+      status: "",
+      isFavorite: false,
+      lastUpdated: "",
     });
   },
   async setFavorite(vrcUserId: string, favorite: boolean): Promise<void> {

--- a/internal/usecase/identity_usecase.go
+++ b/internal/usecase/identity_usecase.go
@@ -417,33 +417,47 @@ var ErrProfileNotInCache = errors.New("user not in cache; log in to load profile
 
 // ResolveUserProfileForNavigation loads or refreshes a user row via cache and GET /users/{id} when logged in.
 // The second return value is true when the row should be shown in the friends list view (user_kind friend).
-func (uc *IdentityUseCase) ResolveUserProfileForNavigation(ctx context.Context, vrcUserID string) (*identity.UserCache, bool, error) {
+// The third is true when the row is the logged-in user (Self profile /me).
+func (uc *IdentityUseCase) ResolveUserProfileForNavigation(ctx context.Context, vrcUserID string) (*identity.UserCache, bool, bool, error) {
 	id := strings.TrimSpace(vrcUserID)
 	if id == "" {
-		return nil, false, fmt.Errorf("empty vrc user id")
-	}
-	row, err := uc.userCacheRepo.GetByVRCUserID(ctx, id)
-	if err != nil {
-		return nil, false, err
+		return nil, false, false, fmt.Errorf("empty vrc user id")
 	}
 	loggedIn, err := uc.IsLoggedIn(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
+	}
+	if loggedIn {
+		isSelf, selfErr := uc.isLoggedInSelfID(ctx, id)
+		if selfErr != nil {
+			return nil, false, false, selfErr
+		}
+		if isSelf {
+			row, profileErr := uc.GetSelfProfile(ctx, false)
+			if profileErr != nil {
+				return nil, false, false, profileErr
+			}
+			return row, false, true, nil
+		}
+	}
+	row, err := uc.userCacheRepo.GetByVRCUserID(ctx, id)
+	if err != nil {
+		return nil, false, false, err
 	}
 	if !loggedIn {
 		if row == nil {
-			return nil, false, ErrProfileNotInCache
+			return nil, false, false, ErrProfileNotInCache
 		}
-		return row, row.UserKind == identity.UserKindFriend, nil
+		return row, row.UserKind == identity.UserKindFriend, false, nil
 	}
 	// Token is already in memory via UnlockSession – no credStore read needed.
 	f, err := uc.apiClient.GetUser(ctx, id)
 	if err != nil {
 		err = uc.handleSessionError(err)
 		if row == nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
-		return row, row.UserKind == identity.UserKindFriend, nil
+		return row, row.UserKind == identity.UserKindFriend, false, nil
 	}
 	now := time.Now()
 	if row == nil {
@@ -452,9 +466,45 @@ func (uc *IdentityUseCase) ResolveUserProfileForNavigation(ctx context.Context, 
 	snap := userCacheFromFriend(*f, row.IsFavorite, now)
 	row.MergeFromGetUserAPI(f.IsFriend, snap, now)
 	if err := uc.userCacheRepo.Save(ctx, row); err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
-	return row, row.UserKind == identity.UserKindFriend, nil
+	return row, row.UserKind == identity.UserKindFriend, false, nil
+}
+
+func (uc *IdentityUseCase) isLoggedInSelfID(ctx context.Context, vrcUserID string) (bool, error) {
+	token := uc.apiClient.GetAuthToken()
+	if token == "" {
+		return false, nil
+	}
+	fp := identity.AuthTokenFingerprint(token)
+	if fp == "" {
+		return false, nil
+	}
+	row, err := uc.userCacheRepo.GetSelfBySessionFingerprint(ctx, fp)
+	if err != nil {
+		return false, err
+	}
+	if row == nil {
+		return false, nil
+	}
+	return row.VRCUserID == vrcUserID, nil
+}
+
+// GetSelfProfile returns the cached self row for the active session, refreshing from the API when forceRefresh is true.
+func (uc *IdentityUseCase) GetSelfProfile(ctx context.Context, forceRefresh bool) (*identity.UserCache, error) {
+	if _, err := uc.GetCurrentUser(ctx, forceRefresh); err != nil {
+		return nil, err
+	}
+	token := uc.apiClient.GetAuthToken()
+	fp := identity.AuthTokenFingerprint(token)
+	row, err := uc.userCacheRepo.GetSelfBySessionFingerprint(ctx, fp)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, errors.New("self profile not in cache")
+	}
+	return row, nil
 }
 
 func jsonStringSlice(s []string) string {

--- a/internal/usecase/identity_usecase_test.go
+++ b/internal/usecase/identity_usecase_test.go
@@ -807,7 +807,7 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_saveError(t *testing.T)
 		getUser: &vrchatapi.Friend{ID: "u9", DisplayName: "Nine", IsFriend: true},
 	}
 	uc := NewIdentityUseCase(userRepo, apiClient, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
-	_, _, err := uc.ResolveUserProfileForNavigation(ctx, "u9")
+	_, _, _, err := uc.ResolveUserProfileForNavigation(ctx, "u9")
 	if err == nil {
 		t.Fatal("expected save error")
 	}
@@ -815,7 +815,7 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_saveError(t *testing.T)
 
 func TestIdentityUseCase_ResolveUserProfileForNavigation_emptyID(t *testing.T) {
 	uc := NewIdentityUseCase(&mockUserCacheRepo{}, &mockAPIClient{}, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
-	_, _, err := uc.ResolveUserProfileForNavigation(context.Background(), "  ")
+	_, _, _, err := uc.ResolveUserProfileForNavigation(context.Background(), "  ")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -1132,9 +1132,12 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_notLoggedIn_cacheHit(t 
 	apiClient := &mockAPIClient{}
 	settingsRepo := newMockSettingsRepo()
 	uc := NewIdentityUseCase(userRepo, apiClient, credStore, settingsRepo)
-	u, openF, err := uc.ResolveUserProfileForNavigation(ctx, "u1")
+	u, openF, openSelf, err := uc.ResolveUserProfileForNavigation(ctx, "u1")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
+	}
+	if openSelf {
+		t.Error("contact should not open self profile")
 	}
 	if openF {
 		t.Error("contact should not use friends view")
@@ -1153,9 +1156,12 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_notLoggedIn_friendOpens
 	row := &identity.UserCache{VRCUserID: "u1", DisplayName: "F", UserKind: identity.UserKindFriend}
 	userRepo := &mockUserCacheRepo{getByID: map[string]*identity.UserCache{"u1": row}}
 	uc := NewIdentityUseCase(userRepo, &mockAPIClient{}, credStore, newMockSettingsRepo())
-	_, openF, err := uc.ResolveUserProfileForNavigation(ctx, "u1")
+	_, openF, openSelf, err := uc.ResolveUserProfileForNavigation(ctx, "u1")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if openSelf {
+		t.Error("friend should not open self profile")
 	}
 	if !openF {
 		t.Error("want openInFriendsView for cached friend")
@@ -1167,7 +1173,7 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_notLoggedIn_miss(t *tes
 	credStore := vrchatapi.NewStubCredentialStore()
 	userRepo := &mockUserCacheRepo{getByID: map[string]*identity.UserCache{}}
 	uc := NewIdentityUseCase(userRepo, &mockAPIClient{}, credStore, newMockSettingsRepo())
-	_, _, err := uc.ResolveUserProfileForNavigation(ctx, "missing")
+	_, _, _, err := uc.ResolveUserProfileForNavigation(ctx, "missing")
 	if !errors.Is(err, ErrProfileNotInCache) {
 		t.Fatalf("want ErrProfileNotInCache, got %v", err)
 	}
@@ -1186,9 +1192,12 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_loggedIn_newContactFrom
 		},
 	}
 	uc := NewIdentityUseCase(userRepo, apiClient, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
-	u, openF, err := uc.ResolveUserProfileForNavigation(ctx, "usr_new")
+	u, openF, openSelf, err := uc.ResolveUserProfileForNavigation(ctx, "usr_new")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if openSelf {
+		t.Error("contact should not open self profile")
 	}
 	if openF {
 		t.Error("non-friend API should not open friends view")
@@ -1214,9 +1223,12 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_loggedIn_friendFromAPI(
 		},
 	}
 	uc := NewIdentityUseCase(userRepo, apiClient, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
-	u, openF, err := uc.ResolveUserProfileForNavigation(ctx, "usr_f")
+	u, openF, openSelf, err := uc.ResolveUserProfileForNavigation(ctx, "usr_f")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if openSelf {
+		t.Error("friend should not open self profile")
 	}
 	if !openF || u.UserKind != identity.UserKindFriend {
 		t.Fatalf("openF=%v kind=%v", openF, u.UserKind)
@@ -1229,12 +1241,89 @@ func TestIdentityUseCase_ResolveUserProfileForNavigation_loggedIn_apiErr_fallsBa
 	userRepo := &mockUserCacheRepo{getByID: map[string]*identity.UserCache{"u1": row}}
 	apiClient := &mockAPIClient{token: "tok", getUserErr: errors.New("network")}
 	uc := NewIdentityUseCase(userRepo, apiClient, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
-	u, openF, err := uc.ResolveUserProfileForNavigation(ctx, "u1")
+	u, openF, openSelf, err := uc.ResolveUserProfileForNavigation(ctx, "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if openSelf {
+		t.Error("cached contact should not open self profile")
+	}
 	if openF || u.DisplayName != "Cached" {
 		t.Fatalf("openF=%v u=%+v", openF, u)
+	}
+}
+
+func TestIdentityUseCase_ResolveUserProfileForNavigation_loggedIn_selfOpensSelfProfile(t *testing.T) {
+	ctx := context.Background()
+	fp := identity.AuthTokenFingerprint("tok-self")
+	selfRow := &identity.UserCache{
+		VRCUserID:          "usr_self",
+		DisplayName:        "Me",
+		UserKind:           identity.UserKindSelf,
+		SessionFingerprint: fp,
+		LastUpdated:        time.Now(),
+	}
+	userRepo := &mockUserCacheRepo{
+		getSelfRow: selfRow,
+		getByID:    map[string]*identity.UserCache{"usr_self": selfRow},
+	}
+	apiClient := &mockAPIClient{
+		token: "tok-self",
+		getCurrentUser: &vrchatapi.CurrentUserProfile{
+			ID:          "usr_self",
+			DisplayName: "Me",
+		},
+	}
+	uc := NewIdentityUseCase(userRepo, apiClient, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
+	u, openF, openSelf, err := uc.ResolveUserProfileForNavigation(ctx, "usr_self")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !openSelf || openF {
+		t.Fatalf("openSelf=%v openF=%v", openSelf, openF)
+	}
+	if u.VRCUserID != "usr_self" || u.UserKind != identity.UserKindSelf {
+		t.Fatalf("user %+v", u)
+	}
+	if apiClient.getUserCalls != 0 {
+		t.Error("GetUser should not run for self navigation")
+	}
+}
+
+func TestIdentityUseCase_GetSelfProfile_ok(t *testing.T) {
+	ctx := context.Background()
+	fp := identity.AuthTokenFingerprint("tok")
+	selfRow := &identity.UserCache{
+		VRCUserID:          "usr_me",
+		DisplayName:        "Self",
+		UserKind:           identity.UserKindSelf,
+		SessionFingerprint: fp,
+		LastUpdated:        time.Now(),
+	}
+	userRepo := &mockUserCacheRepo{getSelfRow: selfRow}
+	apiClient := &mockAPIClient{
+		token: "tok",
+		getCurrentUser: &vrchatapi.CurrentUserProfile{
+			ID:          "usr_me",
+			DisplayName: "Self",
+		},
+	}
+	uc := NewIdentityUseCase(userRepo, apiClient, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
+	got, err := uc.GetSelfProfile(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.VRCUserID != "usr_me" || got.UserKind != identity.UserKindSelf {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestIdentityUseCase_GetSelfProfile_notAuthenticated(t *testing.T) {
+	ctx := context.Background()
+	uc := NewIdentityUseCase(&mockUserCacheRepo{}, &mockAPIClient{}, vrchatapi.NewStubCredentialStore(), newMockSettingsRepo())
+	_, err := uc.GetSelfProfile(ctx, false)
+	if !errors.Is(err, vrchatapi.ErrNotAuthenticated) {
+		t.Fatalf("got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add **Self profile** at `/me` with shared `VrcUserCacheDetail` (`variant="self"`: no favorite/encounters tab, profile refresh on detail)
- Unify profile data on **Cached VRChat user** (`GetSelfProfile` / `users_cache` self row); Settings summary uses the same source with a "View details" link
- Extend **Encounter user navigation** with `openInSelfProfile` so logged-in user always routes to `/me` (not Friends or User profile)
- Document domain terms in `CONTEXT.md` and decisions in ADR 0003

## Test plan

- [x] `make fmt` / `make test` / `make lint`
- [x] `make test-e2e` (45 passed)
- [ ] Log in → Settings shows summary + "詳細を見る" → `/me` shows full profile
- [ ] Sidebar "自分" → `/me` (logged out shows login hint + Settings link)
- [ ] Activity encounter name click routes self to `/me`, friend to Friends, other to User profile


Made with [Cursor](https://cursor.com)