### PR TITLE
refactor: slim bindings.go — expose domain DTOs via Wails (#130)

### DIFF
--- a/app.go
+++ b/app.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/domain/automation"
 	"vrchat-tweaker/internal/domain/launcher"
 	"vrchat-tweaker/internal/domain/media"
 	"vrchat-tweaker/internal/domain/vrchatconfig"
@@ -621,14 +622,17 @@ func (a *App) DeleteLaunchProfile(id string) error {
 }
 
 // ParseLaunchArgsForGUI parses a launch arguments string into GUI fields.
-func (a *App) ParseLaunchArgsForGUI(args string) LaunchArgsParsedDTO {
+func (a *App) ParseLaunchArgsForGUI(args string) launcher.LaunchArgsParsed {
 	p := launcher.ParseLaunchArgsForGUI(args)
-	return toLaunchArgsParsedDTO(p)
+	if p == nil {
+		return launcher.LaunchArgsParsed{}
+	}
+	return *p
 }
 
 // MergeLaunchArgsForGUI builds a launch arguments string from GUI state.
-func (a *App) MergeLaunchArgsForGUI(dto LaunchArgsParsedDTO) string {
-	return launcher.MergeLaunchArgsForGUI(fromLaunchArgsParsedDTO(dto))
+func (a *App) MergeLaunchArgsForGUI(parsed launcher.LaunchArgsParsed) string {
+	return launcher.MergeLaunchArgsForGUI(&parsed)
 }
 
 // --- Settings bindings ---
@@ -654,17 +658,20 @@ func (a *App) SaveOutputLogPath(path string) error {
 }
 
 // GetPathSettings returns VRChat/Steam/output_log path settings.
-func (a *App) GetPathSettings() (PathSettingsDTO, error) {
+func (a *App) GetPathSettings() (usecase.PathSettings, error) {
 	ps, err := a.settings.GetPathSettings(a.ctx)
 	if err != nil {
-		return PathSettingsDTO{}, err
+		return usecase.PathSettings{}, err
 	}
-	return toPathSettingsDTO(ps), nil
+	if ps == nil {
+		return usecase.PathSettings{}, nil
+	}
+	return *ps, nil
 }
 
 // SetPathSettings saves path settings.
-func (a *App) SetPathSettings(dto PathSettingsDTO) error {
-	return a.settings.SetPathSettings(a.ctx, toPathSettings(dto))
+func (a *App) SetPathSettings(ps usecase.PathSettings) error {
+	return a.settings.SetPathSettings(a.ctx, &ps)
 }
 
 // GetSuppressSleepWhileVRChat returns whether sleep is suppressed while VRChat.exe runs (Windows).
@@ -826,7 +833,7 @@ func (e *scanProgressEmitter) emit(p usecase.ScanProgress) {
 	e.pending = p
 	e.hasPending = true
 	if time.Since(e.lastEmit) >= galleryScanProgressEmitMinInterval {
-		runtime.EventsEmit(e.ctx, galleryScanProgressEvent, toScanProgressDTO(e.pending))
+		runtime.EventsEmit(e.ctx, galleryScanProgressEvent, e.pending)
 		e.lastEmit = time.Now()
 		e.hasPending = false
 	}
@@ -838,7 +845,7 @@ func (e *scanProgressEmitter) flush() {
 	if !e.hasPending {
 		return
 	}
-	runtime.EventsEmit(e.ctx, galleryScanProgressEvent, toScanProgressDTO(e.pending))
+	runtime.EventsEmit(e.ctx, galleryScanProgressEvent, e.pending)
 	e.lastEmit = time.Now()
 	e.hasPending = false
 }
@@ -871,7 +878,7 @@ func (a *App) ScanScreenshotDir(path string) (int, error) {
 	var err error
 	defer func() {
 		em.flush()
-		dto := GalleryScanDoneDTO{Count: count}
+		dto := usecase.GalleryScanDone{Count: count}
 		if err != nil {
 			dto.Error = err.Error()
 			if errors.Is(err, context.Canceled) {
@@ -911,12 +918,24 @@ func (a *App) ReindexScreenshotDir(path string) (int, error) {
 // --- Activity bindings ---
 
 // GetActivityStats returns aggregated play stats for the date range.
-func (a *App) GetActivityStats(fromISO, toISO string) (ActivityStatsDTO, error) {
+func (a *App) GetActivityStats(fromISO, toISO string) (activity.ActivityStats, error) {
 	stats, err := a.activity.GetActivityStats(a.ctx, fromISO, toISO)
 	if err != nil {
-		return ActivityStatsDTO{}, err
+		return activity.ActivityStats{}, err
 	}
-	return toActivityStatsDTO(stats), nil
+	if stats == nil {
+		return activity.ActivityStats{
+			DailyPlaySeconds: []activity.DailyPlaySeconds{},
+			TopWorlds:        []activity.TopWorldSummary{},
+		}, nil
+	}
+	if stats.DailyPlaySeconds == nil {
+		stats.DailyPlaySeconds = []activity.DailyPlaySeconds{}
+	}
+	if stats.TopWorlds == nil {
+		stats.TopWorlds = []activity.TopWorldSummary{}
+	}
+	return *stats, nil
 }
 
 // Encounters returns user encounters.
@@ -1220,17 +1239,13 @@ func (a *App) SetStatusAndDescription(status, description string) error {
 // --- Automation bindings ---
 
 // ListAutomationRules returns all automation rules.
-func (a *App) ListAutomationRules() ([]AutomationRuleDTO, error) {
-	list, err := a.automation.ListRules(a.ctx)
-	if err != nil {
-		return nil, err
-	}
-	return toAutomationRuleDTOs(list), nil
+func (a *App) ListAutomationRules() ([]*automation.AutomationRule, error) {
+	return a.automation.ListRules(a.ctx)
 }
 
 // SaveAutomationRule persists an automation rule.
-func (a *App) SaveAutomationRule(rule AutomationRuleDTO) error {
-	return a.automation.SaveRule(a.ctx, toAutomationRule(rule))
+func (a *App) SaveAutomationRule(rule automation.AutomationRule) error {
+	return a.automation.SaveRule(a.ctx, &rule)
 }
 
 // DeleteAutomationRule removes an automation rule by ID.

--- a/bindings.go
+++ b/bindings.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	"time"
-
 	"vrchat-tweaker/internal/domain/activity"
-	"vrchat-tweaker/internal/domain/automation"
 	"vrchat-tweaker/internal/domain/identity"
 	"vrchat-tweaker/internal/domain/launcher"
 	"vrchat-tweaker/internal/domain/media"
 	"vrchat-tweaker/internal/domain/vrchatconfig"
-	"vrchat-tweaker/internal/usecase"
 )
 
 // LaunchProfileDTO is the frontend-facing launch profile.
@@ -22,33 +18,6 @@ type LaunchProfileDTO struct {
 	UpdatedAt *string `json:"updatedAt,omitempty"`
 }
 
-// LaunchArgsParsedDTO is the GUI-parsed launch arguments.
-type LaunchArgsParsedDTO struct {
-	NoVR                        bool   `json:"noVr"`       // -no-vr (デスクトップモード)
-	ScreenMode                  string `json:"screenMode"` // fullscreen|windowed|popupwindow
-	ScreenWidth                 int    `json:"screenWidth"`
-	ScreenHeight                int    `json:"screenHeight"`
-	FPS                         int    `json:"fps"`
-	SkipRegistry                bool   `json:"skipRegistry"`
-	ProcessPriority             int    `json:"processPriority"`    // -2..2, -999=omit
-	MainThreadPriority          int    `json:"mainThreadPriority"` // -2..2, -999=omit
-	Monitor                     int    `json:"monitor"`            // -monitor N (1-based), 0=omit
-	Profile                     int    `json:"profile"`            // --profile=X, -1=omit
-	EnableDebugGui              bool   `json:"enableDebugGui"`
-	EnableSDKLogLevels          bool   `json:"enableSDKLogLevels"`
-	EnableUdonDebugLogging      bool   `json:"enableUdonDebugLogging"`
-	Midi                        string `json:"midi"`
-	WatchWorlds                 bool   `json:"watchWorlds"`
-	WatchAvatars                bool   `json:"watchAvatars"`
-	IgnoreTrackers              string `json:"ignoreTrackers"`
-	VideoDecoding               string `json:"videoDecoding"` // ""|software|hardware
-	DisableAMDStutterWorkaround bool   `json:"disableAMDStutterWorkaround"`
-	OSC                         string `json:"osc"`
-	Affinity                    string `json:"affinity"`
-	EnforceWorldServerChecks    bool   `json:"enforceWorldServerChecks"`
-	Custom                      string `json:"custom"`
-}
-
 func toLaunchProfileDTOs(list []*launcher.LaunchProfile) []LaunchProfileDTO {
 	out := make([]LaunchProfileDTO, len(list))
 	for i, p := range list {
@@ -57,76 +26,11 @@ func toLaunchProfileDTOs(list []*launcher.LaunchProfile) []LaunchProfileDTO {
 			Name:      p.Name,
 			Arguments: p.Arguments,
 			IsDefault: p.IsDefault,
-		}
-		if p.CreatedAt != nil {
-			s := p.CreatedAt.Format(time.RFC3339)
-			out[i].CreatedAt = &s
-		}
-		if p.UpdatedAt != nil {
-			s := p.UpdatedAt.Format(time.RFC3339)
-			out[i].UpdatedAt = &s
+			CreatedAt: formatRFC3339Ptr(p.CreatedAt),
+			UpdatedAt: formatRFC3339Ptr(p.UpdatedAt),
 		}
 	}
 	return out
-}
-
-func toLaunchArgsParsedDTO(p *launcher.LaunchArgsParsed) LaunchArgsParsedDTO {
-	if p == nil {
-		return LaunchArgsParsedDTO{}
-	}
-	return LaunchArgsParsedDTO{
-		NoVR:                        p.NoVR,
-		ScreenMode:                  p.ScreenMode,
-		ScreenWidth:                 p.ScreenWidth,
-		ScreenHeight:                p.ScreenHeight,
-		FPS:                         p.FPS,
-		SkipRegistry:                p.SkipRegistry,
-		ProcessPriority:             p.ProcessPriority,
-		MainThreadPriority:          p.MainThreadPriority,
-		Monitor:                     p.Monitor,
-		Profile:                     p.Profile,
-		EnableDebugGui:              p.EnableDebugGui,
-		EnableSDKLogLevels:          p.EnableSDKLogLevels,
-		EnableUdonDebugLogging:      p.EnableUdonDebugLogging,
-		Midi:                        p.Midi,
-		WatchWorlds:                 p.WatchWorlds,
-		WatchAvatars:                p.WatchAvatars,
-		IgnoreTrackers:              p.IgnoreTrackers,
-		VideoDecoding:               p.VideoDecoding,
-		DisableAMDStutterWorkaround: p.DisableAMDStutterWorkaround,
-		OSC:                         p.OSC,
-		Affinity:                    p.Affinity,
-		EnforceWorldServerChecks:    p.EnforceWorldServerChecks,
-		Custom:                      p.Custom,
-	}
-}
-
-func fromLaunchArgsParsedDTO(d LaunchArgsParsedDTO) *launcher.LaunchArgsParsed {
-	return &launcher.LaunchArgsParsed{
-		NoVR:                        d.NoVR,
-		ScreenMode:                  d.ScreenMode,
-		ScreenWidth:                 d.ScreenWidth,
-		ScreenHeight:                d.ScreenHeight,
-		FPS:                         d.FPS,
-		SkipRegistry:                d.SkipRegistry,
-		ProcessPriority:             d.ProcessPriority,
-		MainThreadPriority:          d.MainThreadPriority,
-		Monitor:                     d.Monitor,
-		Profile:                     d.Profile,
-		EnableDebugGui:              d.EnableDebugGui,
-		EnableSDKLogLevels:          d.EnableSDKLogLevels,
-		EnableUdonDebugLogging:      d.EnableUdonDebugLogging,
-		Midi:                        d.Midi,
-		WatchWorlds:                 d.WatchWorlds,
-		WatchAvatars:                d.WatchAvatars,
-		IgnoreTrackers:              d.IgnoreTrackers,
-		VideoDecoding:               d.VideoDecoding,
-		DisableAMDStutterWorkaround: d.DisableAMDStutterWorkaround,
-		OSC:                         d.OSC,
-		Affinity:                    d.Affinity,
-		EnforceWorldServerChecks:    d.EnforceWorldServerChecks,
-		Custom:                      d.Custom,
-	}
 }
 
 func toLaunchProfile(d LaunchProfileDTO) *launcher.LaunchProfile {
@@ -135,14 +39,8 @@ func toLaunchProfile(d LaunchProfileDTO) *launcher.LaunchProfile {
 		Name:      d.Name,
 		Arguments: d.Arguments,
 		IsDefault: d.IsDefault,
-	}
-	if d.CreatedAt != nil {
-		t, _ := time.Parse(time.RFC3339, *d.CreatedAt)
-		p.CreatedAt = &t
-	}
-	if d.UpdatedAt != nil {
-		t, _ := time.Parse(time.RFC3339, *d.UpdatedAt)
-		p.UpdatedAt = &t
+		CreatedAt: parseRFC3339Ptr(d.CreatedAt),
+		UpdatedAt: parseRFC3339Ptr(d.UpdatedAt),
 	}
 	return p
 }
@@ -167,31 +65,6 @@ type ScreenshotSearchDTO struct {
 	DateTo    string `json:"dateTo,omitempty"`   // ISO date or datetime
 }
 
-// ScanProgressDTO is emitted on Wails event gallery:scan-progress during ScanScreenshotDir.
-// The backend also emits gallery:screenshots-changed (no DTO) when the picture folder watcher ingests a new screenshot.
-type ScanProgressDTO struct {
-	Phase   string `json:"phase"`
-	Current int    `json:"current"`
-	Total   int    `json:"total"`
-	Item    string `json:"item,omitempty"`
-}
-
-func toScanProgressDTO(p usecase.ScanProgress) ScanProgressDTO {
-	return ScanProgressDTO{
-		Phase:   p.Phase,
-		Current: p.Current,
-		Total:   p.Total,
-		Item:    p.Item,
-	}
-}
-
-// GalleryScanDoneDTO is emitted on Wails event gallery:scan-done when ScanScreenshotDir finishes.
-type GalleryScanDoneDTO struct {
-	Count     int    `json:"count"`
-	Error     string `json:"error,omitempty"`
-	Cancelled bool   `json:"cancelled"`
-}
-
 func toScreenshotDTOs(list []*media.Screenshot) []ScreenshotDTO {
 	out := make([]ScreenshotDTO, len(list))
 	for i, s := range list {
@@ -213,11 +86,11 @@ func toScreenshotDTO(s *media.Screenshot) *ScreenshotDTO {
 		AuthorDisplayName: s.AuthorDisplayName,
 	}
 	if s.TakenAt != nil {
-		ts := s.TakenAt.Format(time.RFC3339)
-		dto.TakenAt = &ts
+		dto.TakenAt = formatRFC3339Ptr(s.TakenAt)
 	}
 	if s.FileSizeBytes != nil {
-		dto.FileSizeBytes = s.FileSizeBytes
+		v := *s.FileSizeBytes
+		dto.FileSizeBytes = &v
 	}
 	return dto
 }
@@ -226,20 +99,8 @@ func toScreenshotFilter(d ScreenshotSearchDTO) *media.ScreenshotFilter {
 	f := &media.ScreenshotFilter{
 		WorldID:   d.WorldID,
 		WorldName: d.WorldName,
-	}
-	if d.DateFrom != "" {
-		if t, err := time.Parse(time.RFC3339, d.DateFrom); err == nil {
-			f.FromDate = &t
-		} else if t, err := time.Parse("2006-01-02", d.DateFrom); err == nil {
-			f.FromDate = &t
-		}
-	}
-	if d.DateTo != "" {
-		if t, err := time.Parse(time.RFC3339, d.DateTo); err == nil {
-			f.ToDate = &t
-		} else if t, err := time.Parse("2006-01-02", d.DateTo); err == nil {
-			f.ToDate = &t
-		}
+		FromDate:  parseDateOrRFC3339(d.DateFrom),
+		ToDate:    parseDateOrRFC3339(d.DateTo),
 	}
 	return f
 }
@@ -271,16 +132,16 @@ func toEncounterDTOsFromContext(list []*activity.EncounterWithContext) []UserEnc
 			WorldID:          e.WorldID,
 			WorldDisplayName: row.WorldDisplayName,
 			IsFirstEncounter: row.IsFirstEncounter,
-			JoinedAt:         e.JoinedAt.Format(time.RFC3339),
+			JoinedAt:         formatRFC3339(e.JoinedAt),
 		}
 		if e.LeftAt != nil {
-			dto.LeftAt = e.LeftAt.Format(time.RFC3339)
+			dto.LeftAt = formatRFC3339(*e.LeftAt)
 		}
 		if row.UserFirstSeenAt != nil {
-			dto.UserFirstSeenAt = row.UserFirstSeenAt.Format(time.RFC3339)
+			dto.UserFirstSeenAt = formatRFC3339(*row.UserFirstSeenAt)
 		}
 		if row.UserLastContactAt != nil {
-			dto.UserLastContactAt = row.UserLastContactAt.Format(time.RFC3339)
+			dto.UserLastContactAt = formatRFC3339(*row.UserLastContactAt)
 		}
 		out[i] = dto
 	}
@@ -336,7 +197,7 @@ func toUserCacheDTO(f *identity.UserCache) UserCacheDTO {
 		DisplayName:                 f.DisplayName,
 		Status:                      f.Status,
 		IsFavorite:                  f.IsFavorite,
-		LastUpdated:                 f.LastUpdated.Format(time.RFC3339),
+		LastUpdated:                 formatRFC3339(f.LastUpdated),
 		Username:                    f.Username,
 		StatusDescription:           f.StatusDescription,
 		State:                       f.UserState,
@@ -360,10 +221,10 @@ func toUserCacheDTO(f *identity.UserCache) UserCacheDTO {
 		TagsJSON:                    f.TagsJSON,
 	}
 	if f.FirstSeenAt != nil {
-		dto.FirstSeenAt = f.FirstSeenAt.Format(time.RFC3339)
+		dto.FirstSeenAt = formatRFC3339(*f.FirstSeenAt)
 	}
 	if f.LastContactAt != nil {
-		dto.LastContactAt = f.LastContactAt.Format(time.RFC3339)
+		dto.LastContactAt = formatRFC3339(*f.LastContactAt)
 	}
 	return dto
 }
@@ -398,111 +259,6 @@ type VRChatCurrentUserDTO struct {
 	CurrentAvatarThumbnailImageURL string `json:"currentAvatarThumbnailImageUrl"`
 	UserIcon                       string `json:"userIcon"`
 	ProfilePicOverrideThumbnail    string `json:"profilePicOverrideThumbnail"`
-}
-
-// PathSettingsDTO is the frontend-facing path settings.
-type PathSettingsDTO struct {
-	VRChatPathWindows string `json:"vrchatPathWindows"`
-	SteamPathLinux    string `json:"steamPathLinux"`
-	OutputLogPath     string `json:"outputLogPath"`
-}
-
-func toPathSettingsDTO(ps *usecase.PathSettings) PathSettingsDTO {
-	if ps == nil {
-		return PathSettingsDTO{}
-	}
-	return PathSettingsDTO{
-		VRChatPathWindows: ps.VRChatPathWindows,
-		SteamPathLinux:    ps.SteamPathLinux,
-		OutputLogPath:     ps.OutputLogPath,
-	}
-}
-
-func toPathSettings(d PathSettingsDTO) *usecase.PathSettings {
-	return &usecase.PathSettings{
-		VRChatPathWindows: d.VRChatPathWindows,
-		SteamPathLinux:    d.SteamPathLinux,
-		OutputLogPath:     d.OutputLogPath,
-	}
-}
-
-// DailyPlaySecondsDTO is a single day's play time for the frontend.
-type DailyPlaySecondsDTO struct {
-	Date    string `json:"date"`
-	Seconds int    `json:"seconds"`
-}
-
-// TopWorldDTO is world (or aggregate) stats for the frontend.
-type TopWorldDTO struct {
-	WorldID   string `json:"worldId"`
-	WorldName string `json:"worldName,omitempty"`
-	Seconds   int    `json:"seconds"`
-	Sessions  int    `json:"sessions"`
-}
-
-// ActivityStatsDTO is the frontend-facing activity statistics.
-type ActivityStatsDTO struct {
-	DailyPlaySeconds []DailyPlaySecondsDTO `json:"dailyPlaySeconds"`
-	TopWorlds        []TopWorldDTO         `json:"topWorlds"`
-}
-
-func toActivityStatsDTO(stats *activity.ActivityStats) ActivityStatsDTO {
-	if stats == nil {
-		return ActivityStatsDTO{DailyPlaySeconds: []DailyPlaySecondsDTO{}, TopWorlds: []TopWorldDTO{}}
-	}
-	daily := make([]DailyPlaySecondsDTO, len(stats.DailyPlaySeconds))
-	for i, d := range stats.DailyPlaySeconds {
-		daily[i] = DailyPlaySecondsDTO{Date: d.Date, Seconds: d.Seconds}
-	}
-	topWorlds := make([]TopWorldDTO, len(stats.TopWorlds))
-	for i, t := range stats.TopWorlds {
-		topWorlds[i] = TopWorldDTO{
-			WorldID:   t.WorldID,
-			WorldName: t.WorldName,
-			Seconds:   t.Seconds,
-			Sessions:  t.Sessions,
-		}
-	}
-	return ActivityStatsDTO{DailyPlaySeconds: daily, TopWorlds: topWorlds}
-}
-
-// AutomationRuleDTO is the frontend-facing automation rule.
-type AutomationRuleDTO struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	TriggerType   string `json:"triggerType"`
-	ConditionJSON string `json:"conditionJson"`
-	ActionType    string `json:"actionType"`
-	ActionPayload string `json:"actionPayload"`
-	IsEnabled     bool   `json:"isEnabled"`
-}
-
-func toAutomationRuleDTOs(list []*automation.AutomationRule) []AutomationRuleDTO {
-	out := make([]AutomationRuleDTO, len(list))
-	for i, r := range list {
-		out[i] = AutomationRuleDTO{
-			ID:            r.ID,
-			Name:          r.Name,
-			TriggerType:   r.TriggerType,
-			ConditionJSON: r.ConditionJSON,
-			ActionType:    r.ActionType,
-			ActionPayload: r.ActionPayload,
-			IsEnabled:     r.IsEnabled,
-		}
-	}
-	return out
-}
-
-func toAutomationRule(d AutomationRuleDTO) *automation.AutomationRule {
-	return &automation.AutomationRule{
-		ID:            d.ID,
-		Name:          d.Name,
-		TriggerType:   d.TriggerType,
-		ConditionJSON: d.ConditionJSON,
-		ActionType:    d.ActionType,
-		ActionPayload: d.ActionPayload,
-		IsEnabled:     d.IsEnabled,
-	}
 }
 
 // VRChatConfigDTO is the frontend-facing VRChat config.json.

--- a/bindings_time.go
+++ b/bindings_time.go
@@ -1,0 +1,39 @@
+package main
+
+import "time"
+
+func formatRFC3339(t time.Time) string {
+	return t.Format(time.RFC3339)
+}
+
+func formatRFC3339Ptr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.Format(time.RFC3339)
+	return &s
+}
+
+func parseRFC3339Ptr(s *string) *time.Time {
+	if s == nil || *s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, *s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+func parseDateOrRFC3339(s string) *time.Time {
+	if s == "" {
+		return nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return &t
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return &t
+	}
+	return nil
+}

--- a/bindings_time_test.go
+++ b/bindings_time_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDateOrRFC3339(t *testing.T) {
+	t.Parallel()
+	day := parseDateOrRFC3339("2024-06-01")
+	if day == nil {
+		t.Fatal("expected date")
+	}
+	if day.Format("2006-01-02") != "2024-06-01" {
+		t.Fatalf("got %s", day.Format(time.RFC3339))
+	}
+	rfc := parseDateOrRFC3339("2024-06-01T12:00:00Z")
+	if rfc == nil || !rfc.Equal(time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("got %v", rfc)
+	}
+	if parseDateOrRFC3339("") != nil {
+		t.Fatal("empty should be nil")
+	}
+}

--- a/frontend/src/wails/app.ts
+++ b/frontend/src/wails/app.ts
@@ -1,32 +1,38 @@
 // Wails app bindings - calls Go backend methods
 // When running in Wails, window.go.main.App is injected
 
-import { main } from "../../wailsjs/go/models";
+import {
+  activity,
+  automation,
+  launcher,
+  main,
+  usecase,
+} from "../../wailsjs/go/models";
 import type * as WailsApp from "../../wailsjs/go/main/App";
 
 /** Data fields only (wailsjs model classes may include convertValues). */
 type WailsDTO<T> = Omit<T, "convertValues">;
 
 export type LaunchProfileDTO = WailsDTO<main.LaunchProfileDTO>;
-export type LaunchArgsParsedDTO = WailsDTO<main.LaunchArgsParsedDTO>;
+export type LaunchArgsParsedDTO = WailsDTO<launcher.LaunchArgsParsed>;
 export type ScreenshotDTO = WailsDTO<main.ScreenshotDTO>;
 export type ScreenshotSearchDTO = WailsDTO<main.ScreenshotSearchDTO>;
 export type UserEncounterDTO = WailsDTO<main.UserEncounterDTO>;
 export type UserCacheDTO = WailsDTO<main.UserCacheDTO>;
 export type UserProfileNavigationDTO = WailsDTO<main.UserProfileNavigationDTO>;
-export type PathSettingsDTO = WailsDTO<main.PathSettingsDTO>;
+export type PathSettingsDTO = WailsDTO<usecase.PathSettings>;
 export type LoginResultDTO = WailsDTO<main.LoginResultDTO>;
 export type VRChatCurrentUserDTO = WailsDTO<main.VRChatCurrentUserDTO>;
-export type DailyPlaySecondsDTO = WailsDTO<main.DailyPlaySecondsDTO>;
-export type TopWorldDTO = WailsDTO<main.TopWorldDTO>;
-export type ActivityStatsDTO = WailsDTO<main.ActivityStatsDTO>;
-export type AutomationRuleDTO = WailsDTO<main.AutomationRuleDTO>;
+export type DailyPlaySecondsDTO = WailsDTO<activity.DailyPlaySeconds>;
+export type TopWorldDTO = WailsDTO<activity.TopWorldSummary>;
+export type ActivityStatsDTO = WailsDTO<activity.ActivityStats>;
+export type AutomationRuleDTO = WailsDTO<automation.AutomationRule>;
 export type VRChatConfigDTO = WailsDTO<main.VRChatConfigDTO>;
 
 /** -999 = omit for process/main thread priority */
 export const PRIORITY_OMIT = -999;
 
-/** Payload for Wails event gallery:scan-progress (matches ScanProgressDTO in Go). */
+/** Payload for Wails event gallery:scan-progress (usecase.ScanProgress). */
 export interface ScanProgressPayload {
   phase: string;
   current: number;
@@ -34,7 +40,7 @@ export interface ScanProgressPayload {
   item?: string;
 }
 
-/** Payload for Wails event gallery:scan-done (matches GalleryScanDoneDTO in Go). */
+/** Payload for Wails event gallery:scan-done (usecase.GalleryScanDone). */
 export interface GalleryScanDonePayload {
   count: number;
   error?: string;

--- a/internal/domain/activity/stats.go
+++ b/internal/domain/activity/stats.go
@@ -7,22 +7,22 @@ import (
 
 // DailyPlaySeconds represents play time for a single date.
 type DailyPlaySeconds struct {
-	Date    string // YYYY-MM-DD (local calendar)
-	Seconds int
+	Date    string `json:"date"` // YYYY-MM-DD (local calendar)
+	Seconds int    `json:"seconds"`
 }
 
 // TopWorldSummary represents aggregated stats for a world (or total when world_id is absent).
 type TopWorldSummary struct {
-	WorldID   string
-	WorldName string
-	Seconds   int
-	Sessions  int
+	WorldID   string `json:"worldId"`
+	WorldName string `json:"worldName,omitempty"`
+	Seconds   int    `json:"seconds"`
+	Sessions  int    `json:"sessions"`
 }
 
 // ActivityStats holds aggregated activity statistics.
 type ActivityStats struct {
-	DailyPlaySeconds []DailyPlaySeconds
-	TopWorlds        []TopWorldSummary
+	DailyPlaySeconds []DailyPlaySeconds `json:"dailyPlaySeconds"`
+	TopWorlds        []TopWorldSummary  `json:"topWorlds"`
 }
 
 // AggregatePlaySessions computes daily play seconds and top-world-like summary from sessions.

--- a/internal/domain/automation/entity.go
+++ b/internal/domain/automation/entity.go
@@ -2,11 +2,11 @@ package automation
 
 // AutomationRule represents an IF-THEN automation rule.
 type AutomationRule struct {
-	ID            string
-	Name          string
-	TriggerType   string // e.g., afk_detected, friend_joined
-	ConditionJSON string // JSON parameters for the trigger
-	ActionType    string // e.g., change_status
-	ActionPayload string // JSON parameters for the action
-	IsEnabled     bool
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	TriggerType   string `json:"triggerType"` // e.g., afk_detected, friend_joined
+	ConditionJSON string `json:"conditionJson"`
+	ActionType    string `json:"actionType"` // e.g., change_status
+	ActionPayload string `json:"actionPayload"`
+	IsEnabled     bool   `json:"isEnabled"`
 }

--- a/internal/domain/launcher/launch_args.go
+++ b/internal/domain/launcher/launch_args.go
@@ -24,32 +24,33 @@ const PriorityOmit = -999
 
 // LaunchArgsParsed holds GUI-friendly parsed launch arguments.
 // Per https://docs.vrchat.com/docs/launch-options
+// JSON tags are for Wails IPC (camelCase); not used for CLI parsing.
 type LaunchArgsParsed struct {
 	// 一般設定
-	NoVR       bool   // -no-vr or --no-vr (デスクトップモード)
-	ScreenMode string // fullscreen|windowed|popupwindow (replaces Fullscreen+Windowed)
+	NoVR       bool   `json:"noVr"`       // -no-vr or --no-vr (デスクトップモード)
+	ScreenMode string `json:"screenMode"` // fullscreen|windowed|popupwindow (replaces Fullscreen+Windowed)
 	// 詳細設定
-	ScreenWidth                 int    // -screen-width N, 0=omit
-	ScreenHeight                int    // -screen-height N, 0=omit
-	FPS                         int    // --fps=N, 0=omit
-	SkipRegistry                bool   // --skip-registry-install
-	ProcessPriority             int    // --process-priority=N, -2..2, PriorityOmit=omit
-	MainThreadPriority          int    // --main-thread-priority=N, -2..2, PriorityOmit=omit
-	Monitor                     int    // -monitor N (1-based), 0=omit
-	Profile                     int    // --profile=X, -1=omit
-	EnableDebugGui              bool   // --enable-debug-gui
-	EnableSDKLogLevels          bool   // --enable-sdk-log-levels
-	EnableUdonDebugLogging      bool   // --enable-udon-debug-logging
-	Midi                        string // --midi=deviceName, empty=omit
-	WatchWorlds                 bool   // --watch-worlds
-	WatchAvatars                bool   // --watch-avatars
-	IgnoreTrackers              string // --ignore-trackers=serial1,serial2
-	VideoDecoding               string // ""|software|hardware
-	DisableAMDStutterWorkaround bool   // --disable-amd-stutter-workaround
-	OSC                         string // --osc=inPort:outIP:outPort
-	Affinity                    string // --affinity=<hex>
-	EnforceWorldServerChecks    bool   // --enforce-world-server-checks
-	Custom                      string // remaining args as-is
+	ScreenWidth                 int    `json:"screenWidth"`                 // -screen-width N, 0=omit
+	ScreenHeight                int    `json:"screenHeight"`                // -screen-height N, 0=omit
+	FPS                         int    `json:"fps"`                         // --fps=N, 0=omit
+	SkipRegistry                bool   `json:"skipRegistry"`                // --skip-registry-install
+	ProcessPriority             int    `json:"processPriority"`             // --process-priority=N, -2..2, PriorityOmit=omit
+	MainThreadPriority          int    `json:"mainThreadPriority"`          // --main-thread-priority=N, -2..2, PriorityOmit=omit
+	Monitor                     int    `json:"monitor"`                     // -monitor N (1-based), 0=omit
+	Profile                     int    `json:"profile"`                     // --profile=X, -1=omit
+	EnableDebugGui              bool   `json:"enableDebugGui"`              // --enable-debug-gui
+	EnableSDKLogLevels          bool   `json:"enableSDKLogLevels"`          // --enable-sdk-log-levels
+	EnableUdonDebugLogging      bool   `json:"enableUdonDebugLogging"`      // --enable-udon-debug-logging
+	Midi                        string `json:"midi"`                        // --midi=deviceName, empty=omit
+	WatchWorlds                 bool   `json:"watchWorlds"`                 // --watch-worlds
+	WatchAvatars                bool   `json:"watchAvatars"`                // --watch-avatars
+	IgnoreTrackers              string `json:"ignoreTrackers"`              // --ignore-trackers=serial1,serial2
+	VideoDecoding               string `json:"videoDecoding"`               // ""|software|hardware
+	DisableAMDStutterWorkaround bool   `json:"disableAMDStutterWorkaround"` // --disable-amd-stutter-workaround
+	OSC                         string `json:"osc"`                         // --osc=inPort:outIP:outPort
+	Affinity                    string `json:"affinity"`                    // --affinity=<hex>
+	EnforceWorldServerChecks    bool   `json:"enforceWorldServerChecks"`    // --enforce-world-server-checks
+	Custom                      string `json:"custom"`                      // remaining args as-is
 }
 
 var (

--- a/internal/usecase/media_usecase.go
+++ b/internal/usecase/media_usecase.go
@@ -24,10 +24,17 @@ const scanListingProgressEvery = 50
 
 // ScanProgress is a snapshot for UI progress (optional callback from ScanDirectory).
 type ScanProgress struct {
-	Phase   string
-	Current int
-	Total   int
-	Item    string
+	Phase   string `json:"phase"`
+	Current int    `json:"current"`
+	Total   int    `json:"total"`
+	Item    string `json:"item,omitempty"`
+}
+
+// GalleryScanDone is emitted on Wails event gallery:scan-done when a folder scan finishes.
+type GalleryScanDone struct {
+	Count     int    `json:"count"`
+	Error     string `json:"error,omitempty"`
+	Cancelled bool   `json:"cancelled"`
 }
 
 // MediaUseCase handles screenshot scanning and management.

--- a/internal/usecase/settings_usecase.go
+++ b/internal/usecase/settings_usecase.go
@@ -138,11 +138,11 @@ func parseBoolSetting(v string) bool {
 	}
 }
 
-// PathSettings holds VRChat/Steam/output_log paths.
+// PathSettings holds VRChat/Steam/output_log paths (Wails-bound; camelCase json tags).
 type PathSettings struct {
-	VRChatPathWindows string
-	SteamPathLinux    string
-	OutputLogPath     string
+	VRChatPathWindows string `json:"vrchatPathWindows"`
+	SteamPathLinux    string `json:"steamPathLinux"`
+	OutputLogPath     string `json:"outputLogPath"`
 }
 
 // GetPathSettings returns all path settings.


### PR DESCRIPTION
## Summary

grill-me 方針 **B（軽量化）** — `bindings.go` の重複 DTO / `toXxx` を削減。

### 削除した main パッケージ DTO（domain/usecase に json タグ付与して Wails 直公開）

| 旧 DTO | 新しい公開型 |
|--------|-------------|
| `LaunchArgsParsedDTO` | `launcher.LaunchArgsParsed` |
| `PathSettingsDTO` | `usecase.PathSettings` |
| `ActivityStatsDTO` / `DailyPlaySecondsDTO` / `TopWorldDTO` | `activity.ActivityStats` 等 |
| `AutomationRuleDTO` | `automation.AutomationRule` |
| `ScanProgressDTO` / `GalleryScanDoneDTO` | `usecase.ScanProgress` / `GalleryScanDone` |

### 維持（正当な二重表現）

- `VRChatConfigDTO` — ディスク snake_case vs UI camelCase
- `UserCacheDTO` / `ScreenshotDTO` / `UserEncounterDTO` — フィールド名・時刻変換
- `LaunchProfileDTO` — `*time.Time` → RFC3339 文字列

### その他

- `bindings_time.go` — RFC3339 / 日付パース共通化
- `FileSizeBytes` ポインタ共有を修正（コピーして返却）

**差分**: `bindings.go` 556行 → 312行（+ time helper 39行）

新フィールド追加時: 上記「直公開」型は **domain + フロント（wailsjs）の 2 箇所** に集約。

## Test plan

- [x] `make fmt`
- [x] `make test`
- [x] `make lint`

Closes #130

Made with [Cursor](https://cursor.com)