### PR TITLE
fix(ytdlp): allow GitHub release redirect and refresh Video tab versions

### DIFF
--- a/frontend/src/views/VideoView.vue
+++ b/frontend/src/views/VideoView.vue
@@ -230,7 +230,14 @@ function applyStatus(
   s: YTDLPMaintainStatusDTO,
   opts?: { syncSwitch?: boolean },
 ) {
-  status.value = s;
+  const prev = status.value;
+  status.value = {
+    ...s,
+    latestVersion: s.latestVersion || prev.latestVersion,
+    latestTag: s.latestTag || prev.latestTag,
+    latestDownloadUrl: s.latestDownloadUrl || prev.latestDownloadUrl,
+    cacheVersion: s.cacheVersion || prev.cacheVersion,
+  };
   if (opts?.syncSwitch !== false) {
     maintainOn.value = !!s.maintainDesired;
   }

--- a/frontend/src/views/__tests__/VideoView.spec.ts
+++ b/frontend/src/views/__tests__/VideoView.spec.ts
@@ -135,6 +135,36 @@ describe("VideoView", () => {
     ).toContain("2025.05.01");
   });
 
+  it("keeps latest version in details after cache update", async () => {
+    vi.mocked(App.checkYTDLPLatestRelease).mockResolvedValue({
+      ...baseStatus,
+      latestVersion: "2025.05.01",
+      latestTag: "2025.05.01",
+      latestDownloadUrl: "https://example.com/yt-dlp.exe",
+    });
+    vi.mocked(App.updateOfficialYTDLPCache).mockResolvedValue({
+      ...baseStatus,
+      cacheVersion: "2025.05.01",
+      latestVersion: "",
+      latestTag: "",
+      latestDownloadUrl: "",
+    });
+    const wrapper = mountView();
+    await flushPromises();
+    await wrapper.get('[data-testid="ytdlp-check-latest"]').trigger("click");
+    await flushPromises();
+    await wrapper.get('[data-testid="ytdlp-update-cache"]').trigger("click");
+    await flushPromises();
+    await wrapper.get('[data-testid="ytdlp-details-toggle"]').trigger("click");
+    await flushPromises();
+    expect(wrapper.get('[data-testid="ytdlp-cache-version"]').text()).toContain(
+      "2025.05.01",
+    );
+    expect(
+      wrapper.get('[data-testid="ytdlp-latest-version"]').text(),
+    ).toContain("2025.05.01");
+  });
+
   it("opens cache folder", async () => {
     const wrapper = mountView();
     await flushPromises();

--- a/internal/usecase/settings_usecase.go
+++ b/internal/usecase/settings_usecase.go
@@ -281,18 +281,9 @@ func (uc *SettingsUseCase) SetYTDLPOfficialCacheTag(ctx context.Context, tag str
 
 // GetYTDLPKnownLatest returns the last GitHub latest release metadata shown in the Video tab.
 func (uc *SettingsUseCase) GetYTDLPKnownLatest(ctx context.Context) (version, tag, downloadURL string, err error) {
-	version, err = uc.repo.Get(ctx, keyYTDLPKnownLatestVersion)
-	if err != nil {
-		return "", "", "", err
-	}
-	tag, err = uc.repo.Get(ctx, keyYTDLPKnownLatestTag)
-	if err != nil {
-		return "", "", "", err
-	}
-	downloadURL, err = uc.repo.Get(ctx, keyYTDLPKnownLatestDownloadURL)
-	if err != nil {
-		return "", "", "", err
-	}
+	version, _ = uc.repo.Get(ctx, keyYTDLPKnownLatestVersion)
+	tag, _ = uc.repo.Get(ctx, keyYTDLPKnownLatestTag)
+	downloadURL, _ = uc.repo.Get(ctx, keyYTDLPKnownLatestDownloadURL)
 	return version, tag, downloadURL, nil
 }
 

--- a/internal/usecase/settings_usecase.go
+++ b/internal/usecase/settings_usecase.go
@@ -159,6 +159,10 @@ const (
 	keyYTDLPToolsReplaceMaintain     = "ytdlp_tools_replace_maintain"
 	keyYTDLPToolsReplaceRiskAck      = "ytdlp_tools_replace_risk_ack"
 	keyYTDLPToolsReplacePendingError = "ytdlp_tools_replace_pending_error"
+	keyYTDLPOfficialCacheTag         = "ytdlp_official_cache_tag"
+	keyYTDLPKnownLatestVersion       = "ytdlp_known_latest_version"
+	keyYTDLPKnownLatestTag           = "ytdlp_known_latest_tag"
+	keyYTDLPKnownLatestDownloadURL   = "ytdlp_known_latest_download_url"
 )
 
 // SupportedAppLanguages are UI locale codes persisted in app_settings.
@@ -263,6 +267,44 @@ func (uc *SettingsUseCase) GetYTDLPToolsReplacePendingError(ctx context.Context)
 // SetYTDLPToolsReplacePendingError persists or clears the pending re-link error.
 func (uc *SettingsUseCase) SetYTDLPToolsReplacePendingError(ctx context.Context, msg string) error {
 	return uc.repo.Set(ctx, keyYTDLPToolsReplacePendingError, strings.TrimSpace(msg))
+}
+
+// GetYTDLPOfficialCacheTag returns the last recorded official cache release tag (empty if unset).
+func (uc *SettingsUseCase) GetYTDLPOfficialCacheTag(ctx context.Context) (string, error) {
+	return uc.repo.Get(ctx, keyYTDLPOfficialCacheTag)
+}
+
+// SetYTDLPOfficialCacheTag records the release tag installed into the official cache.
+func (uc *SettingsUseCase) SetYTDLPOfficialCacheTag(ctx context.Context, tag string) error {
+	return uc.repo.Set(ctx, keyYTDLPOfficialCacheTag, normalizeReleaseTag(tag))
+}
+
+// GetYTDLPKnownLatest returns the last GitHub latest release metadata shown in the Video tab.
+func (uc *SettingsUseCase) GetYTDLPKnownLatest(ctx context.Context) (version, tag, downloadURL string, err error) {
+	version, err = uc.repo.Get(ctx, keyYTDLPKnownLatestVersion)
+	if err != nil {
+		return "", "", "", err
+	}
+	tag, err = uc.repo.Get(ctx, keyYTDLPKnownLatestTag)
+	if err != nil {
+		return "", "", "", err
+	}
+	downloadURL, err = uc.repo.Get(ctx, keyYTDLPKnownLatestDownloadURL)
+	if err != nil {
+		return "", "", "", err
+	}
+	return version, tag, downloadURL, nil
+}
+
+// SetYTDLPKnownLatest persists GitHub latest release metadata for the Video tab.
+func (uc *SettingsUseCase) SetYTDLPKnownLatest(ctx context.Context, version, tag, downloadURL string) error {
+	if err := uc.repo.Set(ctx, keyYTDLPKnownLatestVersion, normalizeReleaseTag(version)); err != nil {
+		return err
+	}
+	if err := uc.repo.Set(ctx, keyYTDLPKnownLatestTag, normalizeReleaseTag(tag)); err != nil {
+		return err
+	}
+	return uc.repo.Set(ctx, keyYTDLPKnownLatestDownloadURL, strings.TrimSpace(downloadURL))
 }
 
 func parseBoolSetting(v string) bool {

--- a/internal/usecase/settings_usecase.go
+++ b/internal/usecase/settings_usecase.go
@@ -280,11 +280,12 @@ func (uc *SettingsUseCase) SetYTDLPOfficialCacheTag(ctx context.Context, tag str
 }
 
 // GetYTDLPKnownLatest returns the last GitHub latest release metadata shown in the Video tab.
-func (uc *SettingsUseCase) GetYTDLPKnownLatest(ctx context.Context) (version, tag, downloadURL string, err error) {
+// Missing keys are ignored (same pattern as GetPathSettings); partial results are returned.
+func (uc *SettingsUseCase) GetYTDLPKnownLatest(ctx context.Context) (version, tag, downloadURL string) {
 	version, _ = uc.repo.Get(ctx, keyYTDLPKnownLatestVersion)
 	tag, _ = uc.repo.Get(ctx, keyYTDLPKnownLatestTag)
 	downloadURL, _ = uc.repo.Get(ctx, keyYTDLPKnownLatestDownloadURL)
-	return version, tag, downloadURL, nil
+	return version, tag, downloadURL
 }
 
 // SetYTDLPKnownLatest persists GitHub latest release metadata for the Video tab.

--- a/internal/usecase/ytdlp_maintain.go
+++ b/internal/usecase/ytdlp_maintain.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 )
@@ -192,9 +193,8 @@ func (uc *YTDLPMaintainUseCase) CheckLatest(ctx context.Context) (YTDLPMaintainS
 		st.LatestError = ferr.Error()
 		return st, nil
 	}
-	st.LatestVersion = info.Version
-	st.LatestTag = info.Tag
-	st.LatestDownloadURL = info.DownloadURL
+	st = enrichYTDLPMaintainRelease(st, "", info.Tag, info.DownloadURL, info.Version)
+	uc.persistKnownLatest(ctx, st)
 	return st, nil
 }
 
@@ -210,6 +210,7 @@ func (uc *YTDLPMaintainUseCase) UpdateOfficialCache(ctx context.Context, downloa
 
 	url := downloadURL
 	tag := expectedTag
+	version := ""
 	if url == "" {
 		info, ferr := uc.updater.FetchLatestRelease(ctx)
 		if ferr != nil {
@@ -218,9 +219,10 @@ func (uc *YTDLPMaintainUseCase) UpdateOfficialCache(ctx context.Context, downloa
 		}
 		url = info.DownloadURL
 		tag = info.Tag
-		st.LatestVersion = info.Version
-		st.LatestTag = info.Tag
-		st.LatestDownloadURL = info.DownloadURL
+		version = info.Version
+	}
+	if tag == "" && url != "" {
+		tag = ytdlpReleaseTagFromDownloadURL(url)
 	}
 	if dlErr := uc.updater.DownloadToCache(ctx, cachePath, url); dlErr != nil {
 		return st, dlErr
@@ -233,9 +235,10 @@ func (uc *YTDLPMaintainUseCase) UpdateOfficialCache(ctx context.Context, downloa
 		return st, err
 	}
 	st.CachePresent = true
-	st.CacheVersion = normalizeReleaseTag(tag)
-	if st.CacheVersion == "" {
-		st.CacheVersion = LocalYTDLPVersion(ctx, cachePath)
+	st = enrichYTDLPMaintainRelease(st, cachePath, tag, url, version)
+	uc.persistKnownLatest(ctx, st)
+	if st.CacheVersion != "" {
+		uc.persistOfficialCacheTag(ctx, st.CacheVersion)
 	}
 	if maintainDesired {
 		if linkErr := uc.linkIfNeeded(ctx, toolsPath, cachePath); linkErr != nil {
@@ -378,6 +381,24 @@ func (uc *YTDLPMaintainUseCase) getStatusLocked(ctx context.Context) (YTDLPMaint
 	if fi, stErr := os.Stat(cache); stErr == nil && !fi.IsDir() {
 		st.CachePresent = true
 		st.CacheVersion = LocalYTDLPVersion(ctx, cache)
+		if st.CacheVersion == "" && uc.settings != nil {
+			if saved, tagErr := uc.settings.GetYTDLPOfficialCacheTag(ctx); tagErr == nil {
+				st.CacheVersion = saved
+			}
+		}
+	}
+	if uc.settings != nil {
+		if ver, tag, dl, latestErr := uc.settings.GetYTDLPKnownLatest(ctx); latestErr == nil {
+			if st.LatestVersion == "" {
+				st.LatestVersion = ver
+			}
+			if st.LatestTag == "" {
+				st.LatestTag = tag
+			}
+			if st.LatestDownloadURL == "" {
+				st.LatestDownloadURL = dl
+			}
+		}
 	}
 	eff, err := EffectiveOfficialLink(tools, cache)
 	if err != nil {
@@ -450,6 +471,56 @@ func maintainErrorI18nKey(err error) string {
 		return "errorUnsupportedPlatform"
 	}
 	return ""
+}
+
+// enrichYTDLPMaintainRelease fills Latest* and CacheVersion from a resolved GitHub release ref.
+func enrichYTDLPMaintainRelease(st YTDLPMaintainStatus, cachePath, tag, downloadURL, version string) YTDLPMaintainStatus {
+	if tag == "" && downloadURL != "" {
+		tag = ytdlpReleaseTagFromDownloadURL(downloadURL)
+	}
+	ver := normalizeReleaseTag(version)
+	if ver == "" {
+		ver = normalizeReleaseTag(tag)
+	}
+	if tag != "" {
+		st.LatestTag = tag
+	}
+	if ver != "" {
+		st.LatestVersion = ver
+	}
+	if downloadURL != "" {
+		st.LatestDownloadURL = downloadURL
+	}
+	st.LatestError = ""
+	if ver != "" {
+		st.CacheVersion = ver
+	} else if cachePath != "" {
+		if fileVer := LocalYTDLPVersion(context.Background(), cachePath); fileVer != "" {
+			st.CacheVersion = fileVer
+		}
+	}
+	return st
+}
+
+func (uc *YTDLPMaintainUseCase) persistKnownLatest(ctx context.Context, st YTDLPMaintainStatus) {
+	if uc.settings == nil {
+		return
+	}
+	if st.LatestVersion == "" && st.LatestTag == "" && st.LatestDownloadURL == "" {
+		return
+	}
+	if err := uc.settings.SetYTDLPKnownLatest(ctx, st.LatestVersion, st.LatestTag, st.LatestDownloadURL); err != nil {
+		log.Printf("ytdlp maintain: persist known latest: %v", err)
+	}
+}
+
+func (uc *YTDLPMaintainUseCase) persistOfficialCacheTag(ctx context.Context, tag string) {
+	if uc.settings == nil || strings.TrimSpace(tag) == "" {
+		return
+	}
+	if err := uc.settings.SetYTDLPOfficialCacheTag(ctx, tag); err != nil {
+		log.Printf("ytdlp maintain: persist cache tag: %v", err)
+	}
 }
 
 // FormatMaintainError returns an i18n key for maintain API errors.

--- a/internal/usecase/ytdlp_maintain.go
+++ b/internal/usecase/ytdlp_maintain.go
@@ -193,8 +193,10 @@ func (uc *YTDLPMaintainUseCase) CheckLatest(ctx context.Context) (YTDLPMaintainS
 		st.LatestError = ferr.Error()
 		return st, nil
 	}
-	st = enrichYTDLPMaintainRelease(st, "", info.Tag, info.DownloadURL, info.Version)
+	st = enrichYTDLPMaintainRelease(ctx, st, "", info.Tag, info.DownloadURL, info.Version)
+	uc.mu.Lock()
 	uc.persistKnownLatest(ctx, st)
+	uc.mu.Unlock()
 	return st, nil
 }
 
@@ -235,7 +237,7 @@ func (uc *YTDLPMaintainUseCase) UpdateOfficialCache(ctx context.Context, downloa
 		return st, err
 	}
 	st.CachePresent = true
-	st = enrichYTDLPMaintainRelease(st, cachePath, tag, url, version)
+	st = enrichYTDLPMaintainRelease(ctx, st, cachePath, tag, url, version)
 	uc.persistKnownLatest(ctx, st)
 	if st.CacheVersion != "" {
 		uc.persistOfficialCacheTag(ctx, st.CacheVersion)
@@ -474,7 +476,7 @@ func maintainErrorI18nKey(err error) string {
 }
 
 // enrichYTDLPMaintainRelease fills Latest* and CacheVersion from a resolved GitHub release ref.
-func enrichYTDLPMaintainRelease(st YTDLPMaintainStatus, cachePath, tag, downloadURL, version string) YTDLPMaintainStatus {
+func enrichYTDLPMaintainRelease(ctx context.Context, st YTDLPMaintainStatus, cachePath, tag, downloadURL, version string) YTDLPMaintainStatus {
 	if tag == "" && downloadURL != "" {
 		tag = ytdlpReleaseTagFromDownloadURL(downloadURL)
 	}
@@ -495,7 +497,7 @@ func enrichYTDLPMaintainRelease(st YTDLPMaintainStatus, cachePath, tag, download
 	if ver != "" {
 		st.CacheVersion = ver
 	} else if cachePath != "" {
-		if fileVer := LocalYTDLPVersion(context.Background(), cachePath); fileVer != "" {
+		if fileVer := LocalYTDLPVersion(ctx, cachePath); fileVer != "" {
 			st.CacheVersion = fileVer
 		}
 	}
@@ -503,6 +505,7 @@ func enrichYTDLPMaintainRelease(st YTDLPMaintainStatus, cachePath, tag, download
 }
 
 func (uc *YTDLPMaintainUseCase) persistKnownLatest(ctx context.Context, st YTDLPMaintainStatus) {
+	// Caller must hold uc.mu (serializes the three settings writes with UpdateOfficialCache).
 	if uc.settings == nil {
 		return
 	}
@@ -510,7 +513,7 @@ func (uc *YTDLPMaintainUseCase) persistKnownLatest(ctx context.Context, st YTDLP
 		return
 	}
 	if err := uc.settings.SetYTDLPKnownLatest(ctx, st.LatestVersion, st.LatestTag, st.LatestDownloadURL); err != nil {
-		log.Printf("ytdlp maintain: persist known latest: %v", err)
+		log.Printf("ytdlp maintain: persist known latest (version=%s tag=%s): %v", st.LatestVersion, st.LatestTag, err)
 	}
 }
 

--- a/internal/usecase/ytdlp_maintain.go
+++ b/internal/usecase/ytdlp_maintain.go
@@ -194,6 +194,7 @@ func (uc *YTDLPMaintainUseCase) CheckLatest(ctx context.Context) (YTDLPMaintainS
 		return st, nil
 	}
 	st = enrichYTDLPMaintainRelease(ctx, st, "", info.Tag, info.DownloadURL, info.Version)
+	st.LatestError = ""
 	uc.mu.Lock()
 	uc.persistKnownLatest(ctx, st)
 	uc.mu.Unlock()
@@ -238,6 +239,7 @@ func (uc *YTDLPMaintainUseCase) UpdateOfficialCache(ctx context.Context, downloa
 	}
 	st.CachePresent = true
 	st = enrichYTDLPMaintainRelease(ctx, st, cachePath, tag, url, version)
+	st.LatestError = ""
 	uc.persistKnownLatest(ctx, st)
 	if st.CacheVersion != "" {
 		uc.persistOfficialCacheTag(ctx, st.CacheVersion)
@@ -390,16 +392,15 @@ func (uc *YTDLPMaintainUseCase) getStatusLocked(ctx context.Context) (YTDLPMaint
 		}
 	}
 	if uc.settings != nil {
-		if ver, tag, dl, latestErr := uc.settings.GetYTDLPKnownLatest(ctx); latestErr == nil {
-			if st.LatestVersion == "" {
-				st.LatestVersion = ver
-			}
-			if st.LatestTag == "" {
-				st.LatestTag = tag
-			}
-			if st.LatestDownloadURL == "" {
-				st.LatestDownloadURL = dl
-			}
+		ver, tag, dl, _ := uc.settings.GetYTDLPKnownLatest(ctx)
+		if st.LatestVersion == "" {
+			st.LatestVersion = ver
+		}
+		if st.LatestTag == "" {
+			st.LatestTag = tag
+		}
+		if st.LatestDownloadURL == "" {
+			st.LatestDownloadURL = dl
 		}
 	}
 	eff, err := EffectiveOfficialLink(tools, cache)
@@ -493,7 +494,6 @@ func enrichYTDLPMaintainRelease(ctx context.Context, st YTDLPMaintainStatus, cac
 	if downloadURL != "" {
 		st.LatestDownloadURL = downloadURL
 	}
-	st.LatestError = ""
 	if ver != "" {
 		st.CacheVersion = ver
 	} else if cachePath != "" {

--- a/internal/usecase/ytdlp_maintain.go
+++ b/internal/usecase/ytdlp_maintain.go
@@ -196,7 +196,9 @@ func (uc *YTDLPMaintainUseCase) CheckLatest(ctx context.Context) (YTDLPMaintainS
 	st = enrichYTDLPMaintainRelease(ctx, st, "", info.Tag, info.DownloadURL, info.Version)
 	st.LatestError = ""
 	uc.mu.Lock()
-	uc.persistKnownLatest(ctx, st)
+	if err := uc.persistKnownLatest(ctx, st); err != nil {
+		log.Printf("ytdlp maintain: persist known latest (version=%s tag=%s): %v", st.LatestVersion, st.LatestTag, err)
+	}
 	uc.mu.Unlock()
 	return st, nil
 }
@@ -224,9 +226,6 @@ func (uc *YTDLPMaintainUseCase) UpdateOfficialCache(ctx context.Context, downloa
 		tag = info.Tag
 		version = info.Version
 	}
-	if tag == "" && url != "" {
-		tag = ytdlpReleaseTagFromDownloadURL(url)
-	}
 	if dlErr := uc.updater.DownloadToCache(ctx, cachePath, url); dlErr != nil {
 		return st, dlErr
 	}
@@ -240,9 +239,13 @@ func (uc *YTDLPMaintainUseCase) UpdateOfficialCache(ctx context.Context, downloa
 	st.CachePresent = true
 	st = enrichYTDLPMaintainRelease(ctx, st, cachePath, tag, url, version)
 	st.LatestError = ""
-	uc.persistKnownLatest(ctx, st)
+	if err := uc.persistKnownLatest(ctx, st); err != nil {
+		return st, fmt.Errorf("persist known latest: %w", err)
+	}
 	if st.CacheVersion != "" {
-		uc.persistOfficialCacheTag(ctx, st.CacheVersion)
+		if err := uc.persistOfficialCacheTag(ctx, st.CacheVersion); err != nil {
+			return st, fmt.Errorf("persist cache tag: %w", err)
+		}
 	}
 	if maintainDesired {
 		if linkErr := uc.linkIfNeeded(ctx, toolsPath, cachePath); linkErr != nil {
@@ -392,7 +395,7 @@ func (uc *YTDLPMaintainUseCase) getStatusLocked(ctx context.Context) (YTDLPMaint
 		}
 	}
 	if uc.settings != nil {
-		ver, tag, dl, _ := uc.settings.GetYTDLPKnownLatest(ctx)
+		ver, tag, dl := uc.settings.GetYTDLPKnownLatest(ctx)
 		if st.LatestVersion == "" {
 			st.LatestVersion = ver
 		}
@@ -494,36 +497,32 @@ func enrichYTDLPMaintainRelease(ctx context.Context, st YTDLPMaintainStatus, cac
 	if downloadURL != "" {
 		st.LatestDownloadURL = downloadURL
 	}
-	if ver != "" {
-		st.CacheVersion = ver
-	} else if cachePath != "" {
-		if fileVer := LocalYTDLPVersion(ctx, cachePath); fileVer != "" {
+	if cachePath != "" {
+		if ver != "" {
+			st.CacheVersion = ver
+		} else if fileVer := LocalYTDLPVersion(ctx, cachePath); fileVer != "" {
 			st.CacheVersion = fileVer
 		}
 	}
 	return st
 }
 
-func (uc *YTDLPMaintainUseCase) persistKnownLatest(ctx context.Context, st YTDLPMaintainStatus) {
+func (uc *YTDLPMaintainUseCase) persistKnownLatest(ctx context.Context, st YTDLPMaintainStatus) error {
 	// Caller must hold uc.mu (serializes the three settings writes with UpdateOfficialCache).
 	if uc.settings == nil {
-		return
+		return nil
 	}
 	if st.LatestVersion == "" && st.LatestTag == "" && st.LatestDownloadURL == "" {
-		return
+		return nil
 	}
-	if err := uc.settings.SetYTDLPKnownLatest(ctx, st.LatestVersion, st.LatestTag, st.LatestDownloadURL); err != nil {
-		log.Printf("ytdlp maintain: persist known latest (version=%s tag=%s): %v", st.LatestVersion, st.LatestTag, err)
-	}
+	return uc.settings.SetYTDLPKnownLatest(ctx, st.LatestVersion, st.LatestTag, st.LatestDownloadURL)
 }
 
-func (uc *YTDLPMaintainUseCase) persistOfficialCacheTag(ctx context.Context, tag string) {
+func (uc *YTDLPMaintainUseCase) persistOfficialCacheTag(ctx context.Context, tag string) error {
 	if uc.settings == nil || strings.TrimSpace(tag) == "" {
-		return
+		return nil
 	}
-	if err := uc.settings.SetYTDLPOfficialCacheTag(ctx, tag); err != nil {
-		log.Printf("ytdlp maintain: persist cache tag: %v", err)
-	}
+	return uc.settings.SetYTDLPOfficialCacheTag(ctx, tag)
 }
 
 // FormatMaintainError returns an i18n key for maintain API errors.

--- a/internal/usecase/ytdlp_maintain_test.go
+++ b/internal/usecase/ytdlp_maintain_test.go
@@ -186,7 +186,7 @@ func TestEnrichYTDLPMaintainRelease(t *testing.T) {
 	t.Parallel()
 	st := YTDLPMaintainStatus{}
 	url := "https://github.com/yt-dlp/yt-dlp/releases/download/2026.07.04/yt-dlp.exe"
-	got := enrichYTDLPMaintainRelease(st, "", "", url, "")
+	got := enrichYTDLPMaintainRelease(context.Background(), st, "", "", url, "")
 	if got.LatestTag != "2026.07.04" || got.LatestVersion != "2026.07.04" {
 		t.Fatalf("latest %+v", got)
 	}

--- a/internal/usecase/ytdlp_maintain_test.go
+++ b/internal/usecase/ytdlp_maintain_test.go
@@ -181,3 +181,47 @@ func TestYTDLPMaintain_linkIfNeeded_skipsWhenAlreadyLinked(t *testing.T) {
 		t.Fatalf("pending should clear on skip, got %q", pending)
 	}
 }
+
+func TestEnrichYTDLPMaintainRelease(t *testing.T) {
+	t.Parallel()
+	st := YTDLPMaintainStatus{}
+	url := "https://github.com/yt-dlp/yt-dlp/releases/download/2026.07.04/yt-dlp.exe"
+	got := enrichYTDLPMaintainRelease(st, "", "", url, "")
+	if got.LatestTag != "2026.07.04" || got.LatestVersion != "2026.07.04" {
+		t.Fatalf("latest %+v", got)
+	}
+	if got.LatestDownloadURL != url {
+		t.Fatalf("download url %q", got.LatestDownloadURL)
+	}
+	if got.CacheVersion != "2026.07.04" {
+		t.Fatalf("cache version %q", got.CacheVersion)
+	}
+}
+
+func TestYTDLPKnownLatestSettingsRoundtrip(t *testing.T) {
+	t.Parallel()
+	repo := &fakeAppSettingsRepo{m: map[string]string{}}
+	settings := NewSettingsUseCase(repo)
+	ctx := context.Background()
+	const url = "https://github.com/yt-dlp/yt-dlp/releases/download/2026.07.04/yt-dlp.exe"
+	if err := settings.SetYTDLPKnownLatest(ctx, "2026.07.04", "2026.07.04", url); err != nil {
+		t.Fatal(err)
+	}
+	if err := settings.SetYTDLPOfficialCacheTag(ctx, "2026.06.01"); err != nil {
+		t.Fatal(err)
+	}
+	ver, tag, gotURL, err := settings.GetYTDLPKnownLatest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ver != "2026.07.04" || tag != "2026.07.04" || gotURL != url {
+		t.Fatalf("latest ver=%q tag=%q url=%q", ver, tag, gotURL)
+	}
+	cacheTag, err := settings.GetYTDLPOfficialCacheTag(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cacheTag != "2026.06.01" {
+		t.Fatalf("cache tag %q", cacheTag)
+	}
+}

--- a/internal/usecase/ytdlp_maintain_test.go
+++ b/internal/usecase/ytdlp_maintain_test.go
@@ -184,18 +184,32 @@ func TestYTDLPMaintain_linkIfNeeded_skipsWhenAlreadyLinked(t *testing.T) {
 
 func TestEnrichYTDLPMaintainRelease(t *testing.T) {
 	t.Parallel()
-	st := YTDLPMaintainStatus{}
-	url := "https://github.com/yt-dlp/yt-dlp/releases/download/2026.07.04/yt-dlp.exe"
-	got := enrichYTDLPMaintainRelease(context.Background(), st, "", "", url, "")
-	if got.LatestTag != "2026.07.04" || got.LatestVersion != "2026.07.04" {
-		t.Fatalf("latest %+v", got)
-	}
-	if got.LatestDownloadURL != url {
-		t.Fatalf("download url %q", got.LatestDownloadURL)
-	}
-	if got.CacheVersion != "2026.07.04" {
-		t.Fatalf("cache version %q", got.CacheVersion)
-	}
+	const url = "https://github.com/yt-dlp/yt-dlp/releases/download/2026.07.04/yt-dlp.exe"
+
+	t.Run("latest only does not overwrite cache version", func(t *testing.T) {
+		st := YTDLPMaintainStatus{CacheVersion: "2025.01.01"}
+		got := enrichYTDLPMaintainRelease(context.Background(), st, "", "2026.07.04", url, "2026.07.04")
+		if got.LatestVersion != "2026.07.04" || got.LatestTag != "2026.07.04" {
+			t.Fatalf("latest %+v", got)
+		}
+		if got.CacheVersion != "2025.01.01" {
+			t.Fatalf("cache version should be preserved, got %q", got.CacheVersion)
+		}
+	})
+
+	t.Run("cache update sets cache version from release", func(t *testing.T) {
+		st := YTDLPMaintainStatus{}
+		got := enrichYTDLPMaintainRelease(context.Background(), st, "/cache/yt-dlp.exe", "", url, "")
+		if got.LatestTag != "2026.07.04" || got.LatestVersion != "2026.07.04" {
+			t.Fatalf("latest %+v", got)
+		}
+		if got.LatestDownloadURL != url {
+			t.Fatalf("download url %q", got.LatestDownloadURL)
+		}
+		if got.CacheVersion != "2026.07.04" {
+			t.Fatalf("cache version %q", got.CacheVersion)
+		}
+	})
 }
 
 func TestYTDLPKnownLatestSettingsRoundtrip(t *testing.T) {
@@ -210,10 +224,7 @@ func TestYTDLPKnownLatestSettingsRoundtrip(t *testing.T) {
 	if err := settings.SetYTDLPOfficialCacheTag(ctx, "2026.06.01"); err != nil {
 		t.Fatal(err)
 	}
-	ver, tag, gotURL, err := settings.GetYTDLPKnownLatest(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ver, tag, gotURL := settings.GetYTDLPKnownLatest(ctx)
 	if ver != "2026.07.04" || tag != "2026.07.04" || gotURL != url {
 		t.Fatalf("latest ver=%q tag=%q url=%q", ver, tag, gotURL)
 	}

--- a/internal/usecase/ytdlp_release.go
+++ b/internal/usecase/ytdlp_release.go
@@ -85,9 +85,25 @@ func normalizeReleaseTag(tag string) string {
 	return strings.TrimPrefix(strings.TrimSpace(tag), "v")
 }
 
+// ytdlpReleaseTagFromDownloadURL extracts the release tag from a GitHub browser_download_url.
+func ytdlpReleaseTagFromDownloadURL(raw string) string {
+	const marker = "/releases/download/"
+	i := strings.Index(raw, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := raw[i+len(marker):]
+	end := strings.Index(rest, "/")
+	if end <= 0 {
+		return ""
+	}
+	return normalizeReleaseTag(rest[:end])
+}
+
 var allowedYTDlpDownloadHosts = map[string]struct{}{
-	"github.com":                    {},
-	"objects.githubusercontent.com": {},
+	"github.com":                           {},
+	"objects.githubusercontent.com":        {},
+	"release-assets.githubusercontent.com": {}, // github.com/releases/download → 302
 }
 
 func validateYTDlpDownloadURL(u *YTDLPUpdater, raw string) error {

--- a/internal/usecase/ytdlp_release_test.go
+++ b/internal/usecase/ytdlp_release_test.go
@@ -2,6 +2,8 @@ package usecase
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -47,6 +49,17 @@ func TestNormalizeReleaseTag(t *testing.T) {
 	}
 }
 
+func TestYtdlpReleaseTagFromDownloadURL(t *testing.T) {
+	t.Parallel()
+	const url = "https://github.com/yt-dlp/yt-dlp/releases/download/2026.07.04/yt-dlp.exe"
+	if got := ytdlpReleaseTagFromDownloadURL(url); got != "2026.07.04" {
+		t.Fatalf("got %q", got)
+	}
+	if got := ytdlpReleaseTagFromDownloadURL("https://evil.example/x"); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestFetchLatestRelease_httptest(t *testing.T) {
 	t.Parallel()
 	const relJSON = `{
@@ -88,6 +101,9 @@ func TestValidateYTDlpDownloadURL(t *testing.T) {
 	if err := validateYTDlpDownloadURL(u, "https://objects.githubusercontent.com/x/yt-dlp.exe"); err != nil {
 		t.Fatalf("allowed host: %v", err)
 	}
+	if err := validateYTDlpDownloadURL(u, "https://release-assets.githubusercontent.com/github-production-release-asset/1/yt-dlp.exe"); err != nil {
+		t.Fatalf("release-assets host: %v", err)
+	}
 	if err := validateYTDlpDownloadURL(u, "https://evil.example/yt-dlp.exe"); err == nil {
 		t.Fatal("expected reject for untrusted host")
 	}
@@ -95,6 +111,52 @@ func TestValidateYTDlpDownloadURL(t *testing.T) {
 	if err := validateYTDlpDownloadURL(u, "http://127.0.0.1/x"); err != nil {
 		t.Fatalf("skip validation: %v", err)
 	}
+}
+
+func TestDownloadToCache_followsGitHubReleaseRedirect(t *testing.T) {
+	t.Parallel()
+	const exeBody = "MZfake-official"
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "github.com":
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://release-assets.githubusercontent.com/bin/yt-dlp.exe"}},
+					Body:       http.NoBody,
+					Request:    req,
+				}, nil
+			case "release-assets.githubusercontent.com":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(exeBody)),
+					Request:    req,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected host %q", req.URL.Host)
+			}
+		}),
+	}
+
+	cache := filepath.Join(t.TempDir(), "ytdlp", "yt-dlp.exe")
+	u := &YTDLPUpdater{HTTPClient: client}
+	dlURL := "https://github.com/yt-dlp/yt-dlp/releases/download/2026.07.04/yt-dlp.exe"
+	if err := u.DownloadToCache(context.Background(), cache, dlURL); err != nil {
+		t.Fatalf("DownloadToCache: %v", err)
+	}
+	b, err := os.ReadFile(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != exeBody {
+		t.Fatalf("cache content %q", b)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestDownloadToCache_andEnsure(t *testing.T) {


### PR DESCRIPTION
## Summary
- Allow `release-assets.githubusercontent.com` when following GitHub release download redirects, fixing false "network error" on cache update.
- Keep Video tab detail versions in sync after check/update by enriching maintain status with release metadata and persisting known latest/cache tags in settings.
- Merge prior version fields on the frontend when the backend response omits them.

## Test plan
- [x] `go test -race ./internal/usecase/...` (ytdlp tests)
- [x] `golangci-lint run ./internal/usecase/...`
- [x] `pnpm run test` (includes `VideoView.spec.ts`)
- [ ] On Windows: open Video tab → 「最新版を確認」→ 「yt-dlp 公式最新版を取得・更新」→ expand details and confirm both saved/latest versions update


Made with [Cursor](https://cursor.com)