### PR TITLE
fix(activity): record exit and world name when VRChat restarts

### DIFF
--- a/app.go
+++ b/app.go
@@ -52,6 +52,10 @@ type App struct {
 	sleepSuppressMu     sync.Mutex
 	sleepSuppressCancel context.CancelFunc
 	sleepSuppressWG     sync.WaitGroup
+
+	activityWatchMu     sync.Mutex
+	activityWatchCancel context.CancelFunc
+	activityWatchWG     sync.WaitGroup
 }
 
 // NewApp creates a new App application struct.
@@ -125,6 +129,7 @@ func (a *App) startup(ctx context.Context) {
 
 // onShutdown persists state before the process exits (Wails lifecycle).
 func (a *App) onShutdown(ctx context.Context) {
+	a.stopVRChatActivityMonitor()
 	a.stopSleepSuppressLoop()
 	if a.settings == nil {
 		return
@@ -436,12 +441,24 @@ func (a *App) startOutputLogWatcher(ctx context.Context, eventBus event.EventBus
 	}
 	ingestAdapter.SetSuppressEncounterNotify(false)
 
+	watchDeps := activityLogWatchDeps{
+		watchPath:      watchPath,
+		parser:         parser,
+		ingestAdapter:  ingestAdapter,
+		handler:        handler,
+		logger:         logger,
+		emitEncounters: emitEncounters,
+	}
+
 	watcher := logwatcher.NewOutputLogWatcher(watchPath, parser, handler, logger)
-	watcher.SetOnActiveLogPathChange(ingestAdapter.ResetSessionContextForNewLogFile)
+	watcher.SetLogFileSwitchHandler(logwatcher.LogFileSwitchHandlerFunc(func(c context.Context, previousPath, newPath string) error {
+		return a.handleActivityLogFileSwitch(c, watchDeps, previousPath, newPath)
+	}))
 	if startErr := watcher.Start(ctx); startErr != nil {
 		runtime.LogError(ctx, "failed to start output_log watcher: "+startErr.Error())
 		return
 	}
+	a.startVRChatActivityMonitor(ctx, watchPath)
 	runtime.LogInfo(ctx, "output_log watcher started for "+watchPath)
 }
 

--- a/app_activity_log_rotation_test.go
+++ b/app_activity_log_rotation_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/infrastructure/logwatcher"
+)
+
+func Test_handleActivityLogFileSwitch_finalizesOldSessionAndRecordsWorldName(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	const cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
+	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	joinedAt := time.Date(2026, 6, 24, 8, 20, 0, 0, time.UTC)
+
+	oldPath := filepath.Join(dir, "output_log_2026-06-24_08-00-00.txt")
+	oldContent := []byte(
+		"2026.06.24 08:20:00 Debug      -  [Behaviour] Joining " + cozyInst + "\n" +
+			"2026.06.24 08:20:05 Debug      -  [Behaviour] OnPlayerJoined Alice (usr_abc)\n",
+	)
+	if err := os.WriteFile(oldPath, oldContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	newPath := filepath.Join(dir, "output_log_2026-06-24_08-30-00.txt")
+	newContent := []byte(
+		"2026.06.24 08:30:10 Debug      -  [Behaviour] Destination set: " + cozyInst + "\n" +
+			"2026.06.24 08:30:11 Debug      -  [Behaviour] Entering Room: Cozy with․\n" +
+			"2026.06.24 08:30:12 Debug      -  [Behaviour] Joining " + cozyInst + "\n",
+	)
+	if err := os.WriteFile(newPath, newContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	app, encounterRepo := newTestAppWithActivity(t)
+	if err := encounterRepo.Save(ctx, &activity.UserEncounter{
+		ID:          "enc-open",
+		VRCUserID:   "usr_abc",
+		DisplayName: "Alice",
+		InstanceID:  cozyInst,
+		WorldID:     cozyWorld,
+		JoinedAt:    joinedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.activity.StartPlaySession(ctx, cozyInst, joinedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parser := activity.NewLogParser()
+	adapter := logwatcher.NewActivityIngestAdapter(app.activity, ctx, logLogger{}, nil)
+	handler := logwatcher.NewMultiHandler(adapter, logwatcher.EventHandlerFunc(func(activity.ParsedEvent) {}))
+	deps := activityLogWatchDeps{
+		watchPath:     absDir,
+		parser:        parser,
+		ingestAdapter: adapter,
+		handler:       handler,
+		logger:        logLogger{},
+	}
+
+	if switchErr := app.handleActivityLogFileSwitch(ctx, deps, oldPath, newPath); switchErr != nil {
+		t.Fatal(switchErr)
+	}
+
+	rows, err := app.activity.ListEncountersWithContext(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("encounters = %d, want 1", len(rows))
+	}
+	if rows[0].Encounter == nil || rows[0].Encounter.LeftAt == nil {
+		t.Fatal("encounter left_at is nil, want finalized when VRChat log rotated")
+	}
+	if rows[0].WorldDisplayName != "Cozy with․" {
+		t.Fatalf("world display = %q, want Cozy with․", rows[0].WorldDisplayName)
+	}
+}
+
+func Test_finalizeOpenActivityAtLogPath_usesLastTimestamp(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	ctx := context.Background()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "output_log.txt")
+	const inst = testBootstrapInstID
+	joinedAt := time.Date(2026, 3, 21, 11, 32, 4, 0, time.UTC)
+	lastLine := time.Date(2026, 3, 21, 11, 45, 0, 0, time.UTC)
+	content := []byte(
+		"2026.03.21 11:32:04 Debug      -  [Behaviour] Joining " + inst + "\n" +
+			"2026.03.21 11:45:00 Debug      -  [EOSManager] heartbeat\n",
+	)
+	if err := os.WriteFile(logPath, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	app, _ := newTestAppWithActivity(t)
+	if err := app.activity.StartPlaySession(ctx, inst, joinedAt); err != nil {
+		t.Fatal(err)
+	}
+	app.finalizeOpenActivityAtLogPath(ctx, logPath)
+
+	from := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	sessions, err := app.activity.ListPlaySessions(ctx, from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].EndTime == nil || !sessions[0].EndTime.Equal(lastLine) {
+		t.Fatalf("sessions = %+v, want one closed at %v", sessions, lastLine)
+	}
+}

--- a/app_activity_log_watch.go
+++ b/app_activity_log_watch.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/infrastructure/logwatcher"
+	"vrchat-tweaker/internal/infrastructure/sleepsuppress"
+	"vrchat-tweaker/internal/usecase"
+)
+
+type activityLogWatchDeps struct {
+	watchPath      string
+	parser         *activity.LogParser
+	ingestAdapter  *logwatcher.ActivityIngestAdapter
+	handler        logwatcher.EventHandler
+	logger         logwatcher.Logger
+	emitEncounters func()
+}
+
+func (a *App) finalizeOpenActivityAtLogPath(ctx context.Context, logPath string) {
+	if a.activity == nil || logPath == "" {
+		return
+	}
+	lastTime, err := logwatcher.LastVRChatLineTimeInFile(logPath)
+	if err != nil {
+		runtime.LogWarning(ctx, "activity finalize log time: "+err.Error())
+	}
+	if lastTime.IsZero() {
+		if cp, cpErr := a.activity.GetActivityLogCheckpoint(ctx); cpErr == nil && cp != nil && cp.VRChatLineTime != "" {
+			if t, parseErr := time.Parse(time.RFC3339, cp.VRChatLineTime); parseErr == nil {
+				lastTime = t
+			}
+		}
+	}
+	if lastTime.IsZero() {
+		return
+	}
+	_ = a.activity.CloseOpenPlaySessionAtLastLogLine(ctx, lastTime)
+	_ = a.activity.CloseOpenEncountersAtLastLogLine(ctx, lastTime)
+	if a.ctx != nil {
+		runtime.EventsEmit(a.ctx, activityEncountersChangedEvent, struct{}{})
+	}
+}
+
+func (a *App) handleActivityLogFileSwitch(ctx context.Context, deps activityLogWatchDeps, previousPath, newPath string) error {
+	if previousPath != "" {
+		a.finalizeOpenActivityAtLogPath(ctx, previousPath)
+	}
+	if deps.ingestAdapter != nil {
+		deps.ingestAdapter.ResetSessionContextForNewLogFile()
+	}
+	if newPath == "" || deps.parser == nil || deps.handler == nil {
+		return nil
+	}
+
+	var lastVRLineTime time.Time
+	endOff, err := logwatcher.ProcessOutputLogFileFromOffset(ctx, newPath, 0, deps.parser, deps.handler, deps.logger, func(_ int64, line string) {
+		if ts := activity.ParseVRChatTimestamp(line, time.Time{}); !ts.IsZero() {
+			lastVRLineTime = ts
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	if a.activity != nil && deps.watchPath != "" {
+		absNew, absErr := filepath.Abs(filepath.Clean(newPath))
+		if absErr != nil {
+			absNew = newPath
+		}
+		_ = a.activity.SetActivityLogCheckpoint(ctx, &usecase.ActivityLogCheckpoint{
+			WatchPath:      deps.watchPath,
+			File:           absNew,
+			ByteOffset:     endOff,
+			VRChatLineTime: formatActivityCheckpointLineTime(lastVRLineTime),
+		})
+	}
+	if deps.emitEncounters != nil {
+		deps.emitEncounters()
+	}
+	return nil
+}
+
+func (a *App) startVRChatActivityMonitor(ctx context.Context, watchPath string) {
+	a.activityWatchMu.Lock()
+	if a.activityWatchCancel != nil {
+		a.activityWatchCancel()
+		a.activityWatchWG.Wait()
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	a.activityWatchCancel = cancel
+	a.activityWatchMu.Unlock()
+
+	a.activityWatchWG.Add(1)
+	go func() {
+		defer a.activityWatchWG.Done()
+		checker := sleepsuppress.NewVRChatProcessChecker()
+		_ = logwatcher.MonitorVRChatRunning(runCtx, 4*time.Second, checker, func() {
+			logPath, err := a.resolveActiveOutputLogFilePath(ctx, watchPath)
+			if err != nil || logPath == "" {
+				a.finalizeOpenActivityFromCheckpoint(ctx)
+				return
+			}
+			a.finalizeOpenActivityAtLogPath(ctx, logPath)
+		})
+	}()
+}
+
+func (a *App) stopVRChatActivityMonitor() {
+	var cancel context.CancelFunc
+	a.activityWatchMu.Lock()
+	cancel = a.activityWatchCancel
+	a.activityWatchCancel = nil
+	a.activityWatchMu.Unlock()
+	if cancel != nil {
+		cancel()
+		a.activityWatchWG.Wait()
+	}
+}
+
+func (a *App) finalizeOpenActivityFromCheckpoint(ctx context.Context) {
+	if a.activity == nil {
+		return
+	}
+	cp, err := a.activity.GetActivityLogCheckpoint(ctx)
+	if err != nil || cp == nil || cp.VRChatLineTime == "" {
+		return
+	}
+	lastTime, parseErr := time.Parse(time.RFC3339, cp.VRChatLineTime)
+	if parseErr != nil || lastTime.IsZero() {
+		return
+	}
+	_ = a.activity.CloseOpenPlaySessionAtLastLogLine(ctx, lastTime)
+	_ = a.activity.CloseOpenEncountersAtLastLogLine(ctx, lastTime)
+	if a.ctx != nil {
+		runtime.EventsEmit(a.ctx, activityEncountersChangedEvent, struct{}{})
+	}
+}
+
+func (a *App) resolveActiveOutputLogFilePath(ctx context.Context, watchPath string) (string, error) {
+	p := watchPath
+	if p == "" {
+		var err error
+		p, err = a.resolveEffectiveOutputLogWatchPath(ctx)
+		if err != nil {
+			return "", err
+		}
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return logwatcher.ResolveLatestOutputLogFile(p)
+	}
+	return filepath.Abs(filepath.Clean(p))
+}

--- a/internal/infrastructure/logwatcher/last_line_time.go
+++ b/internal/infrastructure/logwatcher/last_line_time.go
@@ -1,0 +1,31 @@
+package logwatcher
+
+import (
+	"bufio"
+	"os"
+	"time"
+
+	"vrchat-tweaker/internal/domain/activity"
+)
+
+// LastVRChatLineTimeInFile returns the timestamp from the last line in path that starts with
+// a VRChat output_log timestamp, or zero time if none.
+func LastVRChatLineTimeInFile(path string) (time.Time, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var last time.Time
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if ts := activity.ParseVRChatTimestamp(sc.Text(), time.Time{}); !ts.IsZero() {
+			last = ts
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return time.Time{}, err
+	}
+	return last, nil
+}

--- a/internal/infrastructure/logwatcher/last_line_time_test.go
+++ b/internal/infrastructure/logwatcher/last_line_time_test.go
@@ -1,0 +1,48 @@
+package logwatcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLastVRChatLineTimeInFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output_log.txt")
+	content := []byte(
+		"noise without timestamp\n" +
+			"2026.06.24 08:26:40 Debug      -  [Behaviour] Joining wrld_abc:1~region(jp)\n" +
+			"2026.06.24 08:26:50 Debug      -  [Behaviour] OnPlayerJoined Alice (usr_x)\n",
+	)
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LastVRChatLineTimeInFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := time.ParseInLocation("2006.01.02 15:04:05", "2026.06.24 08:26:50", time.Local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("LastVRChatLineTimeInFile = %v, want %v", got, want)
+	}
+}
+
+func TestLastVRChatLineTimeInFile_emptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output_log.txt")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LastVRChatLineTimeInFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("got %v, want zero time", got)
+	}
+}

--- a/internal/infrastructure/logwatcher/output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/output_log_watcher.go
@@ -29,6 +29,23 @@ func (f EventHandlerFunc) Handle(event activity.ParsedEvent) {
 	f(event)
 }
 
+// LogFileSwitchHandler is invoked when the watcher begins tailing a different output_log file,
+// or when the current file was truncated in place. previousPath is empty on the first file.
+type LogFileSwitchHandler interface {
+	OnLogFileSwitch(ctx context.Context, previousPath, newPath string) error
+}
+
+// LogFileSwitchHandlerFunc adapts a function to LogFileSwitchHandler.
+type LogFileSwitchHandlerFunc func(ctx context.Context, previousPath, newPath string) error
+
+// OnLogFileSwitch implements LogFileSwitchHandler.
+func (f LogFileSwitchHandlerFunc) OnLogFileSwitch(ctx context.Context, previousPath, newPath string) error {
+	if f == nil {
+		return nil
+	}
+	return f(ctx, previousPath, newPath)
+}
+
 // LogParser parses a log line into events.
 type LogParser interface {
 	ParseLine(line string, baseTime time.Time) ([]activity.ParsedEvent, error)
@@ -44,11 +61,10 @@ type OutputLogWatcher struct {
 	parser         LogParser
 	handler        EventHandler
 	logger         Logger
-	// onActiveLogPathChange is optional; in directory mode, called after a successful open+seek
-	// when the tailed file path differs from the previous one (not called on the first file).
-	// Used to clear ActivityIngestAdapter correlator state so lines before Joining in the new file
-	// do not inherit the previous log file's world/instance context.
-	onActiveLogPathChange func()
+	// logFileSwitchHandler is optional; called when tailing switches to another output_log file
+	// or when the current file was truncated. Used to finalize open activity rows and ingest
+	// startup lines already written to the new file before the watcher seeks to EOF.
+	logFileSwitchHandler LogFileSwitchHandler
 
 	mu        sync.Mutex
 	status    string // "idle", "running", "stopped"
@@ -79,12 +95,12 @@ func NewOutputLogWatcher(configuredPath string, parser LogParser, handler EventH
 	return w
 }
 
-// SetOnActiveLogPathChange registers a callback invoked in directory mode when the watcher
-// begins tailing a different output_log*.txt path than before. Call before Start.
-func (w *OutputLogWatcher) SetOnActiveLogPathChange(fn func()) {
+// SetLogFileSwitchHandler registers a callback invoked when the tailed output_log path changes
+// or the current file is truncated. Call before Start.
+func (w *OutputLogWatcher) SetLogFileSwitchHandler(h LogFileSwitchHandler) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.onActiveLogPathChange = fn
+	w.logFileSwitchHandler = h
 }
 
 func (w *OutputLogWatcher) resolveActivePath() (string, error) {
@@ -193,12 +209,14 @@ func (w *OutputLogWatcher) run(ctx context.Context) {
 			continue
 		}
 
-		if w.watchDir != "" && activePath != w.lastTailedPath && w.lastTailedPath != "" {
+		if w.lastTailedPath != "" && activePath != w.lastTailedPath {
 			w.mu.Lock()
-			cb := w.onActiveLogPathChange
+			h := w.logFileSwitchHandler
 			w.mu.Unlock()
-			if cb != nil {
-				cb()
+			if h != nil {
+				if switchErr := h.OnLogFileSwitch(ctx, w.lastTailedPath, activePath); switchErr != nil {
+					w.logger.Printf("[logwatcher] log file switch: %v", switchErr)
+				}
 			}
 		}
 		w.lastTailedPath = activePath
@@ -228,7 +246,19 @@ func (w *OutputLogWatcher) run(ctx context.Context) {
 					_ = f.Close()
 					break readLoop
 				}
-				if curInfo.ModTime() != info.ModTime() || curInfo.Size() < initialSize {
+				if curInfo.Size() < initialSize {
+					w.mu.Lock()
+					h := w.logFileSwitchHandler
+					w.mu.Unlock()
+					if h != nil {
+						if switchErr := h.OnLogFileSwitch(ctx, activePath, activePath); switchErr != nil {
+							w.logger.Printf("[logwatcher] log file truncate: %v", switchErr)
+						}
+					}
+					_ = f.Close()
+					break readLoop
+				}
+				if curInfo.ModTime() != info.ModTime() {
 					_ = f.Close()
 					break readLoop
 				}

--- a/internal/infrastructure/logwatcher/output_log_watcher_test.go
+++ b/internal/infrastructure/logwatcher/output_log_watcher_test.go
@@ -143,6 +143,72 @@ func TestOutputLogWatcher_DirectoryMode_SwitchesToNewerFile(t *testing.T) {
 	}
 }
 
+func TestOutputLogWatcher_DirectoryMode_IngestsPrefixedLinesOnSwitch(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "output_log_2026-01-01_00-00-00.txt")
+	newPath := filepath.Join(dir, "output_log_2026-03-22_00-47-45.txt")
+	const cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
+	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	prefixed := []byte(
+		"2026.03.22 00:47:45 Debug      -  [Behaviour] Destination set: " + cozyInst + "\n" +
+			"2026.03.22 00:47:46 Debug      -  [Behaviour] Entering Room: Cozy with․\n",
+	)
+	if err := os.WriteFile(oldPath, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+	oldT := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(oldPath, oldT, oldT); err != nil {
+		t.Fatal(err)
+	}
+
+	parser := activity.NewLogParser()
+	var mu sync.Mutex
+	var received []activity.ParsedEvent
+	handler := EventHandlerFunc(func(ev activity.ParsedEvent) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+
+	watcher := NewOutputLogWatcher(dir, parser, handler, nil)
+	watcher.SetLogFileSwitchHandler(LogFileSwitchHandlerFunc(func(ctx context.Context, _, newPath string) error {
+		_, err := ProcessOutputLogFileFromOffset(ctx, newPath, 0, parser, handler, nil, nil)
+		return err
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.WriteFile(newPath, prefixed, 0600); err != nil {
+		t.Fatal(err)
+	}
+	newT := time.Date(2026, 3, 22, 0, 47, 45, 0, time.UTC)
+	if err := os.Chtimes(newPath, newT, newT); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(received)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) < 2 {
+		t.Fatalf("handler received %d events after switch, want at least 2 (destination + room name)", len(received))
+	}
+}
+
 func TestOutputLogWatcher_DirectoryMode_OnActiveLogPathChangeOnSwitch(t *testing.T) {
 	dir := t.TempDir()
 	oldPath := filepath.Join(dir, "output_log_2026-01-01_00-00-00.txt")
@@ -160,9 +226,10 @@ func TestOutputLogWatcher_DirectoryMode_OnActiveLogPathChangeOnSwitch(t *testing
 
 	var pathChangeCalls atomic.Int32
 	watcher := NewOutputLogWatcher(dir, parser, handler, nil)
-	watcher.SetOnActiveLogPathChange(func() {
+	watcher.SetLogFileSwitchHandler(LogFileSwitchHandlerFunc(func(context.Context, string, string) error {
 		pathChangeCalls.Add(1)
-	})
+		return nil
+	}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/infrastructure/logwatcher/vrchat_process_monitor.go
+++ b/internal/infrastructure/logwatcher/vrchat_process_monitor.go
@@ -1,0 +1,42 @@
+package logwatcher
+
+import (
+	"context"
+	"time"
+)
+
+// VRChatRunningChecker reports whether the VRChat client process is running.
+type VRChatRunningChecker interface {
+	VRChatRunning() (bool, error)
+}
+
+// MonitorVRChatRunning polls until ctx is cancelled. onStopped is called once when VRChat
+// transitions from running to not running.
+func MonitorVRChatRunning(ctx context.Context, interval time.Duration, checker VRChatRunningChecker, onStopped func()) error {
+	if checker == nil || onStopped == nil {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if interval <= 0 {
+		interval = 4 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	wasRunning := false
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			running, err := checker.VRChatRunning()
+			if err != nil {
+				continue
+			}
+			if wasRunning && !running {
+				onStopped()
+			}
+			wasRunning = running
+		}
+	}
+}

--- a/internal/infrastructure/logwatcher/vrchat_process_monitor_test.go
+++ b/internal/infrastructure/logwatcher/vrchat_process_monitor_test.go
@@ -1,0 +1,64 @@
+package logwatcher
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type stubVRChatRunningChecker struct {
+	running atomic.Bool
+}
+
+func (s *stubVRChatRunningChecker) VRChatRunning() (bool, error) {
+	return s.running.Load(), nil
+}
+
+func TestMonitorVRChatRunning_callsOnStoppedOnRunningToStopped(t *testing.T) {
+	checker := &stubVRChatRunningChecker{}
+	checker.running.Store(true)
+	var stopped atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = MonitorVRChatRunning(ctx, 10*time.Millisecond, checker, func() {
+			stopped.Add(1)
+		})
+		close(done)
+	}()
+
+	time.Sleep(25 * time.Millisecond)
+	checker.running.Store(false)
+	time.Sleep(40 * time.Millisecond)
+	cancel()
+	<-done
+
+	if stopped.Load() != 1 {
+		t.Fatalf("onStopped calls = %d, want 1", stopped.Load())
+	}
+}
+
+func TestMonitorVRChatRunning_notCalledWhenNeverRunning(t *testing.T) {
+	checker := &stubVRChatRunningChecker{}
+	var stopped atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		_ = MonitorVRChatRunning(ctx, 10*time.Millisecond, checker, func() {
+			stopped.Add(1)
+		})
+		close(done)
+	}()
+
+	time.Sleep(35 * time.Millisecond)
+	cancel()
+	<-done
+
+	if stopped.Load() != 0 {
+		t.Fatalf("onStopped calls = %d, want 0", stopped.Load())
+	}
+}


### PR DESCRIPTION
## Summary

- VRChat 終了時に `OnLeftRoom` がログに残らない場合でも、プロセス終了検知またはログファイル切り替え時に開いているプレイセッション・遭遇記録を確定する
- 新しい `output_log` へ切り替わった際、末尾シークで読み飛ばされていた起動直後の行（`Destination set` / `Entering Room` など）を先頭から取り込む

## Test plan

- [x] `make fmt`
- [x] `make test`
- [x] `make lint`
- [ ] VRCTweaker 起動中に VRChat を終了し、アクティビティで退出が記録されることを確認
- [ ] その後 VRChat を再起動し、ワールド名が記録されることを確認


Made with [Cursor](https://cursor.com)