### PR TITLE
fix(auth): drop API response body from 2FA verification errors

### DIFF
--- a/internal/infrastructure/vrchatapi/credential_store_file.go
+++ b/internal/infrastructure/vrchatapi/credential_store_file.go
@@ -8,6 +8,11 @@ import (
 
 // FileCredentialStore persists the VRChat auth token in a single file (0600).
 // Used when the OS keyring is unavailable (e.g. headless Linux / devcontainer without D-Bus).
+//
+// ponytail: on Windows, os.WriteFile mode bits do not map to restrictive ACLs; the file
+// gets default user ACLs. Accepted because the value is normally an AES-GCM wrapped blob
+// and Windows uses the keyring as the primary store (this file is a rare fallback). Upgrade
+// path: golang.org/x/sys/windows ACL APIs if restrictive ACLs are ever required.
 type FileCredentialStore struct {
 	path string
 }

--- a/internal/infrastructure/vrchatapi/login.go
+++ b/internal/infrastructure/vrchatapi/login.go
@@ -179,8 +179,7 @@ func (c *Client) verifyTwoFactor(ctx context.Context, client *http.Client, code 
 		return errors.New("2FAコードが正しくありません")
 	}
 	if resp.StatusCode >= 400 {
-		msg, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("2FA verification failed: %d %s", resp.StatusCode, string(msg))
+		return fmt.Errorf("2FA verification failed: %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/internal/infrastructure/vrchatapi/login_test.go
+++ b/internal/infrastructure/vrchatapi/login_test.go
@@ -191,6 +191,9 @@ func TestClient_Login_twoFactorVerifyServerError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "2FA verification failed") {
 		t.Fatalf("err = %v, want verification failed", err)
 	}
+	if strings.Contains(err.Error(), "server blew up") {
+		t.Fatalf("err must not embed API response body, got %v", err)
+	}
 }
 
 func TestClient_getAuthUserWithJar_apiError(t *testing.T) {


### PR DESCRIPTION
## Summary

- セキュリティレビューのフォローアップ 2 件。
- `verifyTwoFactor` の 4xx エラーで API レスポンス本文をエラー文字列に埋め込むのをやめ、ステータスコードのみを返すように変更（本文がログや UI に伝播しうるため）。
- `FileCredentialStore` に Windows ACL の制限（`0600` のモードビットが制限的 ACL に変換されない）を許容済みの仕様として `ponytail:` コメントで明記。挙動の変更なし。

## Test plan

- [x] `make fmt`
- [x] `go test -v -race -cover ./internal/infrastructure/vrchatapi/...`（coverage 90.0%、エラーに本文が含まれないことのアサーションを追加）
- [x] `golangci-lint run ./internal/infrastructure/vrchatapi/...`
- [x] `make test`

Made with [Cursor](https://cursor.com)