### PR TITLE
docs(yt-dlp): Tools replace maintain 方針（ADR 0008）

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -298,6 +298,68 @@ _Avoid_: Visitor タグ, `system_trust_visitor`（存在しない ID）
 User detail で 1 つの User tag を示すチップ UI。ラベルとツールチップ（説明・deprecated 表示）を持つ。ツールチップにタグ ID 行は出さない。未知タグはラベルに生のタグ文字列を示し、ツールチップは不明旨のみ。
 _Avoid_: バッジ, タグ一覧（行全体のラベル付きセクションと混同しやすいため）
 
+## yt-dlp
+
+VRChat の動画プレイヤーが裏で使う yt-dlp 向けの用語。**yt-dlp Cookie linkage**（[Issue #8](https://github.com/JO3QMA/vrctweaker/issues/8)、[ADR 0007](docs/adr/0007-ytdlp-cookie-linkage.md)）は同梱ビルドの Cookie 非対応により Blocked。**yt-dlp Tools replace maintain**（[Issue #9](https://github.com/JO3QMA/vrctweaker/issues/9)、[ADR 0008](docs/adr/0008-ytdlp-tools-replace-maintain.md)）は製品方針を合意済みだが、実機 PoC 前は Proposed。起動前ワンショット置換の試作は [PR #40](https://github.com/JO3QMA/vrctweaker/pull/40)（望む動作に未達）。
+
+### Language
+
+**VRChat-bundled yt-dlp**:
+VRChat が Tools 配下に置く yt-dlp 実行ファイル。公式 yt-dlp を削った／独自オプション付きのビルドであり、調査時点では `--cookies` / `--cookies-from-browser` を受け付けない。起動やログインの過程で Tools 上の差し替えバイナリを同梱版へ戻しうることがある。
+_Avoid_: 公式 yt-dlp, yt-dlp.exe（どちらを指すか曖昧なため）
+
+**yt-dlp Tools replace**:
+Tools 配下の VRChat-bundled yt-dlp を、Official yt-dlp cache など別バイナリで置き換える**一回の配置操作**。起動前のワンショットだけだと VRChat が同梱版へ戻しうる。読み取り専用で戻しを防ぐと、調査時点では動画再生ができなくなる（原因未特定）。維持の仕組み全体は **yt-dlp Tools replace maintain**。
+_Avoid_: yt-dlp 更新（ユーザー config や Cookie linkage と混同しやすいため）, バージョン管理（UI 見出しは可）, 維持モード（maintain を指すときは専用語を使う）
+
+**yt-dlp Tools replace maintain**:
+ユーザーが有効化した、Official yt-dlp cache 由来の exe を Tools に載せ続ける desired 状態（オプトイン・既定オフ）。Tweaker 常駐中に VRChat 起動を検知して yt-dlp Tools replace と監視を行い、無効化時は監視だけ止めて Tools 上のファイルは触らない。v1 は Windows のみ（動画タブ）。製品実装は ADR 0008（Proposed）と PoC 前提。
+_Avoid_: yt-dlp Tools replace（一回の配置操作）, Cookie linkage, 自動更新（明示更新と混同しやすいため）
+
+**Tools replace effective state**:
+Tools 上の `yt-dlp.exe` が Official yt-dlp cache と一致しているかどうかで決まる実効状態。desired（maintain オン／オフ）とは別。動画タブは両方を示す。
+_Avoid_: 維持オン（desired だけを指す印象）, 適用済み（監視中と混同しやすいため）
+
+**Tools replace risk acknowledgment**:
+yt-dlp Tools replace maintain を初めて有効化する前に、同梱版を外すリスクと公式の差し替え非推奨をユーザーが確認したこと。一度行えば以降の有効化では再確認しない。画面上の常時警告文とは別。
+_Avoid_: Cookie linkage risk acknowledgment（別機能）, 利用規約同意, 毎回確認
+
+**Official yt-dlp cache**:
+Tweaker が保持する公式 `yt-dlp.exe` のローカル控え。初回適用と明示の更新確認で取得し、以降の VRChat セッションではこの控えから Tools へ配置する。
+_Avoid_: 最新版（キャッシュと GitHub latest を同一視する印象）, Tools 上の exe（effective 側）
+
+**yt-dlp Cookie linkage**:
+Tweaker が yt-dlp user config へ Cookie 参照オプションを書き込み／削除する設定体験（設計のみ。公式 exe を RO なしで維持できる手順が固まってから実装する。UI は Settings）。Cookie 本体の取得・検証や動画の取得は行わない。VRChat の `config.json` を扱う Config 画面の対象ではない。
+_Avoid_: Cookie 同期, ログイン連携（VRChat 認証と混同しやすいため）, yt-dlp 実行, Config（VRChat config.json 編集と混同しやすいため）, yt-dlp Tools replace / maintain（別問題）, 動画タブ（Cookie は載せない）
+
+**yt-dlp user config**:
+yt-dlp が読むユーザー向け設定ファイル。Cookie 参照オプションの置き場。VRChat の `config.json`（Config 画面の対象）とは別物。無ければ親ディレクトリごと作成してよい。Managed cookie options 削除後に他行が無く空ならファイル自体を削除してよい。
+_Avoid_: VRChat config, config.json, yt-dlp 設定（対象ファイルが曖昧なため）
+
+**Managed cookie options**:
+yt-dlp Cookie linkage が yt-dlp user config 内で所有する Cookie 参照オプション。有効時は Browser cookie source か Cookies file source のどちらか一方だけ（排他）。誰が書いたかに関わらず、同種の Cookie 参照行は Managed とみなし、書き込み時はそれらを upsert（置換）する。無効化時はこれらの行だけを削除する。ファイル内の他行は触らない。
+_Avoid_: yt-dlp 設定全体, config 全体（手書きオプションまで含意するため）, 設定ファイルの退避・リネーム（無効化の意味に含めない）
+
+**Browser cookie source**:
+Cookie 参照方式のひとつ。指定したブラウザのログイン Cookie を yt-dlp に読ませる。v1 で選べるブラウザは chrome / edge / firefox の既定プロファイルのみ（プロファイルパス指定なし）。ブラウザ起動中は Cookie ストアがロックされ、読み込みに失敗しうる。
+_Avoid_: ブラウザ連携, Chrome 連携（特定ブラウザに固定する印象）, プロファイル指定（v1 の範囲外）
+
+**Cookies file source**:
+Cookie 参照方式のひとつ。ユーザーが用意した cookies テキストファイルのパスを yt-dlp に読ませる。Browser cookie source のファイルロック回避手段。ファイルの作成・更新自体は Tweaker の責務外。Managed cookie options への書き込み前に、指定パスにファイルが存在することを必須とする（形式の中身検証はしない）。
+_Avoid_: Cookie エクスポート（Tweaker がファイルを作る印象）, cookies.txt（ファイル名に限定する印象）
+
+**Cookie linkage risk acknowledgment**:
+yt-dlp Cookie linkage を初めて有効化する前に、アカウント BAN リスクとサブアカウント利用の推奨をユーザーが確認したこと。一度行えば、以降の有効化では再確認しない。画面上の常時警告文とは別。
+_Avoid_: 利用規約同意（アプリ全体の同意と混同しやすいため）, 毎回確認
+
+**Cookie linkage effective state**:
+yt-dlp user config 上に Managed cookie options があるかどうかで決まる、いま実際に効いている有効／方式／参照先。ファイルが無いことも「Managed なし＝無効」として扱い、読み取りエラーにはしない。Settings の表示はこれを正とする。書き込み失敗時はエラーを示し、表示を操作前の Effective state に戻す（試した値は Cookie linkage draft に残してよい）。
+_Avoid_: アプリ内の有効フラグ（ファイルと食い違う下書きと混同しやすいため）, 未初期化（無効と別状態にしない）
+
+**Cookie linkage draft**:
+Settings 上で覚える、方式・ブラウザ・cookies ファイルパスなどの入力下書き、および Cookie linkage risk acknowledgment。無効中でも前回の選択を残してよい。有効時の変更は即時に yt-dlp user config へ書き込み、Cookie linkage effective state と揃える。Cookie ファイルの作成・エクスポート、ブラウザ起動中のロック自動検知、yt-dlp／動画再生の成否確認は含まない。
+_Avoid_: 保存済み設定（未書き込みの下書きだけを指す印象）, 適用待ち（明示適用ボタン前提の印象）, Cookie エクスポート, ロック監視
+
 ## Agent contribution
 
 Issue・PR・コミットなど Git に残るテキストを書くときの用語。

--- a/docs/adr/0007-ytdlp-cookie-linkage.md
+++ b/docs/adr/0007-ytdlp-cookie-linkage.md
@@ -1,0 +1,84 @@
+# ADR 0007: yt-dlp Cookie linkage
+
+## Status
+
+**Blocked**（実装保留。[Issue #8](https://github.com/JO3QMA/vrctweaker/issues/8)）
+
+同梱 yt-dlp は Cookie オプション非対応。公式 exe の維持手段は [ADR 0008](0008-ytdlp-tools-replace-maintain.md)（Proposed）と実機 PoC に委譲。grill-with-docs で固めた Cookie config UI の設計（下記 Decision）は、前提が解けてから再開する。
+
+関連: [Issue #9](https://github.com/JO3QMA/vrctweaker/issues/9)、[PR #40](https://github.com/JO3QMA/vrctweaker/pull/40)（起動前ワンショットは未達）。
+
+## Context
+
+- VRChat の動画プレイヤーは `%LocalAppData%Low\VRChat\VRChat\Tools\yt-dlp.exe` を使う
+- Issue #8 は `%APPDATA%\yt-dlp\config`（yt-dlp user config）へ `--cookies-from-browser` / `--cookies` を書き、VRChat／EAC を改変せず制限付き動画を再生できると想定していた
+- その前提は **Cookie 対応の公式 exe が Tools に載っていること**。維持の製品方針は ADR 0008。出荷順は **#9 先・#8 は別 PR**
+- grill-with-docs では config の Managed 行 upsert、Settings UI、risk acknowledgment などを合意した（下記 Decision は設計メモとして残す）
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **yt-dlp** セクションを正本とする。
+
+## Blocking findings
+
+### A. 同梱ビルドに Cookie オプションが無い（Issue #8）
+
+同梱 `yt-dlp.exe`（`--version` → `2026.06.09`）:
+
+- `--help` に `--cookies` / `--cookies-from-browser` が無い（ドメイン allow-list など削った／独自オプションのみ）
+- `--cookies-from-browser chrome -g <URL>` → `error: no such option: --cookies-from-browser`
+
+**config に Cookie 参照を書いても、素の同梱バイナリでは効かない。**
+
+### B. 公式 exe の維持が未検証（Issue #9）
+
+起動前ワンショット置換（PR #40）は VRChat のハッシュ検証で同梱版へ戻され、RO 固定は再生不能の報告がある。維持の方式・製品 Decision は **ADR 0008**。本 ADR では「Cookie 実装の前提がまだ充足していない」ことだけを Blocking とする。
+
+## Prior art findings (2026-07-12)
+
+置換タイミングと先行事例の詳細は調査時点で ADR 0007 に記録し、製品方針は **ADR 0008** へ移した。要約:
+
+- 巻き戻しの原因は置換タイミング（ログイン／ワールド参加時のハッシュ検証）
+- [VRChat-YT-DLP-Fix](https://github.com/ShizCalev/VRChat-YT-DLP-Fix) は起動後・再生成待ち置換で RO なしに公式 exe を載せる（config への `--cookies-from-browser` upsert も行う — 本 Issue の user config 案の実例）
+- [VRCVideoCacher](https://github.com/EllyVR/VRCVideoCacher) は stub＋サーバ方式（Tweaker の Cookie linkage 責務を超える）
+
+## Validation plan（Unblock 条件 2 — Cookie 再開の前提）
+
+リポジトリ内の単発 Go PoC（`cmd/`、Windows）で以下を実機確認する（製品コードではない）:
+
+1. 置換後 `yt-dlp.exe --version` が公式のまま維持されるか（ログイン直後／ワールド移動を跨いで）
+2. `--cookies-from-browser chrome -g <URL>` がエラーにならないか（**本 ADR / #8 の前提確認**）
+3. **RO なしで動画再生が通るか**
+4. 巻き戻しのタイミングと回数（製品の監視要否の材料）
+
+PoC は yt-dlp user config を書かない。結果は Issue #9 と ADR 0008 に記録し、成功時に本 ADR の Blocked 解除を検討する。
+
+## Decision（実装時の設計メモ — 現状は未採用）
+
+前提が満たされた場合に限り、以前の合意を再開候補とする:
+
+1. **責務**: Tweaker は **yt-dlp Cookie linkage** として yt-dlp user config の **Managed cookie options** の書き込み／削除だけを行う。Cookie 本体の取得・検証、cookies ファイルの作成、yt-dlp／動画再生の実行・成否確認は行わない
+2. **ファイル操作**: 有効化は Managed 行の **upsert**。無効化は Managed 行の **削除のみ**（ファイル全体のリネーム退避・丸ごと置換はしない）。他行は常に残す。親ディレクトリが無ければ作成する。無効化後に他行が無く空ならファイルを削除する
+3. **方式**: **Browser cookie source** と **Cookies file source** を v1 で両方提供し、有効時は **排他**。Browser の v1 選択肢は `chrome` / `edge` / `firefox` の既定プロファイルのみ。Cookies file は書き込み前に **ファイル存在**を必須（形式パースはしない）
+4. **正本**: **Cookie linkage effective state** は yt-dlp user config が正。**Cookie linkage draft**（方式・ブラウザ・パスの下書きと **Cookie linkage risk acknowledgment**）はアプリ側。有効時の変更は **即時書き込み**。書き込み失敗時はエラー表示、UI を操作前の Effective に戻し、Draft の試行値は残す。config 未作成の読み取りはエラーにせず Effective＝無効
+5. **UI**: Settings の独立セクション（Config＝VRChat `config.json` 画面には載せない。動画タブ＝Tools replace maintain にも載せない）。**初回有効化のみ** risk acknowledgment 必須。以降は常時警告文。v1 は **Windows のみ**表示（他 OS はセクション非表示）
+6. **ログ**: ブラウザ名と cookies ファイルパスは可。Cookie 中身は禁止
+
+## Out of scope（当面）
+
+- 上記 Decision（#8）の実装
+- Tools replace maintain の製品実装（ADR 0008）
+- PR #40 相当のワンショット置換のマージを「完了」とみなすこと
+- RO による戻し防止を製品機能にすること
+- Cookie ファイルの作成・エクスポート
+- 同梱ビルドへのパッチ／再配布
+
+## Unblock 条件（いずれか）
+
+1. 同梱 `yt-dlp.exe` が `--cookies` または `--cookies-from-browser` を受け入れるようになる（`--help` / 実コマンドで確認）
+2. **RO なしで**公式 exe を起動後も維持でき、かつ動画再生が通る手順が再現できる（ADR 0008 の方式／PoC）。そのうえで Cookie UI を再 grill。ワンショット置換 alone や RO 固定は Unblock に含めない
+3. Issue #8 を閉じる、または前提が違う別 Issue に切り替える
+
+## Consequences
+
+- **#8 はいま出荷しない**。#9 の製品方針は ADR 0008（Proposed）にあり、PoC 前は実装しない
+- #8 は公式（または Cookie 対応）バイナリ前提。その維持が実機で確認できてから Decision を再開する
+- grill で固めた Cookie 用語・設計メモは、Unblock 後の再開用として残す

--- a/docs/adr/0008-ytdlp-tools-replace-maintain.md
+++ b/docs/adr/0008-ytdlp-tools-replace-maintain.md
@@ -1,0 +1,43 @@
+# ADR 0008: yt-dlp Tools replace maintain
+
+## Status
+
+**Proposed**（grill-with-docs で製品方針を合意。[Issue #9](https://github.com/JO3QMA/vrctweaker/issues/9)。実機 PoC で [ADR 0007](0007-ytdlp-cookie-linkage.md) の Unblock 条件 2 を満たすまで**製品実装は保留**）
+
+起動前ワンショット置換（[PR #40](https://github.com/JO3QMA/vrctweaker/pull/40)）は望む動作に未達。本 ADR は維持モードの Decision の正本。Cookie linkage は [ADR 0007](0007-ytdlp-cookie-linkage.md)。
+
+## Context
+
+- VRChat はログイン／ワールド参加時に Tools の `yt-dlp.exe` をハッシュ検証し、不一致なら **VRChat-bundled yt-dlp** へ戻す
+- したがって起動**前**の一回きりの **yt-dlp Tools replace** だけでは維持できない。RO 固定は再生不能の報告がある
+- 先行事例 [VRChat-YT-DLP-Fix](https://github.com/ShizCalev/VRChat-YT-DLP-Fix) は「起動後・同梱再生成を待ってから置換」で RO なしに公式 exe を載せている
+- Issue #9 の目的は公式バイナリの適用しやすさ。Issue #8（Cookie）はその公式（Cookie 対応）exe を前提とするが、**出荷は #9 を先・#8 は別**とする
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **yt-dlp** セクションを正本とする。調査メモは ADR 0007 の Prior art / Validation plan を参照。
+
+## Decision
+
+1. **方式**: ログイン（または同梱再生成）**後**に Official yt-dlp cache から Tools へ **yt-dlp Tools replace** し、VRChat 稼働中は Tools を監視して巻き戻されたら再置換する（watcher）。stub exe／ローカルサーバ方式と RO 固定は採らない
+2. **ライフサイクル**: Tweaker 常駐＋VRChat.exe 起動検知。VRChat が先に起動していても Tweaker 起動時にその場でアタッチする。監視は VRChat 終了で止めてよい
+3. **yt-dlp Tools replace maintain**: オプトイン（既定オフ）。オンのときだけ起動検知・置換・監視を行う
+4. **無効化**: 監視停止のみ。Tools 上のファイルは触らない。同梱版への復元は次の VRChat 起動に任せる
+5. **Official yt-dlp cache**: 初回適用と明示の「更新を確認」で GitHub 公式 `yt-dlp.exe` を取得。以降のセッションはキャッシュから配置する（起動のたびに latest を取りに行かない）
+6. **正本の分離**: desired＝maintain オン／オフ（アプリ設定）。**Tools replace effective state**＝Tools の exe が Official yt-dlp cache と一致するか。UI は両方を示す
+7. **使用中競合**: 再置換時はファイル解放待ちリトライ。上限超過時は保留表示し、次の監視イベント／次セッションで再試行。プロセス強制終了はしない
+8. **UI**: 専用の「動画」タブ（維持トグル・バージョン・更新・警告）。Settings / Config（`config.json`）には載せない。**Windows のみ**表示
+9. **Tools replace risk acknowledgment**: 初回オン時のみ必須。以降は常時警告文
+10. **出荷順**: 本機能（#9）を先に出す。**yt-dlp Cookie linkage**（#8 / ADR 0007）は別 PR。PR #40 はワンショット案として close し、DL／GitHub API／UI コードは再利用候補とする
+
+## Out of scope
+
+- Cookie linkage の実装（ADR 0007）
+- PoC バイナリそのものの製品化（検証用 `cmd/` は別フェーズ）
+- stub／キャッシュプロキシ方式（VRCVideoCacher 型）
+- RO による巻き戻し防止
+- 非 Windows
+
+## Consequences
+
+- #9 の製品スコープは「維持」であり、起動前ワンショット適用ボタン alone ではない
+- #8 は本 ADR の方式が実機で Unblock 条件 2 を満たしてから再開する
+- 動画タブと Settings の Cookie セクションは別画面・別概念のまま


### PR DESCRIPTION
## Summary
- grill-with-docs で合意した **yt-dlp Tools replace maintain**（Issue #9）の製品方針を [ADR 0008](docs/adr/0008-ytdlp-tools-replace-maintain.md) に記録（Status: Proposed、PoC 前は実装保留）
- Cookie linkage（Issue #8）は [ADR 0007](docs/adr/0007-ytdlp-cookie-linkage.md) に寄せ、維持の Decision は 0008 へ委譲。Blocked のまま
- [`CONTEXT.md`](CONTEXT.md) に maintain / effective state / risk acknowledgment / Official yt-dlp cache などの用語を追加

コード変更なし。次フェーズは実機 PoC → Unblock 条件 2 の確認 → 製品実装。

## Test plan
- [ ] ADR 0008 の Decision が grill 合意（常駐＋起動検知、オプトイン、キャッシュ＋明示更新、動画タブ Windows のみ、desired/effective 分離）と一致している
- [ ] ADR 0007 が Cookie 中心で、維持方針を 0008 にリンクしている
- [ ] CONTEXT の yt-dlp 用語で Tools replace（一回）と maintain（維持）が区別できる
- [ ] Issue #8 / #9 の既存コメントと矛盾しない

Refs #9 #8

Made with [Cursor](https://cursor.com)