### PR TITLE
refactor(logwatcher): share output line dispatch and watcher lifecycle state

### DIFF
--- a/internal/infrastructure/logwatcher/multi_output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/multi_output_log_watcher.go
@@ -71,7 +71,7 @@ func (w *MultiOutputLogWatcher) Start(ctx context.Context) error {
 }
 
 func (w *MultiOutputLogWatcher) run(ctx context.Context) {
-	defer w.setStatus(statusStopped)
+	defer w.setStopped()
 
 	tracked := make(map[string]*trackedLogFile)
 	now := time.Now()

--- a/internal/infrastructure/logwatcher/multi_output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/multi_output_log_watcher.go
@@ -3,7 +3,6 @@ package logwatcher
 import (
 	"context"
 	"os"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -28,10 +27,7 @@ type MultiOutputLogWatcher struct {
 
 	activeLogStallTimeout time.Duration
 
-	mu        sync.Mutex
-	status    string
-	lastErr   error
-	lastErrAt time.Time
+	pollWatcherState
 }
 
 type trackedLogFile struct {
@@ -61,43 +57,17 @@ func NewMultiOutputLogWatcher(
 		callbacks:             callbacks,
 		logger:                logger,
 		activeLogStallTimeout: defaultActiveLogStallTimeout,
-		status:                "idle",
+		pollWatcherState:      newPollWatcherState(),
 	}
 }
 
 // Start begins polling in a goroutine. Cancel ctx to stop.
 func (w *MultiOutputLogWatcher) Start(ctx context.Context) error {
-	w.mu.Lock()
-	if w.status == "running" {
-		w.mu.Unlock()
+	if !w.tryStart() {
 		return nil
 	}
-	w.status = "running"
-	w.lastErr = nil
-	w.mu.Unlock()
-
 	go w.run(ctx)
 	return nil
-}
-
-// Status returns the current status and last error if any.
-func (w *MultiOutputLogWatcher) Status() (status string, lastErr error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.status, w.lastErr
-}
-
-func (w *MultiOutputLogWatcher) setErr(err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.lastErr = err
-	w.lastErrAt = time.Now()
-}
-
-func (w *MultiOutputLogWatcher) setStatus(s string) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.status = s
 }
 
 func (w *MultiOutputLogWatcher) run(ctx context.Context) {

--- a/internal/infrastructure/logwatcher/multi_output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/multi_output_log_watcher.go
@@ -27,7 +27,7 @@ type MultiOutputLogWatcher struct {
 
 	activeLogStallTimeout time.Duration
 
-	pollWatcherState
+	*pollWatcherState
 }
 
 type trackedLogFile struct {

--- a/internal/infrastructure/logwatcher/multi_output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/multi_output_log_watcher.go
@@ -71,7 +71,7 @@ func (w *MultiOutputLogWatcher) Start(ctx context.Context) error {
 }
 
 func (w *MultiOutputLogWatcher) run(ctx context.Context) {
-	defer w.setStatus("stopped")
+	defer w.setStatus(statusStopped)
 
 	tracked := make(map[string]*trackedLogFile)
 	now := time.Now()

--- a/internal/infrastructure/logwatcher/output_log_line.go
+++ b/internal/infrastructure/logwatcher/output_log_line.go
@@ -29,6 +29,15 @@ func dispatchOutputLogLine(lineTrimmed string, parser LogParser, handler EventHa
 	return baseTime, nil
 }
 
+// logDispatchLineErr logs dispatchOutputLogLine errors; nil parser/handler uses nilArgFmt.
+func logDispatchLineErr(logger Logger, err error, parseFmt, nilArgFmt string, args ...any) {
+	if errors.Is(err, errNilDispatchArg) {
+		logger(nilArgFmt, append(args, err)...)
+		return
+	}
+	logger(parseFmt, append(args, err)...)
+}
+
 func trimNL(s string) string {
 	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
 		s = s[:len(s)-1]

--- a/internal/infrastructure/logwatcher/output_log_line.go
+++ b/internal/infrastructure/logwatcher/output_log_line.go
@@ -31,11 +31,14 @@ func dispatchOutputLogLine(lineTrimmed string, parser LogParser, handler EventHa
 
 // logDispatchLineErr logs dispatchOutputLogLine errors; nil parser/handler uses nilArgFmt.
 func logDispatchLineErr(logger Logger, err error, parseFmt, nilArgFmt string, args ...any) {
+	fmt := parseFmt
 	if errors.Is(err, errNilDispatchArg) {
-		logger(nilArgFmt, append(args, err)...)
-		return
+		fmt = nilArgFmt
 	}
-	logger(parseFmt, append(args, err)...)
+	logArgs := make([]any, len(args)+1)
+	copy(logArgs, args)
+	logArgs[len(args)] = err
+	logger(fmt, logArgs...)
 }
 
 func trimNL(s string) string {

--- a/internal/infrastructure/logwatcher/output_log_line.go
+++ b/internal/infrastructure/logwatcher/output_log_line.go
@@ -1,0 +1,37 @@
+package logwatcher
+
+import (
+	"errors"
+	"time"
+
+	"vrchat-tweaker/internal/domain/activity"
+)
+
+var errNilDispatchArg = errors.New("logwatcher: nil parser or handler")
+
+// dispatchOutputLogLine parses a trimmed non-empty line and dispatches events.
+// Caller logs parseErr if non-nil. baseTime is for checkpoint (ParseVRChatTimestamp result).
+// parser and handler must be non-nil; otherwise errNilDispatchArg is returned.
+func dispatchOutputLogLine(lineTrimmed string, parser LogParser, handler EventHandler) (baseTime time.Time, parseErr error) {
+	if parser == nil || handler == nil {
+		return time.Time{}, errNilDispatchArg
+	}
+	baseTime = activity.ParseVRChatTimestamp(lineTrimmed, time.Now().In(time.Local))
+	events, parseErr := parser.ParseLine(lineTrimmed, baseTime)
+	if parseErr != nil {
+		return baseTime, parseErr
+	}
+	for _, ev := range events {
+		if ev != nil {
+			handler.Handle(ev)
+		}
+	}
+	return baseTime, nil
+}
+
+func trimNL(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/infrastructure/logwatcher/output_log_line_test.go
+++ b/internal/infrastructure/logwatcher/output_log_line_test.go
@@ -1,0 +1,30 @@
+package logwatcher
+
+import (
+	"errors"
+	"testing"
+
+	"vrchat-tweaker/internal/domain/activity"
+)
+
+func TestDispatchOutputLogLine_nilParser(t *testing.T) {
+	t.Parallel()
+	called := false
+	_, err := dispatchOutputLogLine("line", nil, EventHandlerFunc(func(activity.ParsedEvent) {
+		called = true
+	}))
+	if !errors.Is(err, errNilDispatchArg) {
+		t.Fatalf("err = %v, want %v", err, errNilDispatchArg)
+	}
+	if called {
+		t.Fatal("handler must not be called")
+	}
+}
+
+func TestDispatchOutputLogLine_nilHandler(t *testing.T) {
+	t.Parallel()
+	_, err := dispatchOutputLogLine("line", stubParser{}, nil)
+	if !errors.Is(err, errNilDispatchArg) {
+		t.Fatalf("err = %v, want %v", err, errNilDispatchArg)
+	}
+}

--- a/internal/infrastructure/logwatcher/output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/output_log_watcher.go
@@ -124,7 +124,7 @@ const (
 )
 
 func (w *OutputLogWatcher) run(ctx context.Context) {
-	defer w.setStatus(statusStopped)
+	defer w.setStopped()
 
 	for {
 		select {
@@ -249,7 +249,8 @@ func (w *OutputLogWatcher) run(ctx context.Context) {
 			}
 
 			if _, parseErr := dispatchOutputLogLine(lineTrimmed, w.parser, w.handler); parseErr != nil {
-				w.logger("[logwatcher] parse error: %v", parseErr)
+				logDispatchLineErr(w.logger, parseErr,
+					"[logwatcher] parse error: %v", "[logwatcher] dispatch error: %v")
 				continue
 			}
 		}

--- a/internal/infrastructure/logwatcher/output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/output_log_watcher.go
@@ -64,7 +64,7 @@ type OutputLogWatcher struct {
 	// startup lines already written to the new file before the watcher seeks to EOF.
 	logFileSwitchHandler LogFileSwitchHandler
 
-	pollWatcherState
+	*pollWatcherState
 
 	// lastTailedPath is written only from run(); tracks the path last opened for tailing.
 	lastTailedPath string

--- a/internal/infrastructure/logwatcher/output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/output_log_watcher.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"sync"
 	"time"
 
 	"vrchat-tweaker/internal/domain/activity"
@@ -65,10 +64,7 @@ type OutputLogWatcher struct {
 	// startup lines already written to the new file before the watcher seeks to EOF.
 	logFileSwitchHandler LogFileSwitchHandler
 
-	mu        sync.Mutex
-	status    string // "idle", "running", "stopped"
-	lastErr   error
-	lastErrAt time.Time
+	pollWatcherState
 
 	// lastTailedPath is written only from run(); tracks the path last opened for tailing.
 	lastTailedPath string
@@ -80,11 +76,11 @@ func NewOutputLogWatcher(configuredPath string, parser LogParser, handler EventH
 		logger = diag.Nop
 	}
 	w := &OutputLogWatcher{
-		configuredPath: configuredPath,
-		parser:         parser,
-		handler:        handler,
-		logger:         logger,
-		status:         "idle",
+		configuredPath:   configuredPath,
+		parser:           parser,
+		handler:          handler,
+		logger:           logger,
+		pollWatcherState: newPollWatcherState(),
 	}
 	if info, err := os.Stat(configuredPath); err == nil && info.IsDir() {
 		w.watchDir = configuredPath
@@ -114,37 +110,11 @@ func (w *OutputLogWatcher) resolveActivePath() (string, error) {
 
 // Start begins tailing the file in a goroutine. Cancel ctx to stop.
 func (w *OutputLogWatcher) Start(ctx context.Context) error {
-	w.mu.Lock()
-	if w.status == "running" {
-		w.mu.Unlock()
+	if !w.tryStart() {
 		return nil
 	}
-	w.status = "running"
-	w.lastErr = nil
-	w.mu.Unlock()
-
 	go w.run(ctx)
 	return nil
-}
-
-// Status returns the current status and last error if any.
-func (w *OutputLogWatcher) Status() (status string, lastErr error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.status, w.lastErr
-}
-
-func (w *OutputLogWatcher) setErr(err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.lastErr = err
-	w.lastErrAt = time.Now()
-}
-
-func (w *OutputLogWatcher) setStatus(s string) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.status = s
 }
 
 const (
@@ -278,16 +248,9 @@ func (w *OutputLogWatcher) run(ctx context.Context) {
 				continue
 			}
 
-			baseTime := activity.ParseVRChatTimestamp(lineTrimmed, time.Now().In(time.Local))
-			events, parseErr := w.parser.ParseLine(lineTrimmed, baseTime)
-			if parseErr != nil {
+			if _, parseErr := dispatchOutputLogLine(lineTrimmed, w.parser, w.handler); parseErr != nil {
 				w.logger("[logwatcher] parse error: %v", parseErr)
 				continue
-			}
-			for _, ev := range events {
-				if ev != nil {
-					w.handler.Handle(ev)
-				}
 			}
 		}
 
@@ -299,11 +262,4 @@ func (w *OutputLogWatcher) run(ctx context.Context) {
 		case <-time.After(200 * time.Millisecond):
 		}
 	}
-}
-
-func trimNL(s string) string {
-	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
-		s = s[:len(s)-1]
-	}
-	return s
 }

--- a/internal/infrastructure/logwatcher/output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/output_log_watcher.go
@@ -124,7 +124,7 @@ const (
 )
 
 func (w *OutputLogWatcher) run(ctx context.Context) {
-	defer w.setStatus("stopped")
+	defer w.setStatus(statusStopped)
 
 	for {
 		select {

--- a/internal/infrastructure/logwatcher/poll_watcher_state.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state.go
@@ -33,13 +33,14 @@ func (s *pollWatcherState) setErr(err error) {
 	s.lastErr = err
 }
 
-func (s *pollWatcherState) setStatus(status watcherStatus) {
+func (s *pollWatcherState) setStopped() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.status = status
+	s.status = statusStopped
 }
 
 // tryStart marks the watcher running unless already running.
+// Restart after statusStopped is intentional: ctx cancel stops the goroutine, then Start may run again.
 func (s *pollWatcherState) tryStart() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/infrastructure/logwatcher/poll_watcher_state.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state.go
@@ -2,15 +2,23 @@ package logwatcher
 
 import "sync"
 
+type watcherStatus string
+
+const (
+	statusIdle    watcherStatus = "idle"
+	statusRunning watcherStatus = "running"
+	statusStopped watcherStatus = "stopped"
+)
+
 // pollWatcherState holds status and last error for tail/poll log watchers.
 type pollWatcherState struct {
 	mu      sync.Mutex
-	status  string // "idle", "running", "stopped"
+	status  watcherStatus
 	lastErr error
 }
 
 func newPollWatcherState() *pollWatcherState {
-	return &pollWatcherState{status: "idle"}
+	return &pollWatcherState{status: statusIdle}
 }
 
 func (s *pollWatcherState) Status() (status string, lastErr error) {

--- a/internal/infrastructure/logwatcher/poll_watcher_state.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state.go
@@ -1,0 +1,49 @@
+package logwatcher
+
+import (
+	"sync"
+	"time"
+)
+
+// pollWatcherState holds status and last error for tail/poll log watchers.
+type pollWatcherState struct {
+	mu        sync.Mutex
+	status    string // "idle", "running", "stopped"
+	lastErr   error
+	lastErrAt time.Time
+}
+
+func newPollWatcherState() pollWatcherState {
+	return pollWatcherState{status: "idle"}
+}
+
+func (s *pollWatcherState) Status() (status string, lastErr error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.status, s.lastErr
+}
+
+func (s *pollWatcherState) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastErr = err
+	s.lastErrAt = time.Now()
+}
+
+func (s *pollWatcherState) setStatus(status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = status
+}
+
+// tryStart marks the watcher running unless already running.
+func (s *pollWatcherState) tryStart() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.status == "running" {
+		return false
+	}
+	s.status = "running"
+	s.lastErr = nil
+	return true
+}

--- a/internal/infrastructure/logwatcher/poll_watcher_state.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state.go
@@ -24,7 +24,7 @@ func newPollWatcherState() *pollWatcherState {
 func (s *pollWatcherState) Status() (status string, lastErr error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.status, s.lastErr
+	return string(s.status), s.lastErr
 }
 
 func (s *pollWatcherState) setErr(err error) {
@@ -33,7 +33,7 @@ func (s *pollWatcherState) setErr(err error) {
 	s.lastErr = err
 }
 
-func (s *pollWatcherState) setStatus(status string) {
+func (s *pollWatcherState) setStatus(status watcherStatus) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.status = status
@@ -43,10 +43,10 @@ func (s *pollWatcherState) setStatus(status string) {
 func (s *pollWatcherState) tryStart() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.status == "running" {
+	if s.status == statusRunning {
 		return false
 	}
-	s.status = "running"
+	s.status = statusRunning
 	s.lastErr = nil
 	return true
 }

--- a/internal/infrastructure/logwatcher/poll_watcher_state.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state.go
@@ -36,6 +36,9 @@ func (s *pollWatcherState) setErr(err error) {
 func (s *pollWatcherState) setStopped() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.status != statusRunning {
+		return
+	}
 	s.status = statusStopped
 }
 

--- a/internal/infrastructure/logwatcher/poll_watcher_state.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state.go
@@ -1,20 +1,16 @@
 package logwatcher
 
-import (
-	"sync"
-	"time"
-)
+import "sync"
 
 // pollWatcherState holds status and last error for tail/poll log watchers.
 type pollWatcherState struct {
-	mu        sync.Mutex
-	status    string // "idle", "running", "stopped"
-	lastErr   error
-	lastErrAt time.Time
+	mu      sync.Mutex
+	status  string // "idle", "running", "stopped"
+	lastErr error
 }
 
-func newPollWatcherState() pollWatcherState {
-	return pollWatcherState{status: "idle"}
+func newPollWatcherState() *pollWatcherState {
+	return &pollWatcherState{status: "idle"}
 }
 
 func (s *pollWatcherState) Status() (status string, lastErr error) {
@@ -27,7 +23,6 @@ func (s *pollWatcherState) setErr(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastErr = err
-	s.lastErrAt = time.Now()
 }
 
 func (s *pollWatcherState) setStatus(status string) {

--- a/internal/infrastructure/logwatcher/poll_watcher_state.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state.go
@@ -40,6 +40,7 @@ func (s *pollWatcherState) setStopped() {
 		return
 	}
 	s.status = statusStopped
+	// lastErr is retained after stop so Status() can report the last resolve/read failure.
 }
 
 // tryStart marks the watcher running unless already running.

--- a/internal/infrastructure/logwatcher/poll_watcher_state_test.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state_test.go
@@ -79,6 +79,24 @@ func TestPollWatcherState_setErrStatus_concurrent(t *testing.T) {
 	}
 }
 
+func TestPollWatcherState_setStopped_retainsLastErr(t *testing.T) {
+	t.Parallel()
+	s := newPollWatcherState()
+	if !s.tryStart() {
+		t.Fatal("tryStart")
+	}
+	want := errors.New("resolve failed")
+	s.setErr(want)
+	s.setStopped()
+	status, lastErr := s.Status()
+	if status != string(statusStopped) {
+		t.Fatalf("status = %q, want stopped", status)
+	}
+	if !errors.Is(lastErr, want) {
+		t.Fatalf("lastErr = %v, want retained %v", lastErr, want)
+	}
+}
+
 func TestPollWatcherState_setStopped_onlyFromRunning(t *testing.T) {
 	t.Parallel()
 	s := newPollWatcherState()

--- a/internal/infrastructure/logwatcher/poll_watcher_state_test.go
+++ b/internal/infrastructure/logwatcher/poll_watcher_state_test.go
@@ -1,0 +1,105 @@
+package logwatcher
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPollWatcherState_tryStart_exclusive(t *testing.T) {
+	t.Parallel()
+	s := newPollWatcherState()
+	var started atomic.Int32
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if s.tryStart() {
+				started.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if started.Load() != 1 {
+		t.Fatalf("started = %d, want 1", started.Load())
+	}
+	status, _ := s.Status()
+	if status != string(statusRunning) {
+		t.Fatalf("status = %q, want running", status)
+	}
+}
+
+func TestPollWatcherState_restartCycle(t *testing.T) {
+	t.Parallel()
+	s := newPollWatcherState()
+
+	if !s.tryStart() {
+		t.Fatal("first tryStart should succeed")
+	}
+	s.setStopped()
+	status, _ := s.Status()
+	if status != string(statusStopped) {
+		t.Fatalf("after stop status = %q, want stopped", status)
+	}
+
+	if !s.tryStart() {
+		t.Fatal("restart tryStart should succeed from stopped")
+	}
+	status, _ = s.Status()
+	if status != string(statusRunning) {
+		t.Fatalf("after restart status = %q, want running", status)
+	}
+}
+
+func TestPollWatcherState_setErrStatus_concurrent(t *testing.T) {
+	t.Parallel()
+	s := newPollWatcherState()
+	if !s.tryStart() {
+		t.Fatal("tryStart")
+	}
+	want := errors.New("open failed")
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.setErr(want)
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = s.Status()
+		}()
+	}
+	wg.Wait()
+	_, lastErr := s.Status()
+	if !errors.Is(lastErr, want) {
+		t.Fatalf("lastErr = %v, want %v", lastErr, want)
+	}
+}
+
+func TestPollWatcherState_setStopped_onlyFromRunning(t *testing.T) {
+	t.Parallel()
+	s := newPollWatcherState()
+	s.setStopped()
+	status, _ := s.Status()
+	if status != string(statusIdle) {
+		t.Fatalf("idle setStopped status = %q, want idle", status)
+	}
+
+	if !s.tryStart() {
+		t.Fatal("tryStart")
+	}
+	s.setStopped()
+	status, _ = s.Status()
+	if status != string(statusStopped) {
+		t.Fatalf("running setStopped status = %q, want stopped", status)
+	}
+
+	s.setStopped()
+	status, _ = s.Status()
+	if status != string(statusStopped) {
+		t.Fatalf("stopped setStopped status = %q, want stopped", status)
+	}
+}

--- a/internal/infrastructure/logwatcher/process_output_log.go
+++ b/internal/infrastructure/logwatcher/process_output_log.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"time"
 
 	"vrchat-tweaker/internal/domain/activity"
 	"vrchat-tweaker/internal/infrastructure/diag"
@@ -63,16 +62,8 @@ func WarmSessionCorrelatorFromLogFile(ctx context.Context, path string, endOffse
 		}
 		lineTrimmed := trimNL(line)
 		if lineTrimmed != "" {
-			baseTime := activity.ParseVRChatTimestamp(lineTrimmed, time.Now().In(time.Local))
-			events, parseErr := parser.ParseLine(lineTrimmed, baseTime)
-			if parseErr != nil {
+			if _, parseErr := dispatchOutputLogLine(lineTrimmed, parser, EventHandlerFunc(warmer.WarmFromParsedEvent)); parseErr != nil {
 				logger("[logwatcher] warm parse error: %v", parseErr)
-			} else {
-				for _, ev := range events {
-					if ev != nil {
-						warmer.WarmFromParsedEvent(ev)
-					}
-				}
 			}
 		}
 		if err == io.EOF {
@@ -130,16 +121,8 @@ func ProcessOutputLogFileFromOffset(ctx context.Context, path string, startOffse
 		}
 		lineTrimmed := trimNL(line)
 		if lineTrimmed != "" {
-			baseTime := activity.ParseVRChatTimestamp(lineTrimmed, time.Now().In(time.Local))
-			events, parseErr := parser.ParseLine(lineTrimmed, baseTime)
-			if parseErr != nil {
+			if _, parseErr := dispatchOutputLogLine(lineTrimmed, parser, handler); parseErr != nil {
 				logger("[logwatcher] bootstrap parse error: %v", parseErr)
-			} else {
-				for _, ev := range events {
-					if ev != nil {
-						handler.Handle(ev)
-					}
-				}
 			}
 		}
 		if onProgress != nil {

--- a/internal/infrastructure/logwatcher/process_output_log.go
+++ b/internal/infrastructure/logwatcher/process_output_log.go
@@ -63,7 +63,8 @@ func WarmSessionCorrelatorFromLogFile(ctx context.Context, path string, endOffse
 		lineTrimmed := trimNL(line)
 		if lineTrimmed != "" {
 			if _, parseErr := dispatchOutputLogLine(lineTrimmed, parser, EventHandlerFunc(warmer.WarmFromParsedEvent)); parseErr != nil {
-				logger("[logwatcher] warm parse error: %v", parseErr)
+				logDispatchLineErr(logger, parseErr,
+					"[logwatcher] warm parse error: %v", "[logwatcher] warm dispatch error: %v")
 			}
 		}
 		if err == io.EOF {
@@ -122,7 +123,8 @@ func ProcessOutputLogFileFromOffset(ctx context.Context, path string, startOffse
 		lineTrimmed := trimNL(line)
 		if lineTrimmed != "" {
 			if _, parseErr := dispatchOutputLogLine(lineTrimmed, parser, handler); parseErr != nil {
-				logger("[logwatcher] bootstrap parse error: %v", parseErr)
+				logDispatchLineErr(logger, parseErr,
+					"[logwatcher] bootstrap parse error: %v", "[logwatcher] bootstrap dispatch error: %v")
 			}
 		}
 		if onProgress != nil {

--- a/internal/infrastructure/logwatcher/tail_output_log_file.go
+++ b/internal/infrastructure/logwatcher/tail_output_log_file.go
@@ -68,7 +68,9 @@ func tailOutputLogFile(
 		if lineTrimmed != "" {
 			baseTime, parseErr := dispatchOutputLogLine(lineTrimmed, parser, handler)
 			if parseErr != nil {
-				logger("[multi-logwatcher] parse %s: %v", path, parseErr)
+				logDispatchLineErr(logger, parseErr,
+					"[multi-logwatcher] parse %s: %v", "[multi-logwatcher] dispatch %s: %v",
+					path)
 			}
 			if checkpoint != nil {
 				checkpoint(offset, baseTime)

--- a/internal/infrastructure/logwatcher/tail_output_log_file.go
+++ b/internal/infrastructure/logwatcher/tail_output_log_file.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"os"
 	"time"
-
-	"vrchat-tweaker/internal/domain/activity"
 )
 
 // tailCheckpoint reports read progress after each consumed line.
@@ -68,16 +66,9 @@ func tailOutputLogFile(
 
 		lineTrimmed := trimNL(line)
 		if lineTrimmed != "" {
-			baseTime := activity.ParseVRChatTimestamp(lineTrimmed, time.Now().In(time.Local))
-			events, parseErr := parser.ParseLine(lineTrimmed, baseTime)
+			baseTime, parseErr := dispatchOutputLogLine(lineTrimmed, parser, handler)
 			if parseErr != nil {
 				logger("[multi-logwatcher] parse %s: %v", path, parseErr)
-			} else {
-				for _, ev := range events {
-					if ev != nil {
-						handler.Handle(ev)
-					}
-				}
 			}
 			if checkpoint != nil {
 				checkpoint(offset, baseTime)


### PR DESCRIPTION
## Summary

- Extract `dispatchOutputLogLine` and `trimNL` into `output_log_line.go`; all four call sites (tail, `OutputLogWatcher`, bootstrap, warm replay) use the shared parse/dispatch path (#161).
- Extract `pollWatcherState` for `Start` / `Status` / `setErr` / `setStatus` / double-start guard; embed in `MultiOutputLogWatcher` and `OutputLogWatcher` (#162).
- Parse failures and `errNilDispatchArg` skip the current line and continue tailing; Activity ingest is not stopped (no behavior change).

## Test plan

- [x] `go test -race ./internal/infrastructure/logwatcher/...`
- [x] `make test-back`
- [x] `make lint-back`
- [x] `TestDispatchOutputLogLine_nilParser` / `_nilHandler`

Closes #161
Closes #162

Made with [Cursor](https://cursor.com)