### PR TITLE
fix(activity): prevent duplicate encounter logs and false leave times on restart

### DIFF
--- a/app.go
+++ b/app.go
@@ -415,6 +415,9 @@ func (a *App) startOutputLogWatcher(ctx context.Context, eventBus event.EventBus
 
 	ingestAdapter.SetSuppressEncounterNotify(true)
 	a.ingestActivityLogsBootstrap(ctx, watchPath, parser, ingestAdapter, logger)
+	if _, dedupeErr := a.activity.DeduplicateEncounters(ctx); dedupeErr != nil {
+		runtime.LogWarning(ctx, "activity encounter dedupe: "+dedupeErr.Error())
+	}
 	ingestAdapter.SetSuppressEncounterNotify(false)
 
 	watcher := logwatcher.NewOutputLogWatcher(watchPath, parser, handler, logger)

--- a/app.go
+++ b/app.go
@@ -310,8 +310,10 @@ func (a *App) ingestActivityLogsBootstrap(ctx context.Context, absWatch string, 
 				runtime.LogWarning(ctx, "activity log ingest: "+procErr.Error())
 				return
 			}
-			_ = a.activity.CloseOpenPlaySessionAtLastLogLine(ctx, lastVRLineTime)
-			_ = a.activity.CloseOpenEncountersAtLastLogLine(ctx, lastVRLineTime)
+			if shouldFinalizeOpenActivityAtLogFileEnd(true, i, len(files)) {
+				_ = a.activity.CloseOpenPlaySessionAtLastLogLine(ctx, lastVRLineTime)
+				_ = a.activity.CloseOpenEncountersAtLastLogLine(ctx, lastVRLineTime)
+			}
 			st, statErr := os.Stat(pathCopy)
 			endOff := int64(0)
 			if statErr == nil && st != nil {
@@ -364,8 +366,7 @@ func (a *App) ingestActivityLogsBootstrap(ctx context.Context, absWatch string, 
 		// context.Canceled: preserve last progress-callback checkpoint (same as directory mode)
 		return
 	}
-	_ = a.activity.CloseOpenPlaySessionAtLastLogLine(ctx, lastVRLineTime)
-	_ = a.activity.CloseOpenEncountersAtLastLogLine(ctx, lastVRLineTime)
+	// Single-file watch tails the active output_log; do not close open rows at EOF on bootstrap.
 	st, statErr := os.Stat(pathCopy)
 	endOff := int64(0)
 	if statErr == nil && st != nil {
@@ -384,6 +385,17 @@ func formatActivityCheckpointLineTime(t time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
+}
+
+// shouldFinalizeOpenActivityAtLogFileEnd reports whether bootstrap ingest should close open
+// play sessions and encounters at the end of processing a log file. Only completed historical
+// files in directory mode are finalized; the active tail file may still be written by VRChat
+// while VRCTweaker restarts, so open rows must stay open until real leave events arrive.
+func shouldFinalizeOpenActivityAtLogFileEnd(isDirectoryMode bool, fileIndex, fileCount int) bool {
+	if !isDirectoryMode || fileCount <= 0 {
+		return false
+	}
+	return fileIndex < fileCount-1
 }
 
 func (a *App) startOutputLogWatcher(ctx context.Context, eventBus event.EventBus) {

--- a/app_activity_bootstrap_test.go
+++ b/app_activity_bootstrap_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/infrastructure/logwatcher"
+	"vrchat-tweaker/internal/infrastructure/sqlite"
+	"vrchat-tweaker/internal/usecase"
+)
+
+const (
+	testBootstrapWorldID = "wrld_db637cfb-64f8-4109-977b-6b755482f133"
+	testBootstrapInstID  = testBootstrapWorldID + ":88577~region(jp)"
+	testBootstrapUserID  = "usr_abc"
+)
+
+func Test_shouldFinalizeOpenActivityAtLogFileEnd(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name            string
+		isDirectoryMode bool
+		fileIndex       int
+		fileCount       int
+		want            bool
+	}{
+		{
+			name:            "single file watch never finalizes",
+			isDirectoryMode: false,
+			fileIndex:       0,
+			fileCount:       1,
+			want:            false,
+		},
+		{
+			name:            "directory with one file is still active tail",
+			isDirectoryMode: true,
+			fileIndex:       0,
+			fileCount:       1,
+			want:            false,
+		},
+		{
+			name:            "directory historical file before tail finalizes",
+			isDirectoryMode: true,
+			fileIndex:       0,
+			fileCount:       3,
+			want:            true,
+		},
+		{
+			name:            "directory active tail file does not finalize",
+			isDirectoryMode: true,
+			fileIndex:       2,
+			fileCount:       3,
+			want:            false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldFinalizeOpenActivityAtLogFileEnd(tc.isDirectoryMode, tc.fileIndex, tc.fileCount); got != tc.want {
+				t.Fatalf("shouldFinalizeOpenActivityAtLogFileEnd() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_ingestActivityLogsBootstrap_restart_keepsOpenEncounters_singleFile(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	ctx := context.Background()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "output_log.txt")
+	initial := []byte(
+		"2026.03.21 11:32:04 Debug      -  [Behaviour] Joining " + testBootstrapInstID + "\n" +
+			"2026.03.21 11:32:16 Debug      -  [Behaviour] OnPlayerJoined Alice (" + testBootstrapUserID + ")\n",
+	)
+	if err := os.WriteFile(logPath, initial, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	app, encounterRepo := newTestAppWithActivity(t)
+	joinedAt := time.Date(2026, 3, 21, 11, 32, 16, 0, time.UTC)
+	if err := encounterRepo.Save(ctx, &activity.UserEncounter{
+		ID:          "enc-open",
+		VRCUserID:   testBootstrapUserID,
+		DisplayName: "Alice",
+		InstanceID:  testBootstrapInstID,
+		WorldID:     testBootstrapWorldID,
+		JoinedAt:    joinedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	absLogPath, err := filepath.Abs(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.activity.SetActivityLogCheckpoint(ctx, &usecase.ActivityLogCheckpoint{
+		WatchPath:      absLogPath,
+		File:           absLogPath,
+		ByteOffset:     int64(len(initial)),
+		VRChatLineTime: joinedAt.Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	appendLine := "2026.03.21 11:40:00 Debug      -  [EOSManager] heartbeat while VRCTweaker was closed\n"
+	if err := os.WriteFile(logPath, append(initial, []byte(appendLine)...), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runActivityBootstrap(t, app, ctx, absLogPath)
+	assertEncounterStillOpen(t, app, ctx, testBootstrapUserID)
+}
+
+func Test_ingestActivityLogsBootstrap_restart_keepsOpenEncounters_directoryTailFile(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	ctx := context.Background()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "output_log_2026-03-21_11-00-00.txt")
+	initial := []byte(
+		"2026.03.21 11:32:04 Debug      -  [Behaviour] Joining " + testBootstrapInstID + "\n" +
+			"2026.03.21 11:32:16 Debug      -  [Behaviour] OnPlayerJoined Alice (" + testBootstrapUserID + ")\n",
+	)
+	if err := os.WriteFile(logPath, initial, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	app, encounterRepo := newTestAppWithActivity(t)
+	joinedAt := time.Date(2026, 3, 21, 11, 32, 16, 0, time.UTC)
+	if err := encounterRepo.Save(ctx, &activity.UserEncounter{
+		ID:          "enc-open",
+		VRCUserID:   testBootstrapUserID,
+		DisplayName: "Alice",
+		InstanceID:  testBootstrapInstID,
+		WorldID:     testBootstrapWorldID,
+		JoinedAt:    joinedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absLogPath, err := filepath.Abs(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.activity.SetActivityLogCheckpoint(ctx, &usecase.ActivityLogCheckpoint{
+		WatchPath:      absDir,
+		File:           absLogPath,
+		ByteOffset:     int64(len(initial)),
+		VRChatLineTime: joinedAt.Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	appendLine := "2026.03.21 11:40:00 Debug      -  [EOSManager] heartbeat while VRCTweaker was closed\n"
+	if err := os.WriteFile(logPath, append(initial, []byte(appendLine)...), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runActivityBootstrap(t, app, ctx, absDir)
+	assertEncounterStillOpen(t, app, ctx, testBootstrapUserID)
+}
+
+func Test_ingestActivityLogsBootstrap_finalizesOpenEncounters_onHistoricalDirectoryFile(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	ctx := context.Background()
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "output_log_2026-03-20_23-00-00.txt")
+	newPath := filepath.Join(dir, "output_log_2026-03-21_11-00-00.txt")
+	oldContent := []byte("2026.03.20 23:50:00 Debug      -  [EOSManager] old file tail\n")
+	if err := os.WriteFile(oldPath, oldContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte("2026.03.21 11:00:00 Debug      -  [EOSManager] new file start\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	app, encounterRepo := newTestAppWithActivity(t)
+	joinedAt := time.Date(2026, 3, 20, 22, 0, 0, 0, time.UTC)
+	closeAt := time.Date(2026, 3, 20, 23, 50, 0, 0, time.UTC)
+	if err := encounterRepo.Save(ctx, &activity.UserEncounter{
+		ID:          "enc-historical",
+		VRCUserID:   testBootstrapUserID,
+		DisplayName: "Alice",
+		InstanceID:  testBootstrapInstID,
+		WorldID:     testBootstrapWorldID,
+		JoinedAt:    joinedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runActivityBootstrap(t, app, ctx, absDir)
+
+	rows, err := app.activity.ListEncounters(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListEncounters() = %d rows, want 1", len(rows))
+	}
+	if rows[0].LeftAt == nil {
+		t.Fatal("historical file bootstrap should close open encounters at last line of completed file")
+	}
+	if !rows[0].LeftAt.Equal(closeAt) {
+		t.Fatalf("LeftAt = %v, want %v", rows[0].LeftAt, closeAt)
+	}
+}
+
+func newTestAppWithActivity(t *testing.T) (*App, *sqlite.UserEncounterRepository) {
+	t.Helper()
+	dataDir := t.TempDir()
+	db, err := sqlite.Open(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	encounterRepo := sqlite.NewUserEncounterRepository(db)
+	app := &App{
+		activity: usecase.NewActivityUseCase(
+			sqlite.NewPlaySessionRepository(db),
+			encounterRepo,
+			sqlite.NewAppSettingsRepository(db),
+			sqlite.NewUserCacheRepository(db),
+			sqlite.NewWorldInfoRepository(db),
+		),
+	}
+	return app, encounterRepo
+}
+
+func runActivityBootstrap(t *testing.T, app *App, ctx context.Context, watchPath string) {
+	t.Helper()
+	parser := activity.NewLogParser()
+	adapter := logwatcher.NewActivityIngestAdapter(app.activity, ctx, logLogger{}, nil)
+	app.ingestActivityLogsBootstrap(ctx, watchPath, parser, adapter, logLogger{})
+}
+
+func assertEncounterStillOpen(t *testing.T, app *App, ctx context.Context, vrcUserID string) {
+	t.Helper()
+	rows, err := app.activity.ListEncounters(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.VRCUserID != vrcUserID {
+			continue
+		}
+		if row.LeftAt != nil {
+			t.Fatalf("encounter %s: left_at = %v, want nil (user still in world after VRCTweaker restart)", vrcUserID, row.LeftAt)
+		}
+		return
+	}
+	t.Fatalf("encounter for %s not found", vrcUserID)
+}

--- a/internal/domain/activity/repository.go
+++ b/internal/domain/activity/repository.go
@@ -29,8 +29,13 @@ type UserEncounterRepository interface {
 	ListWithContext(ctx context.Context, filter *EncounterFilter) ([]*EncounterWithContext, error)
 	// Save inserts a user encounter row (typically an open stay with LeftAt nil).
 	Save(ctx context.Context, e *UserEncounter) error
-	// CloseEncounterLeave sets left_at for the user's open stay (left_at IS NULL).
-	CloseEncounterLeave(ctx context.Context, vrcUserID string, leftAt time.Time) (int64, error)
+	// FindByVRCUserIDAndJoinedAt returns an encounter for the user at the exact join time, or nil.
+	FindByVRCUserIDAndJoinedAt(ctx context.Context, vrcUserID string, joinedAt time.Time) (*UserEncounter, error)
+	// UpdateEncounter patches display name and fills empty instance/world fields on an existing row.
+	UpdateEncounter(ctx context.Context, e *UserEncounter) error
+	// CloseEncounterLeave sets left_at on the latest open stay for the user with joined_at <= leftAt.
+	// When instanceID is non-empty, prefers an open row in that instance.
+	CloseEncounterLeave(ctx context.Context, vrcUserID, instanceID string, leftAt time.Time) (int64, error)
 	// CloseOpenEncountersAt sets left_at for every row that is still open.
 	CloseOpenEncountersAt(ctx context.Context, at time.Time) (int64, error)
 	// DeleteOlderThan removes encounters older than the given time (for rotation).
@@ -42,6 +47,9 @@ type UserEncounterRepository interface {
 	// BackfillMissingWorldContext sets world_id (and instance_id when empty) on rows with missing
 	// world_id by propagating the previous row's non-empty context in joined_at ascending order.
 	BackfillMissingWorldContext(ctx context.Context) (updated int64, err error)
+	// DeduplicateEncounters merges duplicate rows sharing vrc_user_id and joined_at, and fixes
+	// invalid left_at values that precede joined_at. Returns the number of rows removed or fixed.
+	DeduplicateEncounters(ctx context.Context) (int64, error)
 }
 
 // EncounterFilter provides optional filtering for List.

--- a/internal/infrastructure/logwatcher/activity_ingest_adapter_test.go
+++ b/internal/infrastructure/logwatcher/activity_ingest_adapter_test.go
@@ -69,7 +69,13 @@ func (stubEncounterRepo) ListWithContext(context.Context, *activity.EncounterFil
 
 func (stubEncounterRepo) Save(context.Context, *activity.UserEncounter) error { return nil }
 
-func (stubEncounterRepo) CloseEncounterLeave(context.Context, string, time.Time) (int64, error) {
+func (stubEncounterRepo) FindByVRCUserIDAndJoinedAt(context.Context, string, time.Time) (*activity.UserEncounter, error) {
+	return nil, nil
+}
+
+func (stubEncounterRepo) UpdateEncounter(context.Context, *activity.UserEncounter) error { return nil }
+
+func (stubEncounterRepo) CloseEncounterLeave(context.Context, string, string, time.Time) (int64, error) {
 	return 0, nil
 }
 
@@ -85,22 +91,63 @@ func (stubEncounterRepo) Count(context.Context) (int64, error) { return 0, nil }
 
 func (stubEncounterRepo) BackfillMissingWorldContext(context.Context) (int64, error) { return 0, nil }
 
+func (stubEncounterRepo) DeduplicateEncounters(context.Context) (int64, error) { return 0, nil }
+
 type spyEncounterRepo struct {
 	stubEncounterRepo
 	saves       []*activity.UserEncounter
+	byJoin      map[string]*activity.UserEncounter
 	closeLeaves []struct {
 		VRCUserID string
 		At        time.Time
 	}
 }
 
+func joinKey(vrcUserID string, joinedAt time.Time) string {
+	return vrcUserID + "|" + joinedAt.Format(time.RFC3339)
+}
+
 func (s *spyEncounterRepo) Save(_ context.Context, e *activity.UserEncounter) error {
 	c := *e
 	s.saves = append(s.saves, &c)
+	if s.byJoin == nil {
+		s.byJoin = make(map[string]*activity.UserEncounter)
+	}
+	cp := c
+	s.byJoin[joinKey(e.VRCUserID, e.JoinedAt)] = &cp
 	return nil
 }
 
-func (s *spyEncounterRepo) CloseEncounterLeave(_ context.Context, vrcUserID string, leftAt time.Time) (int64, error) {
+func (s *spyEncounterRepo) FindByVRCUserIDAndJoinedAt(_ context.Context, vrcUserID string, joinedAt time.Time) (*activity.UserEncounter, error) {
+	if s.byJoin == nil {
+		return nil, nil
+	}
+	if e, ok := s.byJoin[joinKey(vrcUserID, joinedAt)]; ok {
+		cp := *e
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+func (s *spyEncounterRepo) UpdateEncounter(_ context.Context, e *activity.UserEncounter) error {
+	if s.byJoin == nil {
+		return nil
+	}
+	cur, ok := s.byJoin[joinKey(e.VRCUserID, e.JoinedAt)]
+	if !ok {
+		return nil
+	}
+	cur.DisplayName = e.DisplayName
+	if cur.InstanceID == "" && e.InstanceID != "" {
+		cur.InstanceID = e.InstanceID
+	}
+	if cur.WorldID == "" && e.WorldID != "" {
+		cur.WorldID = e.WorldID
+	}
+	return nil
+}
+
+func (s *spyEncounterRepo) CloseEncounterLeave(_ context.Context, vrcUserID, instanceID string, leftAt time.Time) (int64, error) {
 	s.closeLeaves = append(s.closeLeaves, struct {
 		VRCUserID string
 		At        time.Time
@@ -206,5 +253,31 @@ func TestActivityIngestAdapter_EndToEndEncounterPersistence(t *testing.T) {
 	}
 	if len(spy.closeLeaves) != 1 || spy.closeLeaves[0].VRCUserID != otherUser {
 		t.Fatalf("closeLeaves = %+v, want one leave for %s", spy.closeLeaves, otherUser)
+	}
+}
+
+func TestActivityIngestAdapter_ReingestDoesNotDuplicateJoin(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 3, 18, 0, 1, 0, 0, time.UTC)
+	const world = "wrld_c03f8195-3c64-46d8-b5ae-242f214c9404"
+	inst := world + ":98225~hidden(usr_83ba5dc2-2912-4a21-a514-8b954e60a79b)~region(jp)"
+	const otherUser = "usr_1564b5c1-888a-4d08-b7f4-dcedcf702a90"
+
+	spy := &spyEncounterRepo{}
+	uc := usecase.NewActivityUseCase(stubPlaySessionRepo{}, spy, &fakeAppSettingsRepo{m: make(map[string]string)}, nil, nil)
+	a := NewActivityIngestAdapter(uc, ctx, nil, nil)
+
+	play := func() {
+		a.Handle(&activity.DestinationSetEvent{WorldID: world, FullInstance: inst, OccurredAt: base})
+		a.Handle(&activity.SessionEvent{Type: activity.SessionEventStart, InstanceID: inst, OccurredAt: base})
+		a.Handle(&activity.EncounterEvent{
+			VRCUserID: otherUser, DisplayName: "Nau_UoxoU", Action: activity.EncounterActionJoin, EncounteredAt: base,
+		})
+	}
+
+	play()
+	play()
+	if len(spy.saves) != 1 {
+		t.Fatalf("Save calls = %d, want 1 after re-ingest", len(spy.saves))
 	}
 }

--- a/internal/infrastructure/sqlite/activity_repo.go
+++ b/internal/infrastructure/sqlite/activity_repo.go
@@ -241,20 +241,70 @@ func (r *UserEncounterRepository) Save(ctx context.Context, e *activity.UserEnco
 	return err
 }
 
-// CloseEncounterLeave sets left_at for open rows for the user.
-func (r *UserEncounterRepository) CloseEncounterLeave(ctx context.Context, vrcUserID string, leftAt time.Time) (int64, error) {
-	res, err := r.db.ExecContext(ctx, `UPDATE user_encounters SET left_at = ? WHERE vrc_user_id = ? AND (left_at IS NULL OR left_at = '')`,
-		leftAt.Format(time.RFC3339), vrcUserID)
+// FindByVRCUserIDAndJoinedAt returns an encounter for the user at the exact join time.
+func (r *UserEncounterRepository) FindByVRCUserIDAndJoinedAt(ctx context.Context, vrcUserID string, joinedAt time.Time) (*activity.UserEncounter, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT id, vrc_user_id, display_name, instance_id, world_id, joined_at, left_at
+		FROM user_encounters WHERE vrc_user_id = ? AND joined_at = ? LIMIT 1`,
+		vrcUserID, joinedAt.Format(time.RFC3339))
+	return scanUserEncounterRow(row)
+}
+
+// UpdateEncounter patches display name and fills empty instance/world on an existing row.
+func (r *UserEncounterRepository) UpdateEncounter(ctx context.Context, e *activity.UserEncounter) error {
+	var wid interface{}
+	if e.WorldID != "" {
+		wid = e.WorldID
+	}
+	_, err := r.db.ExecContext(ctx, `UPDATE user_encounters SET
+		display_name = ?,
+		instance_id = CASE WHEN (instance_id IS NULL OR instance_id = '') AND ? != '' THEN ? ELSE instance_id END,
+		world_id = CASE WHEN (world_id IS NULL OR world_id = '') AND ? IS NOT NULL THEN ? ELSE world_id END
+		WHERE id = ?`,
+		e.DisplayName, e.InstanceID, e.InstanceID, wid, wid, e.ID)
+	return err
+}
+
+// CloseEncounterLeave sets left_at on the latest eligible open stay for the user.
+func (r *UserEncounterRepository) CloseEncounterLeave(ctx context.Context, vrcUserID, instanceID string, leftAt time.Time) (int64, error) {
+	leftStr := leftAt.Format(time.RFC3339)
+	joinedCutoff := leftStr
+	var id string
+	if instanceID != "" {
+		err := r.db.QueryRowContext(ctx, `SELECT id FROM user_encounters
+			WHERE vrc_user_id = ? AND (left_at IS NULL OR left_at = '') AND joined_at <= ?
+			AND instance_id = ?
+			ORDER BY joined_at DESC LIMIT 1`,
+			vrcUserID, joinedCutoff, instanceID).Scan(&id)
+		if err != nil && err != sql.ErrNoRows {
+			return 0, err
+		}
+	}
+	if id == "" {
+		err := r.db.QueryRowContext(ctx, `SELECT id FROM user_encounters
+			WHERE vrc_user_id = ? AND (left_at IS NULL OR left_at = '') AND joined_at <= ?
+			ORDER BY joined_at DESC LIMIT 1`,
+			vrcUserID, joinedCutoff).Scan(&id)
+		if err == sql.ErrNoRows {
+			return 0, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+	res, err := r.db.ExecContext(ctx, `UPDATE user_encounters SET left_at = ? WHERE id = ?`,
+		leftStr, id)
 	if err != nil {
 		return 0, err
 	}
 	return res.RowsAffected()
 }
 
-// CloseOpenEncountersAt sets left_at on every row still open.
+// CloseOpenEncountersAt sets left_at on every row still open with joined_at <= at.
 func (r *UserEncounterRepository) CloseOpenEncountersAt(ctx context.Context, at time.Time) (int64, error) {
-	res, err := r.db.ExecContext(ctx, `UPDATE user_encounters SET left_at = ? WHERE left_at IS NULL OR left_at = ''`,
-		at.Format(time.RFC3339))
+	atStr := at.Format(time.RFC3339)
+	res, err := r.db.ExecContext(ctx, `UPDATE user_encounters SET left_at = ?
+		WHERE (left_at IS NULL OR left_at = '') AND joined_at <= ?`,
+		atStr, atStr)
 	if err != nil {
 		return 0, err
 	}
@@ -355,6 +405,118 @@ func (r *UserEncounterRepository) BackfillMissingWorldContext(ctx context.Contex
 		return 0, err
 	}
 	return n, nil
+}
+
+// DeduplicateEncounters merges rows sharing vrc_user_id and joined_at and fixes invalid left_at.
+func (r *UserEncounterRepository) DeduplicateEncounters(ctx context.Context) (int64, error) {
+	list, err := r.List(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	type key struct {
+		vrcUserID string
+		join      string
+	}
+	groups := make(map[key][]*activity.UserEncounter)
+	for _, e := range list {
+		k := key{vrcUserID: e.VRCUserID, join: e.JoinedAt.Format(time.RFC3339)}
+		groups[k] = append(groups[k], e)
+	}
+
+	var affected int64
+	for _, rows := range groups {
+		if len(rows) <= 1 {
+			e := rows[0]
+			if e.LeftAt != nil && e.LeftAt.Before(e.JoinedAt) {
+				if _, err := r.db.ExecContext(ctx, `UPDATE user_encounters SET left_at = NULL WHERE id = ?`, e.ID); err != nil {
+					return affected, err
+				}
+				affected++
+			}
+			continue
+		}
+		keep := pickEncounterToKeep(rows)
+		for _, e := range rows {
+			if e.ID == keep.ID {
+				if keep.LeftAt != nil && keep.LeftAt.Before(keep.JoinedAt) {
+					if _, err := r.db.ExecContext(ctx, `UPDATE user_encounters SET left_at = NULL WHERE id = ?`, keep.ID); err != nil {
+						return affected, err
+					}
+					affected++
+				}
+				continue
+			}
+			if _, err := r.db.ExecContext(ctx, `DELETE FROM user_encounters WHERE id = ?`, e.ID); err != nil {
+				return affected, err
+			}
+			affected++
+		}
+	}
+	return affected, nil
+}
+
+func pickEncounterToKeep(rows []*activity.UserEncounter) *activity.UserEncounter {
+	best := rows[0]
+	bestScore := encounterKeepScore(best)
+	for _, e := range rows[1:] {
+		if s := encounterKeepScore(e); s > bestScore {
+			best = e
+			bestScore = s
+		}
+	}
+	return best
+}
+
+func encounterKeepScore(e *activity.UserEncounter) int {
+	score := 0
+	if e.InstanceID != "" {
+		score += 4
+	}
+	if e.WorldID != "" {
+		score += 2
+	}
+	if e.LeftAt != nil {
+		if !e.LeftAt.Before(e.JoinedAt) {
+			score += 8
+			score += int(e.LeftAt.Sub(e.JoinedAt).Seconds())
+		}
+	}
+	return score
+}
+
+func scanUserEncounterRow(row *sql.Row) (*activity.UserEncounter, error) {
+	var id, vrcUserID, displayName, joinedAtStr string
+	var instanceID, worldID, leftAt sql.NullString
+	err := row.Scan(&id, &vrcUserID, &displayName, &instanceID, &worldID, &joinedAtStr, &leftAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	jt, _ := time.Parse(time.RFC3339, joinedAtStr)
+	inst := ""
+	if instanceID.Valid {
+		inst = instanceID.String
+	}
+	wid := ""
+	if worldID.Valid {
+		wid = worldID.String
+	}
+	var lt *time.Time
+	if leftAt.Valid && leftAt.String != "" {
+		t, _ := time.Parse(time.RFC3339, leftAt.String)
+		lt = &t
+	}
+	return &activity.UserEncounter{
+		ID:          id,
+		VRCUserID:   vrcUserID,
+		DisplayName: displayName,
+		InstanceID:  inst,
+		WorldID:     wid,
+		JoinedAt:    jt,
+		LeftAt:      lt,
+	}, nil
 }
 
 func scanUserEncounter(rows *sql.Rows) (*activity.UserEncounter, error) {

--- a/internal/infrastructure/sqlite/error_paths_test.go
+++ b/internal/infrastructure/sqlite/error_paths_test.go
@@ -56,7 +56,7 @@ func TestRepositories_returnErrorWhenDBClosed(t *testing.T) {
 		if _, err := repo.DeleteOlderThan(ctx, now); err == nil {
 			t.Fatal("DeleteOlderThan expected error")
 		}
-		if _, err := repo.CloseEncounterLeave(ctx, "u", now); err == nil {
+		if _, err := repo.CloseEncounterLeave(ctx, "u", "", now); err == nil {
 			t.Fatal("CloseEncounterLeave expected error")
 		}
 		if _, err := repo.CloseOpenEncountersAt(ctx, now); err == nil {

--- a/internal/infrastructure/sqlite/user_encounter_repository_test.go
+++ b/internal/infrastructure/sqlite/user_encounter_repository_test.go
@@ -200,7 +200,7 @@ func TestUserEncounterRepository_CloseEncounterLeave(t *testing.T) {
 		t.Fatal(saveErr)
 	}
 	left := t0.Add(time.Hour)
-	n, err := repo.CloseEncounterLeave(ctx, "usr_x", left)
+	n, err := repo.CloseEncounterLeave(ctx, "usr_x", "", left)
 	if err != nil || n != 1 {
 		t.Fatalf("CloseEncounterLeave: n=%d err=%v", n, err)
 	}
@@ -511,7 +511,7 @@ func TestUserEncounterRepository_CloseEncounterLeave_noMatch(t *testing.T) {
 		t.Fatal(schemaErr)
 	}
 	repo := NewUserEncounterRepository(db)
-	n, err := repo.CloseEncounterLeave(ctx, "nobody", time.Now().UTC())
+	n, err := repo.CloseEncounterLeave(ctx, "nobody", "", time.Now().UTC())
 	if err != nil || n != 0 {
 		t.Fatalf("CloseEncounterLeave no match: n=%d err=%v", n, err)
 	}
@@ -572,5 +572,129 @@ func TestUserEncounterRepository_CloseOpenEncountersAt(t *testing.T) {
 		if e.LeftAt == nil || !e.LeftAt.Equal(at) {
 			t.Fatalf("row %s not closed: %+v", e.ID, e.LeftAt)
 		}
+	}
+}
+
+func TestUserEncounterRepository_CloseEncounterLeave_closesLatestOpenOnly(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if schemaErr := applySchema(db); schemaErr != nil {
+		t.Fatal(schemaErr)
+	}
+	repo := NewUserEncounterRepository(db)
+	t0 := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+	for _, spec := range []struct {
+		id, inst string
+		join     time.Time
+	}{
+		{"old", "inst_a", t0},
+		{"new", "inst_b", t1},
+	} {
+		if saveErr := repo.Save(ctx, &activity.UserEncounter{
+			ID: spec.id, VRCUserID: "usr_x", DisplayName: "X", InstanceID: spec.inst, WorldID: "w",
+			JoinedAt: spec.join, LeftAt: nil,
+		}); saveErr != nil {
+			t.Fatal(saveErr)
+		}
+	}
+	left := t1.Add(30 * time.Minute)
+	n, err := repo.CloseEncounterLeave(ctx, "usr_x", "inst_b", left)
+	if err != nil || n != 1 {
+		t.Fatalf("CloseEncounterLeave: n=%d err=%v", n, err)
+	}
+	list, _ := repo.List(ctx, &activity.EncounterFilter{VRCUserID: "usr_x"})
+	for _, e := range list {
+		switch e.ID {
+		case "new":
+			if e.LeftAt == nil || !e.LeftAt.Equal(left) {
+				t.Fatalf("new row left_at = %v, want %v", e.LeftAt, left)
+			}
+		case "old":
+			if e.LeftAt != nil {
+				t.Fatalf("old row should stay open, left_at=%v", e.LeftAt)
+			}
+		}
+	}
+}
+
+func TestUserEncounterRepository_CloseOpenEncountersAt_skipsFutureJoins(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if schemaErr := applySchema(db); schemaErr != nil {
+		t.Fatal(schemaErr)
+	}
+	repo := NewUserEncounterRepository(db)
+	early := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	late := early.Add(2 * time.Hour)
+	if saveErr := repo.Save(ctx, &activity.UserEncounter{
+		ID: "late", VRCUserID: "usr_late", DisplayName: "Late", InstanceID: "i", WorldID: "w",
+		JoinedAt: late, LeftAt: nil,
+	}); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	n, err := repo.CloseOpenEncountersAt(ctx, early.Add(time.Hour))
+	if err != nil || n != 0 {
+		t.Fatalf("CloseOpenEncountersAt: n=%d err=%v, want 0", n, err)
+	}
+	list, _ := repo.List(ctx, nil)
+	if list[0].LeftAt != nil {
+		t.Fatalf("future join should remain open, left_at=%v", list[0].LeftAt)
+	}
+}
+
+func TestUserEncounterRepository_DeduplicateEncounters(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if schemaErr := applySchema(db); schemaErr != nil {
+		t.Fatal(schemaErr)
+	}
+	repo := NewUserEncounterRepository(db)
+	join := time.Date(2026, 6, 22, 22, 51, 17, 0, time.FixedZone("JST", 9*3600))
+	validLeave := join.Add(17 * time.Minute)
+	invalidLeave := join.Add(-4 * time.Hour)
+	for _, spec := range []struct {
+		id, inst string
+		left     *time.Time
+	}{
+		{"dup_a", "", &invalidLeave},
+		{"dup_b", "wrld_x:1~region(jp)", &validLeave},
+	} {
+		if saveErr := repo.Save(ctx, &activity.UserEncounter{
+			ID: spec.id, VRCUserID: "usr_dup", DisplayName: "User A", InstanceID: spec.inst, WorldID: "wrld_x",
+			JoinedAt: join, LeftAt: spec.left,
+		}); saveErr != nil {
+			t.Fatal(saveErr)
+		}
+	}
+	n, err := repo.DeduplicateEncounters(ctx)
+	if err != nil || n < 1 {
+		t.Fatalf("DeduplicateEncounters: n=%d err=%v", n, err)
+	}
+	list, _ := repo.List(ctx, &activity.EncounterFilter{VRCUserID: "usr_dup"})
+	if len(list) != 1 {
+		t.Fatalf("want 1 row after dedupe, got %d", len(list))
+	}
+	kept := list[0]
+	if kept.InstanceID == "" {
+		t.Fatalf("kept row should prefer filled instance_id, got %+v", kept)
+	}
+	if kept.LeftAt == nil || !kept.LeftAt.Equal(validLeave) {
+		t.Fatalf("kept left_at = %v, want %v", kept.LeftAt, validLeave)
 	}
 }

--- a/internal/usecase/activity_usecase.go
+++ b/internal/usecase/activity_usecase.go
@@ -136,20 +136,39 @@ func (uc *ActivityUseCase) RecordEncounterAt(ctx context.Context, vrcUserID, dis
 	}
 	switch action {
 	case activity.EncounterActionJoin:
-		e := &activity.UserEncounter{
-			ID:          uuid.New().String(),
-			VRCUserID:   vrcUserID,
-			DisplayName: displayName,
-			InstanceID:  instanceID,
-			WorldID:     wid,
-			JoinedAt:    at,
-			LeftAt:      nil,
-		}
-		if err := uc.encounterRepo.Save(ctx, e); err != nil {
+		existing, err := uc.encounterRepo.FindByVRCUserIDAndJoinedAt(ctx, vrcUserID, at)
+		if err != nil {
 			return err
 		}
+		if existing != nil {
+			patch := &activity.UserEncounter{
+				ID:          existing.ID,
+				VRCUserID:   existing.VRCUserID,
+				DisplayName: displayName,
+				InstanceID:  instanceID,
+				WorldID:     wid,
+				JoinedAt:    existing.JoinedAt,
+				LeftAt:      existing.LeftAt,
+			}
+			if patchErr := uc.encounterRepo.UpdateEncounter(ctx, patch); patchErr != nil {
+				return patchErr
+			}
+		} else {
+			e := &activity.UserEncounter{
+				ID:          uuid.New().String(),
+				VRCUserID:   vrcUserID,
+				DisplayName: displayName,
+				InstanceID:  instanceID,
+				WorldID:     wid,
+				JoinedAt:    at,
+				LeftAt:      nil,
+			}
+			if err := uc.encounterRepo.Save(ctx, e); err != nil {
+				return err
+			}
+		}
 	case activity.EncounterActionLeave:
-		if _, err := uc.encounterRepo.CloseEncounterLeave(ctx, vrcUserID, at); err != nil {
+		if _, err := uc.encounterRepo.CloseEncounterLeave(ctx, vrcUserID, instanceID, at); err != nil {
 			return err
 		}
 	default:
@@ -393,6 +412,11 @@ func (uc *ActivityUseCase) UpsertWorldRoomName(ctx context.Context, worldID, roo
 // encounters by propagating the previous row's context in time order.
 func (uc *ActivityUseCase) BackfillEncounterWorldContext(ctx context.Context) (int64, error) {
 	return uc.encounterRepo.BackfillMissingWorldContext(ctx)
+}
+
+// DeduplicateEncounters merges duplicate encounter rows and fixes invalid leave times.
+func (uc *ActivityUseCase) DeduplicateEncounters(ctx context.Context) (int64, error) {
+	return uc.encounterRepo.DeduplicateEncounters(ctx)
 }
 
 // RotateEncounters deletes encounters and play sessions older than Activity retention days.

--- a/internal/usecase/activity_usecase_test.go
+++ b/internal/usecase/activity_usecase_test.go
@@ -74,7 +74,13 @@ func (stubEncounterRepo) ListWithContext(context.Context, *activity.EncounterFil
 
 func (stubEncounterRepo) Save(context.Context, *activity.UserEncounter) error { return nil }
 
-func (stubEncounterRepo) CloseEncounterLeave(context.Context, string, time.Time) (int64, error) {
+func (stubEncounterRepo) FindByVRCUserIDAndJoinedAt(context.Context, string, time.Time) (*activity.UserEncounter, error) {
+	return nil, nil
+}
+
+func (stubEncounterRepo) UpdateEncounter(context.Context, *activity.UserEncounter) error { return nil }
+
+func (stubEncounterRepo) CloseEncounterLeave(context.Context, string, string, time.Time) (int64, error) {
 	return 0, nil
 }
 
@@ -89,6 +95,8 @@ func (stubEncounterRepo) DeleteAll(context.Context) (int64, error) { return 0, n
 func (stubEncounterRepo) Count(context.Context) (int64, error) { return 0, nil }
 
 func (stubEncounterRepo) BackfillMissingWorldContext(context.Context) (int64, error) { return 0, nil }
+
+func (stubEncounterRepo) DeduplicateEncounters(context.Context) (int64, error) { return 0, nil }
 
 type recordingEncounterRepo struct {
 	stubEncounterRepo
@@ -257,22 +265,58 @@ func (m *memEncounterRepo) Save(_ context.Context, e *activity.UserEncounter) er
 	return nil
 }
 
-func (m *memEncounterRepo) CloseEncounterLeave(_ context.Context, vrcUserID string, leftAt time.Time) (int64, error) {
-	var n int64
+func (m *memEncounterRepo) FindByVRCUserIDAndJoinedAt(_ context.Context, vrcUserID string, joinedAt time.Time) (*activity.UserEncounter, error) {
 	for _, e := range m.encounters {
-		if e.VRCUserID == vrcUserID && e.LeftAt == nil {
-			t := leftAt
-			e.LeftAt = &t
-			n++
+		if e.VRCUserID == vrcUserID && e.JoinedAt.Equal(joinedAt) {
+			cp := *e
+			return &cp, nil
 		}
 	}
-	return n, nil
+	return nil, nil
+}
+
+func (m *memEncounterRepo) UpdateEncounter(_ context.Context, e *activity.UserEncounter) error {
+	for _, ex := range m.encounters {
+		if ex.ID != e.ID {
+			continue
+		}
+		ex.DisplayName = e.DisplayName
+		if ex.InstanceID == "" && e.InstanceID != "" {
+			ex.InstanceID = e.InstanceID
+		}
+		if ex.WorldID == "" && e.WorldID != "" {
+			ex.WorldID = e.WorldID
+		}
+		return nil
+	}
+	return nil
+}
+
+func (m *memEncounterRepo) CloseEncounterLeave(_ context.Context, vrcUserID, instanceID string, leftAt time.Time) (int64, error) {
+	var target *activity.UserEncounter
+	for _, e := range m.encounters {
+		if e.VRCUserID != vrcUserID || e.LeftAt != nil || e.JoinedAt.After(leftAt) {
+			continue
+		}
+		if instanceID != "" && e.InstanceID != "" && e.InstanceID != instanceID {
+			continue
+		}
+		if target == nil || e.JoinedAt.After(target.JoinedAt) {
+			target = e
+		}
+	}
+	if target == nil {
+		return 0, nil
+	}
+	t := leftAt
+	target.LeftAt = &t
+	return 1, nil
 }
 
 func (m *memEncounterRepo) CloseOpenEncountersAt(_ context.Context, at time.Time) (int64, error) {
 	var n int64
 	for _, e := range m.encounters {
-		if e.LeftAt == nil {
+		if e.LeftAt == nil && !e.JoinedAt.After(at) {
 			t := at
 			e.LeftAt = &t
 			n++
@@ -307,6 +351,10 @@ func (m *memEncounterRepo) Count(_ context.Context) (int64, error) {
 
 func (m *memEncounterRepo) BackfillMissingWorldContext(_ context.Context) (int64, error) {
 	return m.backfillN, nil
+}
+
+func (m *memEncounterRepo) DeduplicateEncounters(context.Context) (int64, error) {
+	return 0, nil
 }
 
 type activityUserCacheRepo struct {
@@ -824,5 +872,41 @@ func TestActivityUseCase_IsActivityDatastoreEmpty_countError(t *testing.T) {
 	_, err := uc.IsActivityDatastoreEmpty(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestActivityUseCase_RecordEncounterAt_idempotentJoin(t *testing.T) {
+	ctx := context.Background()
+	enc := &memEncounterRepo{}
+	uc := NewActivityUseCase(&fakePlaySessionRepo{}, enc, &fakeAppSettingsRepo{m: make(map[string]string)}, nil, nil)
+	at := time.Date(2026, 6, 22, 22, 51, 17, 0, time.UTC)
+	inst := "wrld_a:1~region(jp)"
+	for i := 0; i < 2; i++ {
+		if err := uc.RecordEncounterAt(ctx, "usr_a", "User A", activity.EncounterActionJoin, inst, "wrld_a", at); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(enc.encounters) != 1 {
+		t.Fatalf("encounters = %d, want 1", len(enc.encounters))
+	}
+	if enc.encounters[0].InstanceID != inst {
+		t.Fatalf("instance_id = %q, want %q", enc.encounters[0].InstanceID, inst)
+	}
+}
+
+func TestActivityUseCase_CloseOpenEncountersAt_skipsFutureJoins(t *testing.T) {
+	ctx := context.Background()
+	enc := &memEncounterRepo{}
+	uc := NewActivityUseCase(&fakePlaySessionRepo{}, enc, &fakeAppSettingsRepo{m: make(map[string]string)}, nil, nil)
+	early := time.Date(2026, 6, 22, 18, 45, 54, 0, time.UTC)
+	lateJoin := time.Date(2026, 6, 22, 22, 51, 17, 0, time.UTC)
+	if err := uc.RecordEncounterAt(ctx, "usr_a", "User A", activity.EncounterActionJoin, "wrld_b:1", "wrld_b", lateJoin); err != nil {
+		t.Fatal(err)
+	}
+	if err := uc.CloseOpenEncountersAt(ctx, early); err != nil {
+		t.Fatal(err)
+	}
+	if enc.encounters[0].LeftAt != nil {
+		t.Fatalf("future join should stay open, left_at=%v", enc.encounters[0].LeftAt)
 	}
 }

--- a/internal/usecase/db_maintenance_usecase_test.go
+++ b/internal/usecase/db_maintenance_usecase_test.go
@@ -26,7 +26,15 @@ func (m *maintEncounterRepo) ListWithContext(context.Context, *activity.Encounte
 
 func (m *maintEncounterRepo) Save(context.Context, *activity.UserEncounter) error { return nil }
 
-func (m *maintEncounterRepo) CloseEncounterLeave(context.Context, string, time.Time) (int64, error) {
+func (m *maintEncounterRepo) FindByVRCUserIDAndJoinedAt(context.Context, string, time.Time) (*activity.UserEncounter, error) {
+	return nil, nil
+}
+
+func (m *maintEncounterRepo) UpdateEncounter(context.Context, *activity.UserEncounter) error {
+	return nil
+}
+
+func (m *maintEncounterRepo) CloseEncounterLeave(context.Context, string, string, time.Time) (int64, error) {
 	return 0, nil
 }
 
@@ -45,6 +53,10 @@ func (m *maintEncounterRepo) DeleteAll(context.Context) (int64, error) {
 func (m *maintEncounterRepo) Count(context.Context) (int64, error) { return 0, nil }
 
 func (m *maintEncounterRepo) BackfillMissingWorldContext(context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (m *maintEncounterRepo) DeduplicateEncounters(context.Context) (int64, error) {
 	return 0, nil
 }
 


### PR DESCRIPTION
## Summary

- Re-ingesting `output_log` no longer creates duplicate encounter rows when the same join event is replayed from a checkpoint (`FindByVRCUserIDAndJoinedAt`, dedupe on bootstrap).
- Bootstrap ingest no longer closes open encounters/play sessions at EOF on the **active** log file, so restarting VRCTweaker while VRChat is still running does not stamp false `left_at` times.
- Historical (non-tail) log files in directory mode still finalize open rows at the last processed line, preserving day-rollover behavior.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [ ] VRChat 起動中に VRCTweaker を再起動し、遭遇ログの退出時刻が付かないこと
- [ ] 初回起動後のログ再取り込みで遭遇ログが重複しないこと
- [ ] 日付ローテーション後の過去ログファイル取り込みで、当該ファイル末尾時刻に遭遇がクローズされること


Made with [Cursor](https://cursor.com)