### PR TITLE
chore(test): use synthetic VRChat users in committed Go tests

### DIFF
--- a/app_activity_bootstrap_test.go
+++ b/app_activity_bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	"vrchat-tweaker/internal/domain/activity"
 	"vrchat-tweaker/internal/infrastructure/logwatcher"
 	"vrchat-tweaker/internal/infrastructure/sqlite"
+	"vrchat-tweaker/internal/testvrc"
 	"vrchat-tweaker/internal/usecase"
 )
 
@@ -227,8 +228,8 @@ func Test_ingestActivityLogsBootstrap_checkpointResume_assignsWorldRoomName(t *t
 		cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
 		buddyID   = "usr_buddy"
 	)
-	homeInst := homeWorld + ":95147~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
-	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	homeInst := homeWorld + ":95147~private(" + testvrc.PlayerUserID + ")~region(jp)"
+	cozyInst := cozyWorld + ":48580~friends(" + testvrc.FriendsHostUserID + ")~region(jp)"
 
 	prefix := []byte(
 		"2026.06.24 08:25:00 Debug      -  [Behaviour] Destination set: " + homeInst + "\n" +
@@ -291,7 +292,7 @@ func Test_ingestActivityLogsBootstrap_checkpointResume_homeEncounterKeepsWorldID
 
 	const (
 		homeWorld = "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b"
-		hostID    = "usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e"
+		hostID    = testvrc.PlayerUserID
 	)
 	homeInst := homeWorld + ":95147~private(" + hostID + ")~region(jp)"
 
@@ -302,7 +303,7 @@ func Test_ingestActivityLogsBootstrap_checkpointResume_homeEncounterKeepsWorldID
 			"2026.06.24 08:25:03 Debug      -  [Behaviour] Joining " + homeInst + "\n",
 	)
 	suffix := []byte(
-		"2026.06.24 08:25:18 Debug      -  [Behaviour] OnPlayerJoined ぶっちゃん！ (" + hostID + ")\n",
+		"2026.06.24 08:25:18 Debug      -  [Behaviour] OnPlayerJoined " + testvrc.PlayerDisplayName + " (" + hostID + ")\n",
 	)
 	if writeErr := os.WriteFile(logPath, prefix, 0600); writeErr != nil {
 		t.Fatal(writeErr)
@@ -352,18 +353,18 @@ func Test_ingestActivityLogsBootstrap_checkpointResume_worldNamesNotCrossAssigne
 	const (
 		homeWorld = "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b"
 		cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
-		hostID    = "usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e"
+		hostID    = testvrc.PlayerUserID
 		buddyID   = "usr_buddy"
 	)
 	homeInst := homeWorld + ":95147~private(" + hostID + ")~region(jp)"
-	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	cozyInst := cozyWorld + ":48580~friends(" + testvrc.FriendsHostUserID + ")~region(jp)"
 
 	prefix := []byte(
 		"2026.06.24 08:25:00 Debug      -  [Behaviour] Destination set: " + homeInst + "\n" +
 			"2026.06.24 08:25:01 Debug      -  [Behaviour] OnLeftRoom\n" +
 			"2026.06.24 08:25:03 Debug      -  [Behaviour] Entering Room: ホームチェックv6․0\n" +
 			"2026.06.24 08:25:03 Debug      -  [Behaviour] Joining " + homeInst + "\n" +
-			"2026.06.24 08:25:18 Debug      -  [Behaviour] OnPlayerJoined ぶっちゃん！ (" + hostID + ")\n",
+			"2026.06.24 08:25:18 Debug      -  [Behaviour] OnPlayerJoined " + testvrc.PlayerDisplayName + " (" + hostID + ")\n",
 	)
 	suffix := []byte(
 		"2026.06.24 08:26:40 Debug      -  [Behaviour] Destination set: " + cozyInst + "\n" +
@@ -384,7 +385,7 @@ func Test_ingestActivityLogsBootstrap_checkpointResume_worldNamesNotCrossAssigne
 	if seedErr := encounterRepo.Save(ctx, &activity.UserEncounter{
 		ID:          "enc-home-seed",
 		VRCUserID:   hostID,
-		DisplayName: "ぶっちゃん！",
+		DisplayName: testvrc.PlayerDisplayName,
 		InstanceID:  homeInst,
 		WorldID:     homeWorld,
 		JoinedAt:    homeJoinedAt,

--- a/app_activity_log_rotation_test.go
+++ b/app_activity_log_rotation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"vrchat-tweaker/internal/domain/activity"
 	"vrchat-tweaker/internal/infrastructure/logwatcher"
+	"vrchat-tweaker/internal/testvrc"
 )
 
 func Test_handleActivityLogFileSwitch_finalizesOldSessionAndRecordsWorldName(t *testing.T) {
@@ -17,7 +18,7 @@ func Test_handleActivityLogFileSwitch_finalizesOldSessionAndRecordsWorldName(t *
 	dir := t.TempDir()
 
 	const cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
-	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	cozyInst := cozyWorld + ":48580~friends(" + testvrc.FriendsHostUserID + ")~region(jp)"
 	joinedAt := time.Date(2026, 6, 24, 8, 20, 0, 0, time.UTC)
 
 	oldPath := filepath.Join(dir, "output_log_2026-06-24_08-00-00.txt")

--- a/docs/agents/redaction.md
+++ b/docs/agents/redaction.md
@@ -15,7 +15,9 @@ Applies when writing or editing:
 | Commits | Message, branch name |
 | Agent outputs | PR drafts, issue drafts, triage notes under `docs/ai_dlc/`, chat summaries intended for paste into GitHub |
 
-**Out of scope (this policy):** unit/E2E test fixtures and committed test log snippets. Prefer synthetic IDs for **new** tests (`usr_e2e_*`, `usr_a1111111-...`). Existing tests may still contain real IDs from log captures; cleaning them is a separate task.
+**Out of scope (this policy):** live bug reports in chat (redact before pasting to GitHub).
+
+**Committed tests:** use synthetic users from `internal/testvrc` — not real display names or production `usr_*` IDs from log captures.
 
 ## Forbidden in scope
 

--- a/internal/domain/activity/log_parser_test.go
+++ b/internal/domain/activity/log_parser_test.go
@@ -1,8 +1,11 @@
 package activity
 
 import (
+	"fmt"
 	"testing"
 	"time"
+
+	"vrchat-tweaker/internal/testvrc"
 )
 
 func TestLogParser_ParseLine_Encounter(t *testing.T) {
@@ -35,11 +38,11 @@ func TestLogParser_ParseLine_Encounter(t *testing.T) {
 		},
 		{
 			name:     "OnPlayerJoined VRChat Behaviour line",
-			line:     "2026.03.21 11:32:16 Debug      -  [Behaviour] OnPlayerJoined ぶっちゃん！ (usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)",
+			line:     fmt.Sprintf("2026.03.21 11:32:16 Debug      -  [Behaviour] OnPlayerJoined %s (%s)", testvrc.PlayerDisplayName, testvrc.PlayerUserID),
 			wantKind: EventKindEncounter,
 			wantAct:  EncounterActionJoin,
-			wantName: "ぶっちゃん！",
-			wantID:   "usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e",
+			wantName: testvrc.PlayerDisplayName,
+			wantID:   testvrc.PlayerUserID,
 		},
 		{
 			name:     "OnPlayerLeft with user ID",
@@ -221,7 +224,7 @@ func TestLogParser_ParseLine_Unparseable(t *testing.T) {
 		"Loading level",
 		"[Time: 1.0] Unrelated message",
 		"OnPlayerJoined Alice (usr_abc123)",
-		"2026.03.21 11:32:16 Debug      -  [VisitorsInformationBoard] 18.88 / OnPlayerJoined / player=ぶっちゃん！(local)",
+		"2026.03.21 11:32:16 Debug      -  [VisitorsInformationBoard] 18.88 / OnPlayerJoined / player=TestPlayerAlpha(local)",
 		"Destination set: wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b:64190~private(usr_x)~region(jp)",
 		"Entering Room: SomeWorld",
 	}
@@ -241,7 +244,7 @@ func TestLogParser_ParseLine_DestinationRoomAvatarVideo(t *testing.T) {
 	p := NewLogParser()
 
 	t.Run("Destination set", func(t *testing.T) {
-		line := "2026.03.17 23:59:56 Debug      -  [Behaviour] Destination set: wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b:64190~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
+		line := fmt.Sprintf("2026.03.17 23:59:56 Debug      -  [Behaviour] Destination set: wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b:64190~private(%s)~region(jp)", testvrc.PlayerUserID)
 		events, err := p.ParseLine(line, base)
 		if err != nil {
 			t.Fatal(err)
@@ -256,7 +259,7 @@ func TestLogParser_ParseLine_DestinationRoomAvatarVideo(t *testing.T) {
 		if d.WorldID != "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b" || d.InstanceID != "64190" || d.InstanceType != "private" {
 			t.Errorf("destination fields %+v", d)
 		}
-		if d.OwnerUserID != "usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e" || d.Region != "jp" {
+		if d.OwnerUserID != testvrc.PlayerUserID || d.Region != "jp" {
 			t.Errorf("owner/region %+v", d)
 		}
 	})
@@ -306,7 +309,7 @@ func TestLogParser_ParseLine_DestinationRoomAvatarVideo(t *testing.T) {
 	})
 
 	t.Run("Avatar switch", func(t *testing.T) {
-		line := "2026.03.18 00:00:08 Debug      -  [Behaviour] Switching ぶっちゃん！ to avatar RearAlice （SailorMaid）"
+		line := "2026.03.18 00:00:08 Debug      -  [Behaviour] Switching TestPlayerAlpha to avatar RearAlice （SailorMaid）"
 		events, err := p.ParseLine(line, base)
 		if err != nil {
 			t.Fatal(err)
@@ -318,7 +321,7 @@ func TestLogParser_ParseLine_DestinationRoomAvatarVideo(t *testing.T) {
 		if !ok {
 			t.Fatalf("type %T", events[0])
 		}
-		if a.DisplayName != "ぶっちゃん！" || a.AvatarName != "RearAlice （SailorMaid）" {
+		if a.DisplayName != "TestPlayerAlpha" || a.AvatarName != "RearAlice （SailorMaid）" {
 			t.Errorf("avatar %+v", a)
 		}
 	})

--- a/internal/domain/activity/session_correlator_test.go
+++ b/internal/domain/activity/session_correlator_test.go
@@ -3,11 +3,13 @@ package activity
 import (
 	"testing"
 	"time"
+
+	"vrchat-tweaker/internal/testvrc"
 )
 
 const testWorldID = "wrld_beddab1e-fee1-cafe-f00d-ca7c0dd1eca7"
 
-var testFullInstance = testWorldID + ":41550~hidden(usr_aeab2f4d-40b4-4f73-acbd-608ac47b763e)~region(jp)"
+var testFullInstance = testWorldID + ":41550~hidden(" + testvrc.EmbedUserID + ")~region(jp)"
 
 func TestSessionCorrelator_RoomNameAfterOnLeftRoom_usesPendingDestinationWorld(t *testing.T) {
 	base := time.Date(2026, 3, 22, 11, 23, 51, 0, time.UTC)
@@ -37,9 +39,9 @@ func TestSessionCorrelator_RoomNameAfterOnLeftRoom_usesPendingDestinationWorld(t
 func TestSessionCorrelator_ResetBetweenLogFiles_RoomNameUsesPendingDestination(t *testing.T) {
 	base := time.Date(2026, 3, 18, 0, 30, 0, 0, time.UTC)
 	const prevWorld = "wrld_c03f8195-3c64-46d8-b5ae-242f214c9404"
-	prevInst := prevWorld + ":98225~hidden(usr_83ba5dc2-2912-4a21-a514-8b954e60a79b)~region(jp)"
+	prevInst := prevWorld + ":98225~hidden(" + testvrc.HiddenHostUserID + ")~region(jp)"
 	const nextWorld = "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b"
-	nextInst := nextWorld + ":77788~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
+	nextInst := nextWorld + ":77788~private(" + testvrc.PlayerUserID + ")~region(jp)"
 
 	c := &SessionCorrelator{}
 	c.Apply(&SessionEvent{Type: SessionEventStart, InstanceID: prevInst, OccurredAt: base})
@@ -63,7 +65,7 @@ func TestSessionCorrelator_ResetBetweenLogFiles_RoomNameUsesPendingDestination(t
 func TestSessionCorrelator_RoomNameWithoutOnLeftRoom_unchanged(t *testing.T) {
 	base := time.Date(2026, 3, 22, 11, 22, 51, 0, time.UTC)
 	const homeWorld = "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b"
-	homeInst := homeWorld + ":04910~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
+	homeInst := homeWorld + ":04910~private(" + testvrc.PlayerUserID + ")~region(jp)"
 	c := &SessionCorrelator{}
 
 	c.Apply(&DestinationSetEvent{
@@ -83,9 +85,9 @@ func TestSessionCorrelator_RoomNameWithoutOnLeftRoom_unchanged(t *testing.T) {
 func TestSessionCorrelator_RoomName_prefersPendingOverActiveSession(t *testing.T) {
 	base := time.Date(2026, 6, 24, 8, 26, 44, 0, time.UTC)
 	const oldWorld = "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b"
-	oldInst := oldWorld + ":95147~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
+	oldInst := oldWorld + ":95147~private(" + testvrc.PlayerUserID + ")~region(jp)"
 	const newWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
-	newInst := newWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	newInst := newWorld + ":48580~friends(" + testvrc.FriendsHostUserID + ")~region(jp)"
 
 	c := &SessionCorrelator{}
 	c.Apply(&SessionEvent{Type: SessionEventStart, InstanceID: oldInst, OccurredAt: base})
@@ -108,8 +110,8 @@ func TestSessionCorrelator_RoomName_prefersPendingOverActiveSession(t *testing.T
 func TestSessionCorrelator_OtherPlayerLeave_afterJoining_keepsWorldContext(t *testing.T) {
 	base := time.Date(2026, 3, 18, 0, 1, 0, 0, time.UTC)
 	const minasocoWorld = "wrld_c03f8195-3c64-46d8-b5ae-242f214c9404"
-	minasocoInst := minasocoWorld + ":98225~hidden(usr_83ba5dc2-2912-4a21-a514-8b954e60a79b)~region(jp)"
-	const otherUser = "usr_1564b5c1-888a-4d08-b7f4-dcedcf702a90"
+	minasocoInst := minasocoWorld + ":98225~hidden(" + testvrc.HiddenHostUserID + ")~region(jp)"
+	otherUser := testvrc.OtherPlayerUserID
 
 	c := &SessionCorrelator{}
 	c.Apply(&DestinationSetEvent{
@@ -149,15 +151,15 @@ func TestSessionCorrelator_OtherPlayerLeave_afterJoining_keepsWorldContext(t *te
 func TestSessionCorrelator_Leave_afterDestinationBeforeJoin_usesLastSessionNotPending(t *testing.T) {
 	base := time.Date(2026, 3, 22, 14, 20, 45, 0, time.UTC)
 	const homeWorld = "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b"
-	oldInst := homeWorld + ":85625~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
-	nextInst := homeWorld + ":62566~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
-	const buddy = "usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e"
+	oldInst := homeWorld + ":85625~private(" + testvrc.PlayerUserID + ")~region(jp)"
+	nextInst := homeWorld + ":62566~private(" + testvrc.PlayerUserID + ")~region(jp)"
+	buddy := testvrc.PlayerUserID
 
 	c := &SessionCorrelator{}
 	c.Apply(&SessionEvent{Type: SessionEventStart, InstanceID: oldInst, OccurredAt: base})
 	c.Apply(&EncounterEvent{
 		VRCUserID:     buddy,
-		DisplayName:   "ぶっちゃん！",
+		DisplayName:   testvrc.PlayerDisplayName,
 		Action:        EncounterActionJoin,
 		EncounteredAt: base,
 	})
@@ -169,7 +171,7 @@ func TestSessionCorrelator_Leave_afterDestinationBeforeJoin_usesLastSessionNotPe
 	c.Apply(&SessionEvent{Type: SessionEventEnd, OccurredAt: base})
 	leaveCmds := c.Apply(&EncounterEvent{
 		VRCUserID:     buddy,
-		DisplayName:   "ぶっちゃん！",
+		DisplayName:   testvrc.PlayerDisplayName,
 		Action:        EncounterActionLeave,
 		EncounteredAt: base.Add(time.Millisecond),
 	})
@@ -228,8 +230,8 @@ func TestSessionCorrelator_logReplay_homeToCozyTransition_roomNamesNotCrossAssig
 		homeWorld = "wrld_e055f1a3-6fcb-4d19-9945-f0a1c92cc19b"
 		cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
 	)
-	homeInst := homeWorld + ":95147~private(usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e)~region(jp)"
-	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	homeInst := homeWorld + ":95147~private(" + testvrc.PlayerUserID + ")~region(jp)"
+	cozyInst := cozyWorld + ":48580~friends(" + testvrc.FriendsHostUserID + ")~region(jp)"
 
 	lines := []string{
 		"2026.06.24 08:25:00 Debug      -  [Behaviour] Destination set: " + homeInst,

--- a/internal/domain/media/metadata_extractor_test.go
+++ b/internal/domain/media/metadata_extractor_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"vrchat-tweaker/internal/testvrc"
 )
 
 //go:embed testdata/minimal_exif.jpg
@@ -121,7 +123,7 @@ func TestDefaultMetadataExtractor_Extract_JPEGWithXMP(t *testing.T) {
 <rdf:Description xmlns:vrc="http://vrchat.com/ns/"
   vrc:WorldID="wrld_db637cfb-64f8-4109-977b-6b755482f133"
   vrc:WorldDisplayName="Test Room"
-  vrc:AuthorID="usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e"
+  vrc:AuthorID="` + testvrc.PlayerUserID + `"
   xmlns:xmp="http://ns.adobe.com/xap/1.0/"
   xmp:Author="Tester"
   xmp:CreateDate="2026:02:17 00:01:28+09:00"

--- a/internal/domain/media/xmp_test.go
+++ b/internal/domain/media/xmp_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"testing"
 	"time"
+
+	"vrchat-tweaker/internal/testvrc"
 )
 
 func TestParseVRChatXMP_sampleAttributes(t *testing.T) {
@@ -13,9 +15,9 @@ func TestParseVRChatXMP_sampleAttributes(t *testing.T) {
 <rdf:Description xmlns:vrc="http://vrchat.com/ns/"
   vrc:WorldID="wrld_db637cfb-64f8-4109-977b-6b755482f133"
   vrc:WorldDisplayName="PARA ROOM"
-  vrc:AuthorID="usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e"
+  vrc:AuthorID="` + testvrc.PlayerUserID + `"
   xmlns:xmp="http://ns.adobe.com/xap/1.0/"
-  xmp:Author="ぶっちゃん！"
+  xmp:Author="` + testvrc.PlayerDisplayName + `"
   xmp:CreateDate="2026:02:17 00:01:28.5281072+09:00"
 />
 </rdf:RDF>
@@ -27,10 +29,10 @@ func TestParseVRChatXMP_sampleAttributes(t *testing.T) {
 	if m.WorldDisplayName != "PARA ROOM" {
 		t.Errorf("WorldDisplayName = %q", m.WorldDisplayName)
 	}
-	if m.AuthorVRCUserID != "usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e" {
+	if m.AuthorVRCUserID != testvrc.PlayerUserID {
 		t.Errorf("AuthorVRCUserID = %q", m.AuthorVRCUserID)
 	}
-	if m.AuthorDisplayName != "ぶっちゃん！" {
+	if m.AuthorDisplayName != testvrc.PlayerDisplayName {
 		t.Errorf("AuthorDisplayName = %q", m.AuthorDisplayName)
 	}
 	if m.TakenAt == nil {
@@ -156,7 +158,7 @@ func TestParseVRChatXMP_elementFallbacks(t *testing.T) {
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 <WorldID>wrld_db637cfb-64f8-4109-977b-6b755482f133</WorldID>
 <vrc:WorldDisplayName>Elem World</vrc:WorldDisplayName>
-<AuthorID>usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e</AuthorID>
+<AuthorID>` + testvrc.PlayerUserID + `</AuthorID>
 <rdf:li>Elem Author</rdf:li>
 </rdf:RDF>
 </x:xmpmeta>`
@@ -167,7 +169,7 @@ func TestParseVRChatXMP_elementFallbacks(t *testing.T) {
 	if m.WorldDisplayName != "Elem World" {
 		t.Errorf("WorldDisplayName = %q", m.WorldDisplayName)
 	}
-	if m.AuthorVRCUserID != "usr_dec48a78-894a-4ef3-8524-8cf546ad1b2e" {
+	if m.AuthorVRCUserID != testvrc.PlayerUserID {
 		t.Errorf("AuthorVRCUserID = %q", m.AuthorVRCUserID)
 	}
 	if m.AuthorDisplayName != "Elem Author" {

--- a/internal/infrastructure/logwatcher/activity_ingest_adapter_test.go
+++ b/internal/infrastructure/logwatcher/activity_ingest_adapter_test.go
@@ -7,12 +7,13 @@ import (
 	"time"
 
 	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/testvrc"
 	"vrchat-tweaker/internal/usecase"
 )
 
 const testWorldID = "wrld_beddab1e-fee1-cafe-f00d-ca7c0dd1eca7"
 
-var testFullInstance = testWorldID + ":41550~hidden(usr_aeab2f4d-40b4-4f73-acbd-608ac47b763e)~region(jp)"
+var testFullInstance = testWorldID + ":41550~hidden(" + testvrc.EmbedUserID + ")~region(jp)"
 
 type spyWorldInfoRepo struct {
 	displayNameCalls []struct {
@@ -215,8 +216,8 @@ func TestActivityIngestAdapter_EndToEndEncounterPersistence(t *testing.T) {
 	ctx := context.Background()
 	base := time.Date(2026, 3, 18, 0, 1, 0, 0, time.UTC)
 	const minasocoWorld = "wrld_c03f8195-3c64-46d8-b5ae-242f214c9404"
-	minasocoInst := minasocoWorld + ":98225~hidden(usr_83ba5dc2-2912-4a21-a514-8b954e60a79b)~region(jp)"
-	const otherUser = "usr_1564b5c1-888a-4d08-b7f4-dcedcf702a90"
+	minasocoInst := minasocoWorld + ":98225~hidden(" + testvrc.HiddenHostUserID + ")~region(jp)"
+	otherUser := testvrc.OtherPlayerUserID
 
 	spy := &spyEncounterRepo{}
 	uc := usecase.NewActivityUseCase(stubPlaySessionRepo{}, spy, &fakeAppSettingsRepo{m: make(map[string]string)}, nil, nil)
@@ -258,8 +259,8 @@ func TestActivityIngestAdapter_ReingestDoesNotDuplicateJoin(t *testing.T) {
 	ctx := context.Background()
 	base := time.Date(2026, 3, 18, 0, 1, 0, 0, time.UTC)
 	const world = "wrld_c03f8195-3c64-46d8-b5ae-242f214c9404"
-	inst := world + ":98225~hidden(usr_83ba5dc2-2912-4a21-a514-8b954e60a79b)~region(jp)"
-	const otherUser = "usr_1564b5c1-888a-4d08-b7f4-dcedcf702a90"
+	inst := world + ":98225~hidden(" + testvrc.HiddenHostUserID + ")~region(jp)"
+	otherUser := testvrc.OtherPlayerUserID
 
 	spy := &spyEncounterRepo{}
 	uc := usecase.NewActivityUseCase(stubPlaySessionRepo{}, spy, &fakeAppSettingsRepo{m: make(map[string]string)}, nil, nil)

--- a/internal/infrastructure/logwatcher/output_log_watcher_test.go
+++ b/internal/infrastructure/logwatcher/output_log_watcher_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/testvrc"
 )
 
 func TestOutputLogWatcher_EmitsEvents(t *testing.T) {
@@ -149,7 +150,7 @@ func TestOutputLogWatcher_DirectoryMode_IngestsPrefixedLinesOnSwitch(t *testing.
 	oldPath := filepath.Join(dir, "output_log_2026-01-01_00-00-00.txt")
 	newPath := filepath.Join(dir, "output_log_2026-03-22_00-47-45.txt")
 	const cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
-	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	cozyInst := cozyWorld + ":48580~friends(" + testvrc.FriendsHostUserID + ")~region(jp)"
 	prefixed := []byte(
 		"2026.03.22 00:47:45 Debug      -  [Behaviour] Destination set: " + cozyInst + "\n" +
 			"2026.03.22 00:47:46 Debug      -  [Behaviour] Entering Room: Cozy with․\n",

--- a/internal/infrastructure/logwatcher/warm_correlator_test.go
+++ b/internal/infrastructure/logwatcher/warm_correlator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/testvrc"
 	"vrchat-tweaker/internal/usecase"
 )
 
@@ -19,7 +20,7 @@ func TestWarmSessionCorrelatorFromLogFile_restoresPendingDestinationBeforeResume
 	logPath := filepath.Join(dir, "output_log.txt")
 
 	const cozyWorld = "wrld_6041ba53-0ac0-4b5b-9ecb-890ea2b0aefa"
-	cozyInst := cozyWorld + ":48580~friends(usr_b4cb47f9-ca01-43db-baa3-ce3fb98ff0d4)~region(jp)"
+	cozyInst := cozyWorld + ":48580~friends(" + testvrc.FriendsHostUserID + ")~region(jp)"
 
 	prefix := []byte(
 		"2026.06.24 08:26:40 Debug      -  [Behaviour] Destination set: " + cozyInst + "\n",

--- a/internal/testvrc/users.go
+++ b/internal/testvrc/users.go
@@ -1,0 +1,13 @@
+// Package testvrc provides synthetic VRChat user IDs and display names for tests.
+// Do not use real account data in committed tests — see docs/agents/redaction.md.
+// IDs use hex UUID segments only (matches production usr_* and media XMP parsers).
+package testvrc
+
+const (
+	PlayerDisplayName = "TestPlayerAlpha"
+	PlayerUserID      = "usr_a1111111-1111-4111-8111-111111111101"
+	FriendsHostUserID = "usr_a2222222-2222-4222-8222-222222222202"
+	HiddenHostUserID  = "usr_a3333333-3333-4333-8333-333333333303"
+	OtherPlayerUserID = "usr_a4444444-4444-4444-8444-444444444404"
+	EmbedUserID       = "usr_a5555555-5555-4555-8555-555555555505"
+)


### PR DESCRIPTION
## Summary

- Add `internal/testvrc` with shared synthetic display names and hex `usr_*` IDs for tests.
- Replace log-captured production user fixtures in activity, logwatcher, and media Go tests with `testvrc` constants.
- Document in `docs/agents/redaction.md` that committed tests must use `internal/testvrc` (follow-up to #156).

## Test plan

- [x] `make fmt`
- [x] `make test`
- [x] `make lint`


Made with [Cursor](https://cursor.com)