### PR TITLE
fix(friends): sync all offline friends from VRChat API

### DIFF
--- a/internal/infrastructure/vrchatapi/friends.go
+++ b/internal/infrastructure/vrchatapi/friends.go
@@ -100,10 +100,10 @@ func (c *Client) GetFriends(ctx context.Context) ([]Friend, error) {
 				seen[f.ID] = struct{}{}
 				out = append(out, f)
 			}
-			if len(batch) < friendsListPageSize {
+			if len(batch) == 0 {
 				break
 			}
-			offset += friendsListPageSize
+			offset += len(batch)
 		}
 	}
 	return out, nil

--- a/internal/infrastructure/vrchatapi/friends_test.go
+++ b/internal/infrastructure/vrchatapi/friends_test.go
@@ -135,6 +135,68 @@ func TestClient_GetFriends_paginationAndOfflinePasses(t *testing.T) {
 	}
 }
 
+// ponytail: VRChat can return a short offline page before the list ends; stop on empty page, not len < n.
+func TestClient_GetFriends_continuesAfterPartialOfflinePage(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/1/auth/user/friends" {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		if q.Get("offline") != "true" {
+			_ = json.NewEncoder(w).Encode([]Friend{})
+			return
+		}
+		off, _ := strconv.Atoi(q.Get("offset"))
+		switch off {
+		case 0, 100, 200:
+			batch := make([]Friend, friendsListPageSize)
+			for i := range batch {
+				batch[i] = Friend{
+					ID:          fmt.Sprintf("usr_off_%d", off+i),
+					DisplayName: "off",
+					Status:      "offline",
+				}
+			}
+			_ = json.NewEncoder(w).Encode(batch)
+		case 300:
+			partial := make([]Friend, 30)
+			for i := range partial {
+				partial[i] = Friend{
+					ID:          fmt.Sprintf("usr_off_%d", off+i),
+					DisplayName: "off",
+					Status:      "offline",
+				}
+			}
+			_ = json.NewEncoder(w).Encode(partial)
+		case 330:
+			tail := make([]Friend, 78)
+			for i := range tail {
+				tail[i] = Friend{
+					ID:          fmt.Sprintf("usr_off_%d", off+i),
+					DisplayName: "off",
+					Status:      "offline",
+				}
+			}
+			_ = json.NewEncoder(w).Encode(tail)
+		default:
+			_ = json.NewEncoder(w).Encode([]Friend{})
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient("")
+	c.apiRoot = srv.URL + "/api/1"
+	list, err := c.GetFriends(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 408 {
+		t.Fatalf("offline pass len = %d, want 408 (330 short-page trap + 78 tail)", len(list))
+	}
+}
+
 func TestClient_GetFriends_errorsWhenPagesNeverShrink(t *testing.T) {
 	var nCalls int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Fix `GetFriends` pagination so the `offline=true` pass does not stop when VRChat returns a page smaller than `n=100` before the list actually ends.
- Stop on an empty page and advance `offset` by `len(batch)` instead of always adding 100.
- Add regression test reproducing the 100×3 + 30 + 78 offline pattern that caused ~74 friends to be missing from sync.

## Context

Users with large friend lists saw offline friends missing from the Tweaker friends view even though they appeared in the official VRChat client. Example: official All Friends 557 vs cached 483 before fix; after cache clear + new binary, sync reached 557.

## Test plan

- [x] `go test ./internal/infrastructure/vrchatapi/ -run GetFriends`
- [x] `make fmt`, `make test`, `make lint`
- [x] Manual: clear friends cache, refresh with new binary → DB `user_kind=friend` count matches VRChat All Friends (557)