### PR TITLE
fix(ytdlp): restore Windows cross-compile for yt-dlp lock detection

### DIFF
--- a/internal/usecase/ytdlp_tools_link.go
+++ b/internal/usecase/ytdlp_tools_link.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 // OfficialYTDLPCachePath returns …/Local/vrchat-tweaker/ytdlp/yt-dlp.exe (outside LocalLow).
@@ -98,7 +100,7 @@ func isTransientLockErr(err error) bool {
 	}
 	var errno syscall.Errno
 	if errors.As(err, &errno) {
-		return errno == syscall.ERROR_SHARING_VIOLATION || errno == syscall.ERROR_LOCK_VIOLATION
+		return errno == windows.ERROR_SHARING_VIOLATION || errno == windows.ERROR_LOCK_VIOLATION
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- Fix `make build-windows` failure caused by undefined `syscall.ERROR_SHARING_VIOLATION` and `syscall.ERROR_LOCK_VIOLATION` when cross-compiling from Linux.
- Use `golang.org/x/sys/windows` for those Win32 errno constants, consistent with other Windows-specific usecase code.

## Test plan
- [x] `GOOS=windows GOARCH=amd64 go build ./internal/usecase/`
- [x] `make test`
- [x] `make lint`
- [x] `make build-windows` (produces `build/bin/vrchat-tweaker.exe`)


Made with [Cursor](https://cursor.com)