### PR TITLE
chore(agents): add Matt Pocock engineering skills configuration

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -77,3 +77,17 @@ GitHub Issue の URL・番号、または `docs/ai_dlc/issues/` 等の Issue ド
 - **advisor-workflow**: Composer をメインに、詰まりどころだけ Sonnet / Codex で短い相談を挟む（`.cursor/skills/advisor-workflow/SKILL.md`）
 - **tdd-workflow**: テスト駆動開発と fmt→test→lint→（フロント時）E2E の検証ループ。コード変更時に適用。
 - **element-plus-frontend**: Element Plus による UI 実装・Vitest/Playwright セレクタ・公式ドキュメント参照（`.cursor/skills/element-plus-frontend/SKILL.md`）
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `JO3QMA/vrctweaker` (`gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical triage roles use default label names (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: 不具合の報告（再現手順と期待動作を含めてください）
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **プライバシー:** 表示名・VRC user ID・ログ全文はマスクしてください。再現に必要なら手順とバージョンだけで構いません。
+        ドメイン用語は [CONTEXT.md](https://github.com/JO3QMA/vrctweaker/blob/main/CONTEXT.md) に合わせて記載してください。
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: 実際に起きたこと。スクリーンショットやログの抜粋（マスク済み）があれば添付してください。
+      placeholder: Activity の遭遇ログに同一入室時刻の行が2件表示される…
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What I expected
+      description: 正しいと思う振る舞い
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: 再現手順（番号付きリスト推奨）
+      placeholder: |
+        1. VRChat Tweaker を起動し、…を有効にする
+        2. …
+        3. …画面を開く
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: 当たりがつく画面・領域
+      options:
+        - Dashboard
+        - Launcher
+        - Gallery
+        - Activity / Encounter log
+        - Friends / User profile
+        - Automation
+        - Settings / Config
+        - Backend / ingest
+        - Other / Unknown
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: App version or commit
+      description: リリースタグ、ビルド日、または `git rev-parse --short HEAD` の結果
+      placeholder: main @ abc1234 / v0.x.y
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows
+        - Linux
+        - WSL2
+        - Dev Container
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: 関連する設定、直前の操作、仮説、既存 Issue / PR へのリンクなど
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/JO3QMA/vrctweaker/blob/main/README.md#コントリビューション
+    about: Issue / PR の書き方と開発コマンド

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature request
+description: 新機能や既存機能の改善提案
+title: "[Feature]: "
+labels:
+  - enhancement
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        用語は [CONTEXT.md](https://github.com/JO3QMA/vrctweaker/blob/main/CONTEXT.md) に合わせてください。
+        大きな変更は背景と受け入れ条件を具体的に書くと、`ready-for-agent` / `ready-for-human` の判断がしやすくなります。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: 何を実現したいか（1〜3 文）
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: いま何が不便か、誰のどんな作業を助けるか
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: 期待する UX や振る舞い。UI のラフでも可
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: 完了とみなす条件（チェックリスト推奨）
+      placeholder: |
+        - [ ] …
+        - [ ] `make test` / `make lint` がパスする
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: 検討した別案があれば
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 関連する `CONTEXT.md` 節、`docs/adr/`、既存 Issue、feature ドキュメントなど
+      placeholder: CONTEXT.md — Gallery scope / docs/adr/0001-...
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- 何を・なぜ変えたかを 1〜3 文で -->
+
+## Related issues
+
+<!-- あれば: Closes #123 / Fixes #456 / Relates to #789 -->
+
+## Changes
+
+<!-- 主な変更点。箇条書きで十分 -->
+
+-
+
+## Test plan
+
+<!-- 実施した検証にチェック。未実施は理由を書く -->
+
+- [ ] `make fmt`
+- [ ] `make test`
+- [ ] `make lint`
+- [ ] `make test-e2e`（`frontend/src` を変更した場合）
+- [ ] Storybook 更新（Wails UI / コンポーネント抽象化を変更した場合）
+- [ ] 手動確認（該当する画面・操作を記載）
+
+## Screenshots / recordings
+
+<!-- UI 変更がある場合。なければ N/A -->
+
+## Notes for reviewers
+
+<!-- 判断が必要な点、意図的にスコープ外にしたこと、フォローアップ Issue など -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,19 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      # ドキュメント・エージェント設定のみの変更では Lint / テストを走らせない
+      - '**.md'
+      - 'docs/**'
+      - '.cursor/**'
+      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.cursor/**'
+      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,11 @@ name: Dependency Review
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.cursor/**'
+      - '.github/ISSUE_TEMPLATE/**'
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# VRChat Tweaker
+
+VRChat 周辺のログ・スクリーンショット・フレンド情報などをまとめて扱うデスクトップアプリです。  
+[Wails v2](https://wails.io/)（Go バックエンド + Vue 3 フロントエンド）で構築しています。
+
+## 主な機能
+
+| 画面 | 概要 |
+|------|------|
+| **Dashboard** | ホーム / 概要 |
+| **Launcher** | VRChat の起動補助 |
+| **Gallery** | スクリーンショットの閲覧・検索（日付グループ、ワールド検索、期間フィルタ） |
+| **Activity** | Output log からの遭遇ログ・プレイ時間など |
+| **Friends** | フレンド一覧・プロフィール |
+| **Automation** | 自動化設定 |
+| **Settings / Config** | アプリ・VRChat 連携の設定 |
+
+ドメイン用語は [`CONTEXT.md`](./CONTEXT.md)、設計判断は [`docs/adr/`](./docs/adr/) を参照してください。
+
+## 技術スタック
+
+- **Backend**: Go 1.25, SQLite, Wails v2
+- **Frontend**: Vue 3, TypeScript, Element Plus, Vite, Vitest, Playwright, Storybook
+
+## 開発環境
+
+### 推奨: Dev Container
+
+VS Code / Cursor の **Reopen in Container** で `.devcontainer/` を開くと、Go・pnpm・Playwright・`gh` が揃います。
+
+WSL 上でホストの VRChat フォルダ（`/mnt/c/...`）をマウントする場合は、`.devcontainer/wsl-host-vrchat/` の構成を選んでください。
+
+### 手動セットアップ
+
+| ツール | 用途 |
+|--------|------|
+| Go 1.25+ | バックエンド |
+| [Wails CLI v2](https://wails.io/docs/gettingstarted/installation) | デスクトップアプリのビルド・開発 |
+| Node.js 20+ / pnpm | フロントエンド |
+| golangci-lint | Go の Lint |
+
+```bash
+# 依存関係
+make install-front
+
+# 開発サーバー（ヘッドレス環境では xvfb 付き）
+make dev-wails
+
+# 品質チェック（コミット前の目安）
+make fmt
+make test
+make lint
+
+# フロントの src を変更したときは E2E も
+make setup-e2e   # 初回のみ
+make test-e2e
+```
+
+`make help` で Makefile の全ターゲットを確認できます。
+
+## リポジトリ構成（抜粋）
+
+```
+.
+├── app.go                 # Wails エントリ・バインディング
+├── internal/              # Go（domain / usecase / infrastructure）
+├── frontend/              # Vue アプリ
+├── docs/
+│   ├── adr/               # Architecture Decision Records
+│   ├── agents/            # Issue トラッカー・トリアージ・エージェント向け規約
+│   └── features/          # 機能仕様
+├── CONTEXT.md             # ドメイン用語集
+└── .cursor/               # Cursor エージェント用ルール・スキル
+```
+
+## コントリビューション
+
+### Issue
+
+バグ報告・機能要望は [GitHub Issues](https://github.com/JO3QMA/vrctweaker/issues) から作成してください。テンプレートに沿って記入すると、再現や受け入れ条件の確認がしやすくなります。
+
+| テンプレート | 用途 |
+|--------------|------|
+| Bug report | 不具合（`bug` ラベル） |
+| Feature request | 機能追加・改善（`enhancement` ラベル） |
+
+新規 Issue には `needs-triage` が付きます。トリアージ用ラベルの意味は [`docs/agents/triage-labels.md`](./docs/agents/triage-labels.md) を参照してください。
+
+**プライバシー**: Issue 本文に VRChat の表示名・ユーザー ID・ログの生データを載せないでください。必要ならマスクするか、再現手順だけを書いてください。
+
+### Pull Request
+
+`main` 向けの PR では、`.github/pull_request_template.md` のチェックリストを埋めてください。
+
+- 関連 Issue があれば `Closes #123` などでリンク
+- コード変更後は `make fmt` → `make test` → `make lint`（フロント `src` 変更時は `make test-e2e` も）
+- UI 変更時は Storybook 側の更新も検討（`.cursor/rules/storybook-wails-ui.mdc`）
+
+エージェント駆動で開発する場合は [`.cursor/AGENTS.md`](./.cursor/AGENTS.md) と [`docs/agents/`](./docs/agents/) も参照してください。
+
+## CI
+
+`main` への push / PR で `.github/workflows/ci.yml` が `make lint` と `make test` を実行します。
+
+## ライセンス
+
+このリポジトリのライセンスは各 `package.json` / 依存パッケージの表記に従います。アプリ内の **Licenses** 画面でも確認できます。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

- Add `docs/agents/` with issue tracker, triage label, and domain doc conventions for Matt Pocock engineering skills (`to-issues`, `triage`, `to-prd`, `qa`, `improve-codebase-architecture`, etc.)
- Extend `.cursor/AGENTS.md` with an `## Agent skills` section pointing to those docs
- GitHub triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`) were created on the repo; `wontfix` already existed

## Test plan

- [x] Docs-only change; no application code affected
- [ ] Confirm `docs/agents/issue-tracker.md` matches `JO3QMA/vrctweaker` GitHub Issues workflow
- [ ] Confirm triage labels appear in GitHub repo settings


Made with [Cursor](https://cursor.com)