### PR TITLE
feat(dashboard): VRChat server status on Dashboard (#10)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,64 @@ _Avoid_: 自動スキャン, リアルタイム同期（フル同期と混同し
 ユーザーが Gallery 上の操作で Picture folder sync を明示的に開始すること。
 _Avoid_: 手動スキャン, 更新ボタン（一覧再取得だけを指す場合があるため）
 
+## Dashboard
+
+起動・自分のプレゼンス変更・公式サービス健全性をまとめるホーム画面体験の用語。**Server status**（[Issue #10](https://github.com/JO3QMA/vrctweaker/issues/10)、[ADR 0009](docs/adr/0009-dashboard-server-status.md)）は grill-with-docs / grill-review-ready で合意済み。実装契約は ADR を正本とする。
+
+### Language
+
+**Dashboard**:
+サイドバー先頭（`/`）のホーム画面体験。Quick launch、Instance rejoin section、自分のプレゼンス変更（Quick status 等）、**Server status** を置く。
+_Avoid_: ダッシュボード画面, ホーム（他アプリのホームと混同しやすいため）
+
+**Server status**:
+[status.vrchat.com](https://status.vrchat.com/) が示す VRChat **サービス**の健全性（API / 認証 / リージョン別リアルタイムなど）。ログイン中ユーザー自身の join me / busy などのプレゼンスや、フレンドのオンライン状況とは別物。
+_Avoid_: VRChat status, ステータス（Quick status や Cached VRChat user の status と混同しやすいため）, Server Status Page（取得元の俗称）
+
+**Server status summary**:
+Dashboard の Server status で常に示す全体の健全性の要約（例: 全システム正常 / 一部障害）。公式 `summary.json` のインジケータに相当。平常時はこれと外部リンク程度に畳む。
+_Avoid_: Quick status, サマリー行（Activity 等の別サマリーと混同しやすいため）
+
+**Server status detail**:
+component ごとの健全性の内訳。**Abnormal server status** のときだけ Dashboard に展開する。平常時（全 component が operational）は出さない。v1 の展開内容は、(1) リーフ component の名前とステータス、(2) 未解決インシデントの見出し（あれば 1 件）、(3) 予定または進行中メンテナンスの見出し（あれば）とする。過去インシデント履歴や公式ページ相当の全文は載せない。
+_Avoid_: component 一覧（常時表示を含意するため）, ステータス詳細（ユーザープロフィールと混同しやすいため）
+
+**Abnormal server status**:
+Server status detail を Dashboard に出す条件。少なくとも 1 つの component が `operational` 以外（`degraded_performance` / `partial_outage` / `major_outage` / `under_maintenance` など）のとき。未解決インシデントや予定メンテの有無は v1 では detail 展開条件に含めない（component 状態のみで判定）。
+_Avoid_: 障害中, メンテ中（component 状態とインシデント文面を同一視しないため）
+
+**Server status section**:
+Dashboard 上 **Quick launch より上**に置く Server status の UI ブロック。Server status summary を常時示し、Abnormal server status のときだけ Server status detail を展開する。status.vrchat.com への外部リンクを含む。
+_Avoid_: Quick status パネル, ステータスカード（個人プレゼンス変更と混同しやすいため）
+
+**Server status refresh**:
+Server status section のデータ再取得。Dashboard 表示時（`onMounted`）に 1 回行い、表示中は一定間隔（v1: 5 分）でバックグラウンドポーリングする。手動リフレッシュボタンは v1 では置かない。取得は Go バックエンド経由（フロントから status.vrchat.com へ直接 fetch しない）。
+_Avoid_: Activity refresh, 同期ボタン（他画面の更新と混同しやすいため）
+
+**Server status visibility**:
+Server status section の表示条件。VRChat へのログイン状態に依存せず、Dashboard を開けば常に表示する（未ログインでも取得・表示する）。Quick status とは別で、公開の status.vrchat.com API のみを参照する。
+_Avoid_: ログイン必須, 認証後のみ（Quick status の条件と混同しやすいため）
+
+**Server status fetch failure**:
+status.vrchat.com からの取得が失敗したときの扱い。Server status section は残し、取得できなかった旨だけを示す。次回の Server status refresh（ポーリング）で再試行する。最後に成功した値の stale 表示や、失敗時だけの手動リフレッシュは v1 では行わない。
+_Avoid_: 非表示, オフライン（ネットワーク断と公式障害を同一視しないため）
+
+**Server status labeling**:
+Server status section の表示言語の扱い。component 名とインシデント／メンテ見出しは API 原文（英語）のまま示す。ステータス値（operational / under_maintenance 等）と Server status summary の文言は UI ロケール（i18n）で翻訳する。
+_Avoid_: 全英語表示, 日本語 component 名（公式表記と照合しづらいため）
+
+**Server status presentation**:
+Server status section の視覚表現。他 Dashboard パネルと同様 `el-card` で枠を揃えつつ、健全性は status.vrchat.com に近い色分け（正常=緑、パフォーマンス低下=黄、部分障害=橙、重大障害=赤、メンテナンス=青系）で示す。平常時はコンパクトなサマリー行、Abnormal server status 時は Server status detail を同色ルールで展開する。
+_Avoid_: Quick status ボタン色（個人プレゼンス用の独自パレットと混同しやすいため）, モノクロのみ（障害判別が弱いため）
+
+**Server status v1 scope**:
+Issue #10 で最初に届ける Server status の範囲。Dashboard の Server status section（取得・表示・外部リンク）に限定する。v1 では含めないもの: 障害時 OS 通知、Settings でのオンオフやポーリング間隔変更、リージョン絞り込み、Dashboard 以外への常設表示、取得結果のローカル履歴・グラフ。
+_Avoid_: Server status（v1 機能全体を指すときは section とセットで書く）, 将来拡張（スコープ外リストの総称として曖昧なため）
+
+**Quick status**:
+Dashboard 上でログイン中ユーザー自身の VRChat プレゼンス（join me / active / ask me / busy）を API 経由で変更する操作群。Custom status・Templates と併置する。**Server status** とは無関係。
+_Avoid_: ステータス, Server status, クイックステータス（インフラ健全性と混同しやすいため）
+
 ## Launcher
 
 VRChat の起動引数を名前付きで保存し、起動に使うための用語。

--- a/app.go
+++ b/app.go
@@ -25,6 +25,7 @@ import (
 	"vrchat-tweaker/internal/infrastructure/picturewatcher"
 	"vrchat-tweaker/internal/infrastructure/sleepsuppress"
 	"vrchat-tweaker/internal/infrastructure/sqlite"
+	"vrchat-tweaker/internal/infrastructure/statuspage"
 	"vrchat-tweaker/internal/infrastructure/vrchatapi"
 	"vrchat-tweaker/internal/infrastructure/vrchatpipeline"
 	"vrchat-tweaker/internal/infrastructure/ytdlpmaintain"
@@ -43,6 +44,7 @@ type App struct {
 	settings         *usecase.SettingsUseCase
 	dbMaintenance    *usecase.DBMaintenanceUseCase
 	ytdlp            *usecase.YTDLPMaintainUseCase
+	serverStatus     *statuspage.Client
 	vrchatConfigRepo vrchatconfig.ConfigRepository
 
 	galleryScanMu     sync.Mutex
@@ -120,6 +122,7 @@ func (a *App) startup(ctx context.Context) {
 	a.settings = usecase.NewSettingsUseCase(settingsRepo)
 	a.dbMaintenance = usecase.NewDBMaintenanceUseCase(db, encounterRepo, mediaRepo, userCacheRepo, settingsRepo)
 	a.ytdlp = usecase.NewYTDLPMaintainUseCase(a.settings, usecase.NewYTDLPUpdater())
+	a.serverStatus = statuspage.NewClient()
 
 	configPath := getVRChatConfigPath()
 	configRepo := filesystem.NewVRChatConfigFileRepository(configPath)

--- a/app_server_status.go
+++ b/app_server_status.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 	"vrchat-tweaker/internal/infrastructure/statuspage"
 )
 
@@ -14,6 +15,9 @@ func (a *App) GetServerStatus() (ServerStatusDTO, error) {
 		ctx = context.Background()
 	}
 	snap := a.serverStatusClient().Fetch(ctx)
+	if snap.FetchState != statuspage.FetchStateOK {
+		runtime.LogWarning(ctx, "server status fetch: state="+snap.FetchState)
+	}
 	return toServerStatusDTO(snap), nil
 }
 
@@ -21,7 +25,8 @@ func (a *App) serverStatusClient() *statuspage.Client {
 	if a.serverStatus != nil {
 		return a.serverStatus
 	}
-	return statuspage.NewClient()
+	a.serverStatus = statuspage.NewClient()
+	return a.serverStatus
 }
 
 func toServerStatusDTO(snap statuspage.Snapshot) ServerStatusDTO {

--- a/app_server_status.go
+++ b/app_server_status.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+
+	"vrchat-tweaker/internal/infrastructure/statuspage"
+)
+
+// GetServerStatus returns VRChat service health from status.vrchat.com for the Dashboard.
+// Infrastructure failures are expressed via FetchState on the DTO, not via error.
+func (a *App) GetServerStatus() (ServerStatusDTO, error) {
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	snap := a.serverStatusClient().Fetch(ctx)
+	return toServerStatusDTO(snap), nil
+}
+
+func (a *App) serverStatusClient() *statuspage.Client {
+	if a.serverStatus != nil {
+		return a.serverStatus
+	}
+	return statuspage.NewClient()
+}
+
+func toServerStatusDTO(snap statuspage.Snapshot) ServerStatusDTO {
+	components := make([]ServerStatusComponentDTO, len(snap.Components))
+	for i, c := range snap.Components {
+		components[i] = ServerStatusComponentDTO{Name: c.Name, Status: c.Status}
+	}
+	incidents := make([]ServerStatusHeadlineDTO, len(snap.Incidents))
+	for i, h := range snap.Incidents {
+		incidents[i] = ServerStatusHeadlineDTO{Name: h.Name}
+	}
+	maintenances := make([]ServerStatusHeadlineDTO, len(snap.Maintenances))
+	for i, h := range snap.Maintenances {
+		maintenances[i] = ServerStatusHeadlineDTO{Name: h.Name}
+	}
+	return ServerStatusDTO{
+		FetchState: snap.FetchState,
+		Summary: ServerStatusSummaryDTO{
+			Indicator:   snap.Summary.Indicator,
+			Description: snap.Summary.Description,
+		},
+		Components:   components,
+		Incidents:    incidents,
+		Maintenances: maintenances,
+	}
+}

--- a/app_server_status_test.go
+++ b/app_server_status_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"vrchat-tweaker/internal/infrastructure/statuspage"
+)
+
+func TestToServerStatusDTO_mapsSnapshot(t *testing.T) {
+	got := toServerStatusDTO(statuspage.Snapshot{
+		FetchState: statuspage.FetchStateOK,
+		Summary: statuspage.Summary{
+			Indicator:   "maintenance",
+			Description: "Service Under Maintenance",
+		},
+		Components: []statuspage.Component{
+			{Name: "Authentication / Login", Status: "under_maintenance"},
+		},
+		Incidents:    []statuspage.Headline{{Name: "API Degraded"}},
+		Maintenances: []statuspage.Headline{{Name: "Database Maintenance"}},
+	})
+	if got.FetchState != statuspage.FetchStateOK {
+		t.Fatalf("FetchState: got %q", got.FetchState)
+	}
+	if got.Summary.Indicator != "maintenance" {
+		t.Fatalf("indicator: got %q", got.Summary.Indicator)
+	}
+	if len(got.Components) != 1 || got.Components[0].Name != "Authentication / Login" {
+		t.Fatalf("components: %+v", got.Components)
+	}
+	if len(got.Incidents) != 1 || got.Incidents[0].Name != "API Degraded" {
+		t.Fatalf("incidents: %+v", got.Incidents)
+	}
+	if len(got.Maintenances) != 1 {
+		t.Fatalf("maintenances: %+v", got.Maintenances)
+	}
+}
+
+func TestGetServerStatus_returnsDTOWithoutErrorOnFetchFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("down"))
+	}))
+	defer srv.Close()
+
+	a := &App{
+		ctx: t.Context(),
+		serverStatus: &statuspage.Client{
+			BaseURL:               srv.URL + "/api/v2/",
+			InsecureSkipHostCheck: true,
+		},
+	}
+	got, err := a.GetServerStatus()
+	if err != nil {
+		t.Fatalf("GetServerStatus error: %v", err)
+	}
+	if got.FetchState != statuspage.FetchStateUnavailable {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, statuspage.FetchStateUnavailable)
+	}
+}

--- a/app_server_status_test.go
+++ b/app_server_status_test.go
@@ -46,11 +46,8 @@ func TestGetServerStatus_returnsDTOWithoutErrorOnFetchFailure(t *testing.T) {
 	defer srv.Close()
 
 	a := &App{
-		ctx: t.Context(),
-		serverStatus: &statuspage.Client{
-			BaseURL:               srv.URL + "/api/v2/",
-			InsecureSkipHostCheck: true,
-		},
+		ctx:          t.Context(),
+		serverStatus: statuspage.NewTestClient(srv.URL + "/api/v2/"),
 	}
 	got, err := a.GetServerStatus()
 	if err != nil {
@@ -58,5 +55,17 @@ func TestGetServerStatus_returnsDTOWithoutErrorOnFetchFailure(t *testing.T) {
 	}
 	if got.FetchState != statuspage.FetchStateUnavailable {
 		t.Fatalf("FetchState: got %q want %q", got.FetchState, statuspage.FetchStateUnavailable)
+	}
+}
+
+func TestServerStatusClient_cachesDefaultClient(t *testing.T) {
+	a := &App{}
+	first := a.serverStatusClient()
+	second := a.serverStatusClient()
+	if first != second {
+		t.Fatal("expected same cached client instance")
+	}
+	if a.serverStatus == nil {
+		t.Fatal("expected serverStatus field to be set")
 	}
 }

--- a/bindings.go
+++ b/bindings.go
@@ -53,6 +53,32 @@ type InstanceRejoinSectionDTO struct {
 	SelectedProfileID string             `json:"selectedProfileId"`
 }
 
+// ServerStatusDTO is the Dashboard Server status section (status.vrchat.com).
+type ServerStatusDTO struct {
+	FetchState   string                     `json:"fetchState"`
+	Summary      ServerStatusSummaryDTO     `json:"summary"`
+	Components   []ServerStatusComponentDTO `json:"components"`
+	Incidents    []ServerStatusHeadlineDTO  `json:"incidents"`
+	Maintenances []ServerStatusHeadlineDTO  `json:"maintenances"`
+}
+
+// ServerStatusSummaryDTO is the overall indicator from status.vrchat.com.
+type ServerStatusSummaryDTO struct {
+	Indicator   string `json:"indicator"`
+	Description string `json:"description"`
+}
+
+// ServerStatusComponentDTO is a non-operational statuspage leaf component.
+type ServerStatusComponentDTO struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// ServerStatusHeadlineDTO is an incident or maintenance headline.
+type ServerStatusHeadlineDTO struct {
+	Name string `json:"name"`
+}
+
 // ScreenshotDTO is the frontend-facing screenshot.
 type ScreenshotDTO struct {
 	ID                string  `json:"id"`

--- a/docs/adr/0009-dashboard-server-status.md
+++ b/docs/adr/0009-dashboard-server-status.md
@@ -1,0 +1,184 @@
+# ADR 0009: Dashboard Server status
+
+## Status
+
+Accepted（grill-with-docs / grill-review-ready で合意、[Issue #10](https://github.com/JO3QMA/vrctweaker/issues/10)）
+
+## Context
+
+- VRChat のサービス障害・メンテ中に、起動やログインの失敗がローカル環境由来か公式側か切り分けたい（Issue #10）
+- 公式 [status.vrchat.com](https://status.vrchat.com/) は Statuspage API（`summary.json` / `components.json` 等）を公開している。認証不要
+- Dashboard には既に **Quick status**（join me / busy 等の個人プレゼンス変更）があり、**Server status**（インフラ健全性）と混同しやすい
+- 本番 CSP は `connect-src 'self'` で、外部 HTTP は Go 経由が既存方針（`main.go` の AssetServer middleware コメント）。フロントから status.vrchat.com へ直接 `fetch` しない
+- `GetInstanceRejoinSection` は infra 失敗時 `(nil, error)` + `ElMessage.error` だが、Server status は常時表示・定期ポーリングのため別契約が必要
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Dashboard** セクション（**Server status**、**Server status section**、**Quick status** 等）を正本とする。
+
+## Decision
+
+1. **対象**: status.vrchat.com のサービス健全性のみ。個人プレゼンス（Quick status）・フレンドオンラインとは別
+2. **配置**: Dashboard の **Quick launch より上**に **Server status section**（`ServerStatusSection.vue`）
+3. **表示量**: **Server status summary** を常時。`operational` 以外の component が 1 件でもあれば **Abnormal server status** とし **Server status detail** を展開。平常時はコンパクトな 1 行 + status.vrchat.com への外部リンク
+4. **detail 内容**: (1) リーフ component のうち **`operational` 以外のみ**（フラット。親グループ見出しは v1 なし）、(2) 未解決インシデント見出し（あれば）、(3) 予定または進行中メンテ見出し（あれば）。component 名・インシデント／メンテ見出しは API 原文（英語）。ステータス値とサマリー文言は i18n
+5. **色**: `el-card` 枠 + status.vrchat.com に近い色分け（正常=緑、低下=黄、部分障害=橙、重大=赤、メンテ=青系）
+6. **ログイン**: **不要**。未ログインでも表示・取得する
+7. **取得経路**: Wails **`GetServerStatus()`** — Go が status.vrchat.com を HTTP GET。`User-Agent` は `vrchatapi.UserAgent` を流用
+8. **更新**: Dashboard 表示中のみ。`onMounted` で即 1 回 + **5 分**間隔ポーリング。`onUnmounted` で `clearInterval`。手動リフレッシュ・`document.visibilitychange` による停止は v1 なし
+9. **外部リンク**: `<a href="https://status.vrchat.com" target="_blank" rel="noopener noreferrer">`（`LicensesView` と同パターン）
+10. **出荷**: **PR1** Go（infra + usecase + binding + テスト）→ **PR2** Vue + i18n×5 + E2E mock
+
+## Failure modes（review-ready）
+
+| 状況 | ユーザー | サーバ |
+|------|----------|--------|
+| 全体取得失敗（タイムアウト、DNS、非 200、不正 JSON、body 超過） | セクション内「取得できませんでした」（i18n）。detail なし | `fetchState=unavailable` を DTO で返す。ログに `err` または非 200 + body 先頭 200 文字 |
+| **部分失敗**（summary OK、components / incidents / maintenances のいずれか失敗） | サマリー表示 + detail 領域に「詳細を取得できませんでした」 | `fetchState=partial` |
+| ポーリング失敗（上記） | 同上。**`ElMessage` は出さない**（5 分ごとの toast 汚染を避ける） | 同上 |
+| 全 component `operational` | コンパクトサマリー + リンク。component リストなし | `fetchState=ok`、components 空 |
+| Abnormal | サマリー + 非 operational component + 見出し（取れた分） | `fetchState=ok` |
+
+Quick launch・Instance rejoin・Quick status は Server status 失敗の影響を受けない（非ブロッキング）。
+
+## Return-value contract（review-ready）
+
+### 読み取り — `GetServerStatus() (ServerStatusDTO, error)`
+
+| 層 | 取得失敗（infra / HTTP） | 部分成功 | 成功 |
+|----|--------------------------|----------|------|
+| **Usecase / App** | **`(DTO{fetchState:"unavailable"}, nil)`** | **`(DTO{fetchState:"partial", summary:…}, nil)`** | **`(DTO{fetchState:"ok", …}, nil)`** |
+| **Programming mistake**（例: subsystem 未初期化） | 読み取り系は `(DTO{fetchState:"unavailable"}, nil)` または `error` のどちらかに **統一**（yt-dlp `notInitialized` パターン） | — | — |
+| **Frontend** | セクション内 i18n エラー。toast なし | サマリー + detail 失敗文言 | 通常表示 |
+
+- `fetchState` は Go が返す生文字列 `ok` | `unavailable` | `partial`。翻訳はフロントの `dashboard.serverStatus.*`
+- **`callApp` fallback**（`app.ts`）は毎回 **新規** `{ fetchState: "unavailable", … }` を返す（共有 mutable 禁止）
+- Instance rejoin と異なり、infra 失敗を **`error` で Wails に上げない**（ポーリング前提）
+
+DTO 概要:
+
+```go
+type ServerStatusDTO struct {
+    FetchState   string                      `json:"fetchState"`
+    Summary      ServerStatusSummaryDTO      `json:"summary"`
+    Components   []ServerStatusComponentDTO  `json:"components"`   // non-operational only when ok/partial
+    Incidents    []ServerStatusHeadlineDTO   `json:"incidents"`
+    Maintenances []ServerStatusHeadlineDTO   `json:"maintenances"`
+}
+```
+
+## Config（review-ready）
+
+v1 は **Settings / env 追加なし**。定数は Go に固定:
+
+| 定数 | 値 | 備考 |
+|------|-----|------|
+| HTTP timeout | 15s | `vrchatapi.Client` と同じ |
+| Max body | 1 MiB | `LimitReader` + 超過は失敗 |
+| Allowed host | `status.vrchat.com` | https のみ。リダイレクト先も同ホストのみ |
+| Poll interval | 5 min | **Vue のみ**（`ServerStatusSection.vue`） |
+
+API エンドポイント（ベース `https://status.vrchat.com/api/v2/`）:
+
+- 常時: `summary.json`
+- Abnormal 判定・detail: `components.json`
+- detail 見出し: `incidents/unresolved.json`、`scheduled-maintenances/active.json`（または `upcoming.json` — 実装時に active を優先し、空なら upcoming）
+
+同一 `GetServerStatus` 呼び出し内は **`errgroup` で並列 GET**（ネットワーク I/O は mutex 外）。
+
+## Trust boundaries（review-ready）
+
+| 境界 | 方針 |
+|------|------|
+| **URL** | コード内ベース URL 固定 + host allowlist。ユーザー入力なし |
+| **リダイレクト** | 許可外ホストへ飛ぶ 302 は拒否 |
+| **ログ** | 非 200 時は status + body 先頭 200 文字まで。成功レスポンス全文は出さない |
+| **User-Agent** | `vrchatapi.UserAgent` |
+| **Frontend** | 公開 API の component 名・インシデント見出しをそのまま表示（PII は通常含まれない）。`docs/agents/redaction.md` は公開成果物向け |
+
+## Lifecycle（review-ready）
+
+- **Go**: 常駐 goroutine なし。リクエストごとに `context` 付き HTTP（App の `a.ctx` またはリクエスト scope）
+- **Vue**: `inFlight` — 前回 `GetServerStatus` 未完了なら poll tick をスキップ
+- **Vue**: **generation カウンタ** — `onUnmounted` で increment し、await 後に古い generation なら `ref` 更新しない
+- **Vue**: `setInterval` は `onUnmounted` で `clearInterval`
+
+## Interim / v1 scope（review-ready）
+
+### v1 でやる
+
+- Dashboard **Server status section** のみ
+- detail の component は **フラット・非 operational のみ**
+
+```go
+// ponytail: flat leaf components only; no parent-group headings yet.
+// Upgrade path: group by components[].group_id to match status.vrchat.com.
+```
+
+### v1 スコープ外（Issue #10 以降）
+
+- 障害検知時の OS 通知
+- Settings でのオンオフ・ポーリング間隔変更
+- リージョン絞り込み
+- サイドバー等 Dashboard 以外への常設
+- 取得結果のローカル履歴・グラフ
+- `document.visibilitychange` による poll 停止
+- status ページの親グループ見出し表示
+
+## Edge cases → tests（review-ready）
+
+### Backend（`internal/infrastructure/statuspage` + usecase）
+
+| 入力 | 期待 | テスト名 |
+|------|------|----------|
+| 全 component `operational` | `fetchState=ok`、components 空 | `TestFetch_allOperational` |
+| 1 件 `under_maintenance` | `fetchState=ok`、components 1 件 | `TestFetch_abnormalOneComponent` |
+| summary 失敗 | `fetchState=unavailable` | `TestFetch_summaryFailure` |
+| summary OK、components 失敗 | `fetchState=partial` | `TestFetch_partialComponentsFailure` |
+| 不正 JSON | `fetchState=unavailable` | `TestFetch_invalidJSON` |
+| body > 1MiB | `fetchState=unavailable` | `TestFetch_bodyTooLarge` |
+| 302 → 許可外ホスト | 失敗 | `TestFetch_redirectHostRejected` |
+| HTTP 503 | `fetchState=unavailable` | `TestFetch_non200` |
+
+### Frontend（`ServerStatusSection.spec.ts` / `DashboardView.spec.ts`）
+
+| 入力 | 期待 | テスト名 |
+|------|------|----------|
+| `fetchState=unavailable` | セクション内エラー、detail なし | `shows server status fetch failure` |
+| `fetchState=partial` | サマリー + detail 失敗文言 | `shows partial server status detail failure` |
+| `fetchState=ok`、全 operational | コンパクトサマリー、リストなし | `hides server status detail when operational` |
+| `fetchState=ok`、abnormal | 非 operational のみ | `shows non-operational components only` |
+| unmount 後 resolve | ref 更新なし | `does not update server status after unmount` |
+| inFlight 中の tick | 2 回目スキップ | `skips overlapping server status poll` |
+
+### E2E
+
+| 入力 | 期待 | テスト名 |
+|------|------|----------|
+| mock `GetServerStatus` 正常 | section visible（`data-testid`） | `dashboard shows server status section` |
+
+## i18n（review-ready）
+
+- キー名前空間: **`dashboard.serverStatus.*`**（`dashboard.quickStatus` と並列）
+- ロケール: `en` / `ja` / `ko` / `zh-CN` / `zh-TW` すべてに同一キー
+- component 名は翻訳しない。`operational` 等のステータス ID → i18n マップはフロント（例: `dashboard.serverStatus.statusOperational`）
+
+## Considered options
+
+| 案 | 却下理由 |
+|----|----------|
+| フロントから status.vrchat.com 直 `fetch` | CSP `connect-src 'self'` 変更が必要。既存「外部 HTTP は Go」と不一致 |
+| infra 失敗を `(nil, error)` + `ElMessage`（Instance rejoin 同様） | 5 分 poll で toast 汚染。セクション常時表示と矛盾 |
+| 平常時も全 component 一覧 | Dashboard ノイズ。Issue の意図（障害時の切り分け）に対して過剰 |
+| stale 表示（最後の成功値を保持） | 古い「正常」表示のリスク。grill-with-docs で却下 |
+| 1 PR に Go+Vue 一括 | レビュー可能だが、HTTP 層と UI 層の関心分離のため **2 PR** を採用 |
+
+## Consequences
+
+- Dashboard にインフラ系と個人プレゼンス系の 2 種の「status」が並ぶ。用語と UI ラベルで **Server status** / **Quick status** を厳密に分ける
+- `GetServerStatus` は VRChat セッション不要。オフライン時も「取得できませんでした」と区別できる
+- 将来 Settings で poll 間隔を変える場合は本 ADR の Config 節と `Server status v1 scope` を更新する
+
+## Related
+
+- [Issue #10](https://github.com/JO3QMA/vrctweaker/issues/10)
+- [status.vrchat.com API](https://status.vrchat.com/api/)
+- [ADR 0006](0006-instance-rejoin-and-last-launch-profile.md)（Dashboard 上の別セクション・別 Wails 契約の先例）

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -35,6 +35,8 @@ test.describe("VRChat Tweaker", () => {
     test("displays default profile and status buttons", async ({ page }) => {
       await page.goto("/");
       await expect(page.locator("h1")).toContainText("ダッシュボード");
+      await expect(page.getByTestId("server-status-section")).toBeVisible();
+      await expect(page.getByTestId("server-status-summary")).toBeVisible();
       // モックでデフォルトプロファイル1件を返すため、起動ボタンが有効になる
       await expect(
         page.getByRole("button", { name: /VRChat 起動/ }),

--- a/frontend/e2e/fixtures/mock-wails.ts
+++ b/frontend/e2e/fixtures/mock-wails.ts
@@ -68,6 +68,13 @@ export function getMockWailsInitScript(options: MockWailsOptions = {}): string {
     latestError: "",
   };
   const ytdlpMaintainStatusJson = JSON.stringify(ytdlpMaintainStatus);
+  const serverStatusJson = JSON.stringify({
+    fetchState: "ok",
+    summary: { indicator: "none", description: "All Systems Operational" },
+    components: [],
+    incidents: [],
+    maintenances: [],
+  });
 
   return `
     (function() {
@@ -88,6 +95,7 @@ export function getMockWailsInitScript(options: MockWailsOptions = {}): string {
       const resolveSelfProfileSeed = ${resolveSelfProfileSeedJson};
       const loggedIn = ${loggedInJson};
       const ytdlpMaintainStatus = ${ytdlpMaintainStatusJson};
+      const serverStatus = ${serverStatusJson};
       var selfProfile = Object.assign({}, selfProfileSeed);
       var selfProfileRefreshCount = 0;
 
@@ -195,6 +203,7 @@ export function getMockWailsInitScript(options: MockWailsOptions = {}): string {
         LaunchVRChat: () => Promise.resolve(),
         LaunchVRChatWithArgs: (_args, _profileId) => Promise.resolve(),
         GetInstanceRejoinSection: () => Promise.resolve(null),
+        GetServerStatus: () => Promise.resolve(serverStatus),
         InstanceRejoin: (_profileId, _playSessionId) => Promise.resolve(),
         ParseLaunchArgsForGUI: () =>
           Promise.resolve({

--- a/frontend/src/components/ServerStatusSection.vue
+++ b/frontend/src/components/ServerStatusSection.vue
@@ -10,7 +10,15 @@
       }}</span>
     </template>
 
-    <div v-if="fetchState === 'unavailable'" class="server-status-message">
+    <div
+      v-if="loading"
+      class="server-status-message"
+      data-testid="server-status-loading"
+    >
+      {{ t("dashboard.serverStatus.loading") }}
+    </div>
+
+    <div v-else-if="fetchState === 'unavailable'" class="server-status-message">
       {{ t("dashboard.serverStatus.fetchUnavailable") }}
     </div>
 
@@ -85,6 +93,7 @@ import {
 const { t } = useI18n();
 
 const statusPageUrl = SERVER_STATUS_PAGE_URL;
+const loading = ref(true);
 const fetchState = ref<ServerStatusDTO["fetchState"]>("unavailable");
 const summaryIndicator = ref("");
 const components = ref<ServerStatusDTO["components"]>([]);
@@ -140,8 +149,16 @@ async function refresh(): Promise<void> {
     const dto = await App.getServerStatus();
     if (gen !== generation) return;
     applySnapshot(dto);
+  } catch {
+    if (gen !== generation) return;
+    if (loading.value) {
+      fetchState.value = "unavailable";
+    }
   } finally {
     inFlight = false;
+    if (gen === generation) {
+      loading.value = false;
+    }
   }
 }
 

--- a/frontend/src/components/ServerStatusSection.vue
+++ b/frontend/src/components/ServerStatusSection.vue
@@ -1,0 +1,257 @@
+<template>
+  <el-card
+    class="server-status-panel"
+    shadow="never"
+    data-testid="server-status-section"
+  >
+    <template #header>
+      <span class="server-status-title">{{
+        t("dashboard.serverStatus.title")
+      }}</span>
+    </template>
+
+    <div v-if="fetchState === 'unavailable'" class="server-status-message">
+      {{ t("dashboard.serverStatus.fetchUnavailable") }}
+    </div>
+
+    <template v-else>
+      <div
+        class="server-status-summary"
+        :class="summaryColorClass"
+        data-testid="server-status-summary"
+      >
+        <span class="server-status-dot" aria-hidden="true" />
+        <span>{{ summaryLabel }}</span>
+      </div>
+
+      <p
+        v-if="fetchState === 'partial'"
+        class="server-status-message"
+        data-testid="server-status-detail-unavailable"
+      >
+        {{ t("dashboard.serverStatus.detailUnavailable") }}
+      </p>
+
+      <ul
+        v-else-if="showDetail"
+        class="server-status-detail"
+        data-testid="server-status-detail"
+      >
+        <li
+          v-for="(row, idx) in componentRows"
+          :key="`component-${idx}`"
+          class="server-status-detail-row"
+          :class="row.colorClass"
+        >
+          <span class="server-status-dot" aria-hidden="true" />
+          <span class="server-status-detail-name">{{ row.name }}</span>
+          <span class="server-status-detail-status">{{ row.statusLabel }}</span>
+        </li>
+        <li
+          v-for="(headline, idx) in headlineRows"
+          :key="`headline-${idx}`"
+          class="server-status-detail-row server-status-detail-headline"
+        >
+          {{ headline }}
+        </li>
+      </ul>
+
+      <a
+        class="server-status-link"
+        :href="statusPageUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="server-status-external-link"
+      >
+        {{ t("dashboard.serverStatus.linkToStatusPage") }}
+      </a>
+    </template>
+  </el-card>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { App, type ServerStatusDTO } from "../wails/app";
+import {
+  SERVER_STATUS_PAGE_URL,
+  SERVER_STATUS_POLL_MS,
+  serverStatusComponentColorClass,
+  serverStatusComponentI18nKey,
+  serverStatusSummaryColorClass,
+  serverStatusSummaryI18nKey,
+} from "../utils/serverStatus";
+
+const { t } = useI18n();
+
+const statusPageUrl = SERVER_STATUS_PAGE_URL;
+const fetchState = ref<ServerStatusDTO["fetchState"]>("unavailable");
+const summaryIndicator = ref("");
+const components = ref<ServerStatusDTO["components"]>([]);
+const incidents = ref<ServerStatusDTO["incidents"]>([]);
+const maintenances = ref<ServerStatusDTO["maintenances"]>([]);
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let inFlight = false;
+let generation = 0;
+
+const summaryColorClass = computed(() =>
+  serverStatusSummaryColorClass(summaryIndicator.value),
+);
+
+const summaryLabel = computed(() =>
+  t(serverStatusSummaryI18nKey(summaryIndicator.value)),
+);
+
+const showDetail = computed(
+  () =>
+    fetchState.value === "ok" &&
+    (components.value.length > 0 ||
+      incidents.value.length > 0 ||
+      maintenances.value.length > 0),
+);
+
+const componentRows = computed(() =>
+  components.value.map((c) => ({
+    name: c.name,
+    statusLabel: t(serverStatusComponentI18nKey(c.status)),
+    colorClass: serverStatusComponentColorClass(c.status),
+  })),
+);
+
+const headlineRows = computed(() => [
+  ...incidents.value.map((h) => h.name).filter(Boolean),
+  ...maintenances.value.map((h) => h.name).filter(Boolean),
+]);
+
+function applySnapshot(dto: ServerStatusDTO): void {
+  fetchState.value = dto.fetchState;
+  summaryIndicator.value = dto.summary?.indicator ?? "";
+  components.value = dto.components ?? [];
+  incidents.value = dto.incidents ?? [];
+  maintenances.value = dto.maintenances ?? [];
+}
+
+async function refresh(): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  const gen = generation;
+  try {
+    const dto = await App.getServerStatus();
+    if (gen !== generation) return;
+    applySnapshot(dto);
+  } finally {
+    inFlight = false;
+  }
+}
+
+onMounted(() => {
+  void refresh();
+  pollTimer = setInterval(() => {
+    void refresh();
+  }, SERVER_STATUS_POLL_MS);
+});
+
+onUnmounted(() => {
+  generation += 1;
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+});
+</script>
+
+<style scoped>
+.server-status-panel {
+  background: var(--bg-secondary) !important;
+  border-color: var(--border) !important;
+}
+
+.server-status-title {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.server-status-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.server-status-message {
+  margin: 0 0 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.server-status-detail {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.server-status-detail-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
+.server-status-detail-name {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.server-status-detail-status {
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.server-status-detail-headline {
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
+}
+
+.server-status-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: currentColor;
+}
+
+.server-status-link {
+  font-size: 0.85rem;
+  color: var(--el-color-primary);
+}
+
+.server-status--operational {
+  color: #2e9f4a;
+}
+
+.server-status--degraded {
+  color: #d4a017;
+}
+
+.server-status--partial {
+  color: #e8943c;
+}
+
+.server-status--major {
+  color: #d94a4a;
+}
+
+.server-status--maintenance {
+  color: #2b7fd9;
+}
+
+.server-status--unknown {
+  color: var(--text-secondary);
+}
+</style>

--- a/frontend/src/components/__tests__/ServerStatusSection.spec.ts
+++ b/frontend/src/components/__tests__/ServerStatusSection.spec.ts
@@ -1,0 +1,160 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createI18n } from "vue-i18n";
+import ServerStatusSection from "../ServerStatusSection.vue";
+import en from "../../i18n/locales/en.json";
+
+const mockGetServerStatus = vi.fn();
+
+vi.mock("../../wails/app", () => ({
+  App: {
+    getServerStatus: (...args: unknown[]) => mockGetServerStatus(...args),
+  },
+}));
+
+function mountSection() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: "en",
+    messages: { en },
+  });
+  return mount(ServerStatusSection, {
+    global: { plugins: [i18n] },
+  });
+}
+
+describe("ServerStatusSection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetServerStatus.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows server status fetch failure", async () => {
+    mockGetServerStatus.mockResolvedValue({
+      fetchState: "unavailable",
+      summary: { indicator: "", description: "" },
+      components: [],
+      incidents: [],
+      maintenances: [],
+    });
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).toContain("Could not load server status.");
+    expect(wrapper.find('[data-testid="server-status-detail"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("shows partial server status detail failure", async () => {
+    mockGetServerStatus.mockResolvedValue({
+      fetchState: "partial",
+      summary: { indicator: "none", description: "All Systems Operational" },
+      components: [],
+      incidents: [],
+      maintenances: [],
+    });
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).toContain("All systems operational");
+    expect(
+      wrapper.find('[data-testid="server-status-detail-unavailable"]').exists(),
+    ).toBe(true);
+  });
+
+  it("hides server status detail when operational", async () => {
+    mockGetServerStatus.mockResolvedValue({
+      fetchState: "ok",
+      summary: { indicator: "none", description: "All Systems Operational" },
+      components: [],
+      incidents: [],
+      maintenances: [],
+    });
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.find('[data-testid="server-status-detail"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("shows non-operational components only", async () => {
+    mockGetServerStatus.mockResolvedValue({
+      fetchState: "ok",
+      summary: {
+        indicator: "maintenance",
+        description: "Service Under Maintenance",
+      },
+      components: [
+        { name: "Authentication / Login", status: "under_maintenance" },
+      ],
+      incidents: [{ name: "API Degraded" }],
+      maintenances: [{ name: "Database Maintenance" }],
+    });
+    const wrapper = mountSection();
+    await flushPromises();
+    const detail = wrapper.find('[data-testid="server-status-detail"]');
+    expect(detail.exists()).toBe(true);
+    expect(detail.text()).toContain("Authentication / Login");
+    expect(detail.text()).toContain("Under maintenance");
+    expect(detail.text()).toContain("API Degraded");
+    expect(detail.text()).toContain("Database Maintenance");
+  });
+
+  it("does not update server status after unmount", async () => {
+    let resolveFetch!: (value: unknown) => void;
+    mockGetServerStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const wrapper = mountSection();
+    wrapper.unmount();
+    resolveFetch({
+      fetchState: "ok",
+      summary: { indicator: "critical", description: "Major outage" },
+      components: [],
+      incidents: [],
+      maintenances: [],
+    });
+    await flushPromises();
+    expect(mockGetServerStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips overlapping server status poll", async () => {
+    let resolveFirst!: (value: unknown) => void;
+    mockGetServerStatus.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    mockGetServerStatus.mockResolvedValue({
+      fetchState: "ok",
+      summary: { indicator: "none", description: "" },
+      components: [],
+      incidents: [],
+      maintenances: [],
+    });
+
+    mountSection();
+    expect(mockGetServerStatus).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    expect(mockGetServerStatus).toHaveBeenCalledTimes(1);
+
+    resolveFirst({
+      fetchState: "ok",
+      summary: { indicator: "none", description: "" },
+      components: [],
+      incidents: [],
+      maintenances: [],
+    });
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    expect(mockGetServerStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/__tests__/ServerStatusSection.spec.ts
+++ b/frontend/src/components/__tests__/ServerStatusSection.spec.ts
@@ -33,6 +33,15 @@ describe("ServerStatusSection", () => {
     vi.useRealTimers();
   });
 
+  it("shows loading before first fetch completes", () => {
+    mockGetServerStatus.mockReturnValue(new Promise(() => {}));
+    const wrapper = mountSection();
+    expect(wrapper.find('[data-testid="server-status-loading"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.text()).not.toContain("Could not load server status.");
+  });
+
   it("shows server status fetch failure", async () => {
     mockGetServerStatus.mockResolvedValue({
       fetchState: "unavailable",
@@ -101,6 +110,33 @@ describe("ServerStatusSection", () => {
     expect(detail.text()).toContain("Under maintenance");
     expect(detail.text()).toContain("API Degraded");
     expect(detail.text()).toContain("Database Maintenance");
+  });
+
+  it("keeps prior state when Wails IPC fails after initial load", async () => {
+    mockGetServerStatus.mockResolvedValueOnce({
+      fetchState: "ok",
+      summary: { indicator: "none", description: "" },
+      components: [],
+      incidents: [],
+      maintenances: [],
+    });
+    mockGetServerStatus.mockRejectedValueOnce(new Error("ipc failed"));
+
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).toContain("All systems operational");
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await flushPromises();
+    expect(wrapper.text()).toContain("All systems operational");
+    expect(wrapper.text()).not.toContain("Could not load server status.");
+  });
+
+  it("shows unavailable when Wails IPC fails on initial load", async () => {
+    mockGetServerStatus.mockRejectedValue(new Error("ipc failed"));
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).toContain("Could not load server status.");
   });
 
   it("does not update server status after unmount", async () => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -74,7 +74,25 @@
     "instanceRejoinWithWorld": "Join {name}",
     "instanceRejoinGeneric": "Rejoin last instance",
     "instanceRejoinError": "Failed to launch rejoin to instance",
-    "instanceRejoinLoadError": "Failed to load rejoin section"
+    "instanceRejoinLoadError": "Failed to load rejoin section",
+    "serverStatus": {
+      "title": "VRChat server status",
+      "summaryAllOperational": "All systems operational",
+      "summaryDegraded": "Degraded performance",
+      "summaryPartialOutage": "Partial outage",
+      "summaryMajorOutage": "Major outage",
+      "summaryMaintenance": "Service under maintenance",
+      "summaryUnknown": "Status unknown",
+      "fetchUnavailable": "Could not load server status.",
+      "detailUnavailable": "Could not load status details.",
+      "linkToStatusPage": "View status.vrchat.com",
+      "statusOperational": "Operational",
+      "statusDegradedPerformance": "Degraded performance",
+      "statusPartialOutage": "Partial outage",
+      "statusMajorOutage": "Major outage",
+      "statusUnderMaintenance": "Under maintenance",
+      "statusUnknown": "Unknown"
+    }
   },
   "launcher": {
     "title": "Launcher",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -84,6 +84,7 @@
       "summaryMaintenance": "Service under maintenance",
       "summaryUnknown": "Status unknown",
       "fetchUnavailable": "Could not load server status.",
+      "loading": "Loading server status…",
       "detailUnavailable": "Could not load status details.",
       "linkToStatusPage": "View status.vrchat.com",
       "statusOperational": "Operational",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -74,7 +74,25 @@
     "instanceRejoinWithWorld": "{name} に参加",
     "instanceRejoinGeneric": "最後のインスタンスに参加",
     "instanceRejoinError": "インスタンスへの再参加起動に失敗しました",
-    "instanceRejoinLoadError": "再参加セクションの読み込みに失敗しました"
+    "instanceRejoinLoadError": "再参加セクションの読み込みに失敗しました",
+    "serverStatus": {
+      "title": "VRChat サーバーステータス",
+      "summaryAllOperational": "すべてのシステムが正常です",
+      "summaryDegraded": "パフォーマンス低下",
+      "summaryPartialOutage": "一部障害",
+      "summaryMajorOutage": "重大な障害",
+      "summaryMaintenance": "メンテナンス中",
+      "summaryUnknown": "状態不明",
+      "fetchUnavailable": "サーバーステータスを取得できませんでした。",
+      "detailUnavailable": "詳細を取得できませんでした。",
+      "linkToStatusPage": "status.vrchat.com を開く",
+      "statusOperational": "正常",
+      "statusDegradedPerformance": "パフォーマンス低下",
+      "statusPartialOutage": "一部障害",
+      "statusMajorOutage": "重大な障害",
+      "statusUnderMaintenance": "メンテナンス中",
+      "statusUnknown": "不明"
+    }
   },
   "launcher": {
     "title": "ランチャー",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -84,6 +84,7 @@
       "summaryMaintenance": "メンテナンス中",
       "summaryUnknown": "状態不明",
       "fetchUnavailable": "サーバーステータスを取得できませんでした。",
+      "loading": "サーバーステータスを読み込み中…",
       "detailUnavailable": "詳細を取得できませんでした。",
       "linkToStatusPage": "status.vrchat.com を開く",
       "statusOperational": "正常",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -74,7 +74,25 @@
     "instanceRejoinWithWorld": "{name}에 참가",
     "instanceRejoinGeneric": "마지막 인스턴스에 참가",
     "instanceRejoinError": "인스턴스 재참가 실행에 실패했습니다",
-    "instanceRejoinLoadError": "재참가 섹션을 불러오지 못했습니다"
+    "instanceRejoinLoadError": "재참가 섹션을 불러오지 못했습니다",
+    "serverStatus": {
+      "title": "VRChat 서버 상태",
+      "summaryAllOperational": "모든 시스템이 정상입니다",
+      "summaryDegraded": "성능 저하",
+      "summaryPartialOutage": "부분 장애",
+      "summaryMajorOutage": "심각한 장애",
+      "summaryMaintenance": "유지보수 중",
+      "summaryUnknown": "상태 알 수 없음",
+      "fetchUnavailable": "서버 상태를 불러올 수 없습니다.",
+      "detailUnavailable": "상세 정보를 불러올 수 없습니다.",
+      "linkToStatusPage": "status.vrchat.com 열기",
+      "statusOperational": "정상",
+      "statusDegradedPerformance": "성능 저하",
+      "statusPartialOutage": "부분 장애",
+      "statusMajorOutage": "심각한 장애",
+      "statusUnderMaintenance": "유지보수 중",
+      "statusUnknown": "알 수 없음"
+    }
   },
   "launcher": {
     "title": "런처",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -84,6 +84,7 @@
       "summaryMaintenance": "유지보수 중",
       "summaryUnknown": "상태 알 수 없음",
       "fetchUnavailable": "서버 상태를 불러올 수 없습니다.",
+      "loading": "서버 상태 불러오는 중…",
       "detailUnavailable": "상세 정보를 불러올 수 없습니다.",
       "linkToStatusPage": "status.vrchat.com 열기",
       "statusOperational": "정상",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -84,6 +84,7 @@
       "summaryMaintenance": "维护中",
       "summaryUnknown": "状态未知",
       "fetchUnavailable": "无法获取服务器状态。",
+      "loading": "正在加载服务器状态…",
       "detailUnavailable": "无法获取详细信息。",
       "linkToStatusPage": "打开 status.vrchat.com",
       "statusOperational": "正常",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -74,7 +74,25 @@
     "instanceRejoinWithWorld": "加入 {name}",
     "instanceRejoinGeneric": "加入上次实例",
     "instanceRejoinError": "重新加入实例启动失败",
-    "instanceRejoinLoadError": "无法加载重新加入区域"
+    "instanceRejoinLoadError": "无法加载重新加入区域",
+    "serverStatus": {
+      "title": "VRChat 服务器状态",
+      "summaryAllOperational": "所有系统运行正常",
+      "summaryDegraded": "性能下降",
+      "summaryPartialOutage": "部分故障",
+      "summaryMajorOutage": "重大故障",
+      "summaryMaintenance": "维护中",
+      "summaryUnknown": "状态未知",
+      "fetchUnavailable": "无法获取服务器状态。",
+      "detailUnavailable": "无法获取详细信息。",
+      "linkToStatusPage": "打开 status.vrchat.com",
+      "statusOperational": "正常",
+      "statusDegradedPerformance": "性能下降",
+      "statusPartialOutage": "部分故障",
+      "statusMajorOutage": "重大故障",
+      "statusUnderMaintenance": "维护中",
+      "statusUnknown": "未知"
+    }
   },
   "launcher": {
     "title": "启动器",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -84,6 +84,7 @@
       "summaryMaintenance": "維護中",
       "summaryUnknown": "狀態未知",
       "fetchUnavailable": "無法取得伺服器狀態。",
+      "loading": "正在載入伺服器狀態…",
       "detailUnavailable": "無法取得詳細資訊。",
       "linkToStatusPage": "開啟 status.vrchat.com",
       "statusOperational": "正常",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -74,7 +74,25 @@
     "instanceRejoinWithWorld": "加入 {name}",
     "instanceRejoinGeneric": "加入上次實例",
     "instanceRejoinError": "重新加入實例啟動失敗",
-    "instanceRejoinLoadError": "無法載入重新加入區塊"
+    "instanceRejoinLoadError": "無法載入重新加入區塊",
+    "serverStatus": {
+      "title": "VRChat 伺服器狀態",
+      "summaryAllOperational": "所有系統運作正常",
+      "summaryDegraded": "效能下降",
+      "summaryPartialOutage": "部分故障",
+      "summaryMajorOutage": "重大故障",
+      "summaryMaintenance": "維護中",
+      "summaryUnknown": "狀態未知",
+      "fetchUnavailable": "無法取得伺服器狀態。",
+      "detailUnavailable": "無法取得詳細資訊。",
+      "linkToStatusPage": "開啟 status.vrchat.com",
+      "statusOperational": "正常",
+      "statusDegradedPerformance": "效能下降",
+      "statusPartialOutage": "部分故障",
+      "statusMajorOutage": "重大故障",
+      "statusUnderMaintenance": "維護中",
+      "statusUnknown": "未知"
+    }
   },
   "launcher": {
     "title": "啟動器",

--- a/frontend/src/utils/__tests__/serverStatus.spec.ts
+++ b/frontend/src/utils/__tests__/serverStatus.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  serverStatusComponentColorClass,
+  serverStatusComponentI18nKey,
+  serverStatusSummaryColorClass,
+  serverStatusSummaryI18nKey,
+} from "../serverStatus";
+
+describe("serverStatus utils", () => {
+  it("maps summary indicator to i18n keys", () => {
+    expect(serverStatusSummaryI18nKey("none")).toBe(
+      "dashboard.serverStatus.summaryAllOperational",
+    );
+    expect(serverStatusSummaryI18nKey("maintenance")).toBe(
+      "dashboard.serverStatus.summaryMaintenance",
+    );
+  });
+
+  it("maps component status to i18n keys", () => {
+    expect(serverStatusComponentI18nKey("under_maintenance")).toBe(
+      "dashboard.serverStatus.statusUnderMaintenance",
+    );
+  });
+
+  it("maps colors for indicator and component status", () => {
+    expect(serverStatusSummaryColorClass("none")).toBe(
+      "server-status--operational",
+    );
+    expect(serverStatusComponentColorClass("major_outage")).toBe(
+      "server-status--major",
+    );
+  });
+});

--- a/frontend/src/utils/serverStatus.ts
+++ b/frontend/src/utils/serverStatus.ts
@@ -1,0 +1,81 @@
+/** status.vrchat.com summary indicator → i18n key under dashboard.serverStatus */
+export function serverStatusSummaryI18nKey(
+  indicator: string | undefined | null,
+): string {
+  switch ((indicator ?? "").trim().toLowerCase()) {
+    case "none":
+      return "dashboard.serverStatus.summaryAllOperational";
+    case "minor":
+      return "dashboard.serverStatus.summaryDegraded";
+    case "major":
+      return "dashboard.serverStatus.summaryPartialOutage";
+    case "critical":
+      return "dashboard.serverStatus.summaryMajorOutage";
+    case "maintenance":
+      return "dashboard.serverStatus.summaryMaintenance";
+    default:
+      return "dashboard.serverStatus.summaryUnknown";
+  }
+}
+
+/** statuspage component status → i18n key */
+export function serverStatusComponentI18nKey(
+  status: string | undefined | null,
+): string {
+  switch ((status ?? "").trim().toLowerCase()) {
+    case "operational":
+      return "dashboard.serverStatus.statusOperational";
+    case "degraded_performance":
+      return "dashboard.serverStatus.statusDegradedPerformance";
+    case "partial_outage":
+      return "dashboard.serverStatus.statusPartialOutage";
+    case "major_outage":
+      return "dashboard.serverStatus.statusMajorOutage";
+    case "under_maintenance":
+      return "dashboard.serverStatus.statusUnderMaintenance";
+    default:
+      return "dashboard.serverStatus.statusUnknown";
+  }
+}
+
+export function serverStatusSummaryColorClass(
+  indicator: string | undefined | null,
+): string {
+  switch ((indicator ?? "").trim().toLowerCase()) {
+    case "none":
+      return "server-status--operational";
+    case "minor":
+      return "server-status--degraded";
+    case "major":
+      return "server-status--partial";
+    case "critical":
+      return "server-status--major";
+    case "maintenance":
+      return "server-status--maintenance";
+    default:
+      return "server-status--unknown";
+  }
+}
+
+export function serverStatusComponentColorClass(
+  status: string | undefined | null,
+): string {
+  switch ((status ?? "").trim().toLowerCase()) {
+    case "operational":
+      return "server-status--operational";
+    case "degraded_performance":
+      return "server-status--degraded";
+    case "partial_outage":
+      return "server-status--partial";
+    case "major_outage":
+      return "server-status--major";
+    case "under_maintenance":
+      return "server-status--maintenance";
+    default:
+      return "server-status--unknown";
+  }
+}
+
+export const SERVER_STATUS_POLL_MS = 5 * 60 * 1000;
+
+export const SERVER_STATUS_PAGE_URL = "https://status.vrchat.com/";

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -2,6 +2,7 @@
   <div class="dashboard">
     <h1 class="page-title">{{ t("routes.dashboard") }}</h1>
     <div class="quick-actions">
+      <ServerStatusSection />
       <el-button
         type="primary"
         size="large"
@@ -112,6 +113,7 @@
 import { ref, onMounted, onUnmounted, computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { ElMessage } from "element-plus";
+import ServerStatusSection from "../components/ServerStatusSection.vue";
 import {
   App,
   type InstanceRejoinSectionDTO,

--- a/frontend/src/wails/app.ts
+++ b/frontend/src/wails/app.ts
@@ -15,6 +15,10 @@ type WailsDTO<T> = Omit<T, "convertValues">;
 
 export type LaunchProfileDTO = WailsDTO<main.LaunchProfileDTO>;
 export type InstanceRejoinSectionDTO = WailsDTO<main.InstanceRejoinSectionDTO>;
+export type ServerStatusDTO = WailsDTO<main.ServerStatusDTO>;
+export type ServerStatusSummaryDTO = WailsDTO<main.ServerStatusSummaryDTO>;
+export type ServerStatusComponentDTO = WailsDTO<main.ServerStatusComponentDTO>;
+export type ServerStatusHeadlineDTO = WailsDTO<main.ServerStatusHeadlineDTO>;
 export type LaunchArgsParsedDTO = WailsDTO<launcher.LaunchArgsParsed>;
 export type ScreenshotDTO = WailsDTO<main.ScreenshotDTO>;
 export type ScreenshotSearchDTO = WailsDTO<main.ScreenshotSearchDTO>;
@@ -30,6 +34,16 @@ export type TopWorldDTO = WailsDTO<activity.TopWorldSummary>;
 export type ActivityStatsDTO = WailsDTO<activity.ActivityStats>;
 export type AutomationRuleDTO = WailsDTO<automation.AutomationRule>;
 export type VRChatConfigDTO = WailsDTO<main.VRChatConfigDTO>;
+
+function emptyServerStatus(): ServerStatusDTO {
+  return {
+    fetchState: "unavailable",
+    summary: { indicator: "", description: "" },
+    components: [],
+    incidents: [],
+    maintenances: [],
+  };
+}
 
 function emptyYTDLPMaintainStatus(): YTDLPMaintainStatusDTO {
   return {
@@ -235,6 +249,9 @@ export const App = {
   },
   async getInstanceRejoinSection(): Promise<InstanceRejoinSectionDTO | null> {
     return callApp((a) => a.GetInstanceRejoinSection(), null);
+  },
+  async getServerStatus(): Promise<ServerStatusDTO> {
+    return callApp((a) => a.GetServerStatus(), emptyServerStatus());
   },
   async instanceRejoin(
     profileID: string,

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/wailsapp/wails/v2 v2.13.0
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/image v0.44.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.53.0
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/wailsapp/wails/v2 v2.13.0
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/image v0.44.0
-	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.53.0
 )

--- a/internal/infrastructure/statuspage/client.go
+++ b/internal/infrastructure/statuspage/client.go
@@ -1,0 +1,139 @@
+package statuspage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"vrchat-tweaker/internal/infrastructure/vrchatapi"
+)
+
+const (
+	DefaultBaseURL           = "https://status.vrchat.com/api/v2/"
+	serverStatusHTTPTimeout  = 15 * time.Second
+	serverStatusMaxBodyBytes = 1 << 20
+	serverStatusAllowedHost  = "status.vrchat.com"
+)
+
+// Client fetches VRChat statuspage API responses.
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+	UserAgent  string
+	// InsecureSkipHostCheck disables status.vrchat.com host checks (tests only).
+	InsecureSkipHostCheck bool
+}
+
+// NewClient returns a client with production defaults.
+func NewClient() *Client {
+	return &Client{
+		BaseURL:   DefaultBaseURL,
+		UserAgent: vrchatapi.UserAgent,
+	}
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{
+		Timeout:       serverStatusHTTPTimeout,
+		CheckRedirect: c.redirectPolicy,
+	}
+}
+
+func (c *Client) redirectPolicy(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("too many redirects")
+	}
+	if c != nil && c.InsecureSkipHostCheck {
+		return nil
+	}
+	return validateHost(req.URL)
+}
+
+func validateHost(u *url.URL) error {
+	if u == nil {
+		return errors.New("url is nil")
+	}
+	if strings.ToLower(u.Scheme) != "https" {
+		return fmt.Errorf("url must use https: %s", u.String())
+	}
+	host := strings.ToLower(u.Hostname())
+	if host != serverStatusAllowedHost {
+		return fmt.Errorf("host not allowed: %s", host)
+	}
+	return nil
+}
+
+func (c *Client) validateRequestHost(u *url.URL) error {
+	if c != nil && c.InsecureSkipHostCheck {
+		return nil
+	}
+	return validateHost(u)
+}
+
+func (c *Client) fetchJSON(ctx context.Context, path string, dest any) error {
+	base := strings.TrimSpace(c.BaseURL)
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	rawURL, err := url.Parse(base)
+	if err != nil {
+		return fmt.Errorf("parse base url: %w", err)
+	}
+	ref, err := url.Parse(path)
+	if err != nil {
+		return fmt.Errorf("parse path: %w", err)
+	}
+	full := rawURL.ResolveReference(ref)
+	if err := c.validateRequestHost(full); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full.String(), nil)
+	if err != nil {
+		return err
+	}
+	ua := strings.TrimSpace(c.UserAgent)
+	if ua == "" {
+		ua = vrchatapi.UserAgent
+	}
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, serverStatusMaxBodyBytes+1))
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	if len(body) > serverStatusMaxBodyBytes {
+		return fmt.Errorf("response body exceeds %d bytes", serverStatusMaxBodyBytes)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("statuspage api: %s: %s", resp.Status, truncateForErr(string(body), 200))
+	}
+	if err := json.Unmarshal(body, dest); err != nil {
+		return fmt.Errorf("parse json: %w", err)
+	}
+	return nil
+}
+
+func truncateForErr(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/internal/infrastructure/statuspage/client.go
+++ b/internal/infrastructure/statuspage/client.go
@@ -52,6 +52,9 @@ func NewTestClient(baseURL string) *Client {
 
 func (c *Client) httpClient() *http.Client {
 	if c.HTTPClient != nil {
+		if c.HTTPClient.CheckRedirect == nil {
+			c.HTTPClient.CheckRedirect = c.redirectPolicy
+		}
 		return c.HTTPClient
 	}
 	c.once.Do(func() {
@@ -151,8 +154,12 @@ func (c *Client) fetchJSON(ctx context.Context, path string, dest any) error {
 
 func truncateForErr(s string, max int) string {
 	s = strings.TrimSpace(s)
-	if max <= 0 || len(s) <= max {
+	if max <= 0 {
 		return s
 	}
-	return s[:max] + "…"
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "…"
 }

--- a/internal/infrastructure/statuspage/client.go
+++ b/internal/infrastructure/statuspage/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"vrchat-tweaker/internal/infrastructure/vrchatapi"
@@ -26,8 +27,11 @@ type Client struct {
 	BaseURL    string
 	HTTPClient *http.Client
 	UserAgent  string
-	// InsecureSkipHostCheck disables status.vrchat.com host checks (tests only).
-	InsecureSkipHostCheck bool
+
+	once          sync.Once
+	defaultClient *http.Client
+	// insecureSkipHostCheck disables status.vrchat.com host checks (tests only).
+	insecureSkipHostCheck bool
 }
 
 // NewClient returns a client with production defaults.
@@ -38,21 +42,32 @@ func NewClient() *Client {
 	}
 }
 
+// NewTestClient returns a client for httptest servers (skips production host checks).
+func NewTestClient(baseURL string) *Client {
+	return &Client{
+		BaseURL:               baseURL,
+		insecureSkipHostCheck: true,
+	}
+}
+
 func (c *Client) httpClient() *http.Client {
 	if c.HTTPClient != nil {
 		return c.HTTPClient
 	}
-	return &http.Client{
-		Timeout:       serverStatusHTTPTimeout,
-		CheckRedirect: c.redirectPolicy,
-	}
+	c.once.Do(func() {
+		c.defaultClient = &http.Client{
+			Timeout:       serverStatusHTTPTimeout,
+			CheckRedirect: c.redirectPolicy,
+		}
+	})
+	return c.defaultClient
 }
 
 func (c *Client) redirectPolicy(req *http.Request, via []*http.Request) error {
 	if len(via) >= 10 {
 		return errors.New("too many redirects")
 	}
-	if c != nil && c.InsecureSkipHostCheck {
+	if c != nil && c.insecureSkipHostCheck {
 		return nil
 	}
 	return validateHost(req.URL)
@@ -73,13 +88,17 @@ func validateHost(u *url.URL) error {
 }
 
 func (c *Client) validateRequestHost(u *url.URL) error {
-	if c != nil && c.InsecureSkipHostCheck {
+	if c != nil && c.insecureSkipHostCheck {
 		return nil
 	}
 	return validateHost(u)
 }
 
 func (c *Client) fetchJSON(ctx context.Context, path string, dest any) error {
+	if strings.HasPrefix(path, "/") {
+		return fmt.Errorf("path must be relative: %q", path)
+	}
+
 	base := strings.TrimSpace(c.BaseURL)
 	if base == "" {
 		base = DefaultBaseURL

--- a/internal/infrastructure/statuspage/client.go
+++ b/internal/infrastructure/statuspage/client.go
@@ -93,8 +93,8 @@ func (c *Client) fetchJSON(ctx context.Context, path string, dest any) error {
 		return fmt.Errorf("parse path: %w", err)
 	}
 	full := rawURL.ResolveReference(ref)
-	if err := c.validateRequestHost(full); err != nil {
-		return err
+	if hostErr := c.validateRequestHost(full); hostErr != nil {
+		return hostErr
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full.String(), nil)

--- a/internal/infrastructure/statuspage/fetch.go
+++ b/internal/infrastructure/statuspage/fetch.go
@@ -2,8 +2,7 @@ package statuspage
 
 import (
 	"context"
-
-	"golang.org/x/sync/errgroup"
+	"sync"
 )
 
 // Fetch loads status.vrchat.com data for Dashboard Server status.
@@ -27,28 +26,34 @@ func (c *Client) Fetch(ctx context.Context) Snapshot {
 		maintenancesErr  error
 	)
 
-	g, gctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		componentsErr = c.fetchJSON(gctx, "components.json", &componentsResp)
-		return nil
-	})
-	g.Go(func() error {
-		incidentsErr = c.fetchJSON(gctx, "incidents/unresolved.json", &incidentsResp)
-		return nil
-	})
-	g.Go(func() error {
-		maintenancesErr = c.fetchJSON(gctx, "scheduled-maintenances/active.json", &maintenancesResp)
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		componentsErr = c.fetchJSON(ctx, "components.json", &componentsResp)
+	}()
+	go func() {
+		defer wg.Done()
+		incidentsErr = c.fetchJSON(ctx, "incidents/unresolved.json", &incidentsResp)
+	}()
+	go func() {
+		defer wg.Done()
+		maintenancesErr = c.fetchJSON(ctx, "scheduled-maintenances/active.json", &maintenancesResp)
 		if maintenancesErr == nil && len(maintenancesResp.ScheduledMaintenances) == 0 {
-			maintenancesErr = c.fetchJSON(gctx, "scheduled-maintenances/upcoming.json", &maintenancesResp)
+			maintenancesErr = c.fetchJSON(ctx, "scheduled-maintenances/upcoming.json", &maintenancesResp)
 		}
-		return nil
-	})
-	_ = g.Wait()
+	}()
+	wg.Wait()
+
+	incidents := headlinesFromIncidents(incidentsResp.Incidents)
+	maintenances := headlinesFromMaintenances(maintenancesResp.ScheduledMaintenances)
 
 	if componentsErr != nil {
 		return Snapshot{
-			FetchState: FetchStatePartial,
-			Summary:    summary,
+			FetchState:   FetchStatePartial,
+			Summary:      summary,
+			Incidents:    incidents,
+			Maintenances: maintenances,
 		}
 	}
 
@@ -57,13 +62,13 @@ func (c *Client) Fetch(ctx context.Context) Snapshot {
 
 	if len(nonOperational) > 0 && (incidentsErr != nil || maintenancesErr != nil) {
 		return Snapshot{
-			FetchState: FetchStatePartial,
-			Summary:    summary,
+			FetchState:   FetchStatePartial,
+			Summary:      summary,
+			Components:   nonOperational,
+			Incidents:    incidents,
+			Maintenances: maintenances,
 		}
 	}
-
-	incidents := headlinesFromIncidents(incidentsResp.Incidents)
-	maintenances := headlinesFromMaintenances(maintenancesResp.ScheduledMaintenances)
 
 	return Snapshot{
 		FetchState:   FetchStateOK,
@@ -96,20 +101,23 @@ func filterNonOperational(leaves []apiComponent) []Component {
 }
 
 func headlinesFromIncidents(list []apiIncident) []Headline {
-	if len(list) == 0 {
-		return nil
+	out := make([]Headline, 0, len(list))
+	for _, inc := range list {
+		if inc.Name == "" {
+			continue
+		}
+		out = append(out, Headline(inc))
 	}
-	return []Headline{{Name: list[0].Name}}
+	return out
 }
 
 func headlinesFromMaintenances(list []apiMaintenance) []Headline {
 	out := make([]Headline, 0, len(list))
 	for _, m := range list {
-		name := m.Name
-		if name == "" {
+		if m.Name == "" {
 			continue
 		}
-		out = append(out, Headline{Name: name})
+		out = append(out, Headline(m))
 	}
 	return out
 }

--- a/internal/infrastructure/statuspage/fetch.go
+++ b/internal/infrastructure/statuspage/fetch.go
@@ -1,0 +1,115 @@
+package statuspage
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Fetch loads status.vrchat.com data for Dashboard Server status.
+func (c *Client) Fetch(ctx context.Context) Snapshot {
+	var summaryResp summaryResponse
+	if err := c.fetchJSON(ctx, "summary.json", &summaryResp); err != nil {
+		return Snapshot{FetchState: FetchStateUnavailable}
+	}
+
+	summary := Summary{
+		Indicator:   summaryResp.Status.Indicator,
+		Description: summaryResp.Status.Description,
+	}
+
+	var (
+		componentsResp   componentsResponse
+		incidentsResp    incidentsResponse
+		maintenancesResp maintenancesResponse
+		componentsErr    error
+		incidentsErr     error
+		maintenancesErr  error
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		componentsErr = c.fetchJSON(gctx, "components.json", &componentsResp)
+		return nil
+	})
+	g.Go(func() error {
+		incidentsErr = c.fetchJSON(gctx, "incidents/unresolved.json", &incidentsResp)
+		return nil
+	})
+	g.Go(func() error {
+		maintenancesErr = c.fetchJSON(gctx, "scheduled-maintenances/active.json", &maintenancesResp)
+		if maintenancesErr == nil && len(maintenancesResp.ScheduledMaintenances) == 0 {
+			maintenancesErr = c.fetchJSON(gctx, "scheduled-maintenances/upcoming.json", &maintenancesResp)
+		}
+		return nil
+	})
+	_ = g.Wait()
+
+	if componentsErr != nil {
+		return Snapshot{
+			FetchState: FetchStatePartial,
+			Summary:    summary,
+		}
+	}
+
+	leaves := leafComponents(componentsResp.Components)
+	nonOperational := filterNonOperational(leaves)
+
+	if len(nonOperational) > 0 && (incidentsErr != nil || maintenancesErr != nil) {
+		return Snapshot{
+			FetchState: FetchStatePartial,
+			Summary:    summary,
+		}
+	}
+
+	incidents := headlinesFromIncidents(incidentsResp.Incidents)
+	maintenances := headlinesFromMaintenances(maintenancesResp.ScheduledMaintenances)
+
+	return Snapshot{
+		FetchState:   FetchStateOK,
+		Summary:      summary,
+		Components:   nonOperational,
+		Incidents:    incidents,
+		Maintenances: maintenances,
+	}
+}
+
+func leafComponents(list []apiComponent) []apiComponent {
+	out := make([]apiComponent, 0, len(list))
+	for _, c := range list {
+		if !c.Group {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func filterNonOperational(leaves []apiComponent) []Component {
+	out := make([]Component, 0)
+	for _, c := range leaves {
+		if c.Status == componentStatusOperational {
+			continue
+		}
+		out = append(out, Component{Name: c.Name, Status: c.Status})
+	}
+	return out
+}
+
+func headlinesFromIncidents(list []apiIncident) []Headline {
+	if len(list) == 0 {
+		return nil
+	}
+	return []Headline{{Name: list[0].Name}}
+}
+
+func headlinesFromMaintenances(list []apiMaintenance) []Headline {
+	out := make([]Headline, 0, len(list))
+	for _, m := range list {
+		name := m.Name
+		if name == "" {
+			continue
+		}
+		out = append(out, Headline{Name: name})
+	}
+	return out
+}

--- a/internal/infrastructure/statuspage/fetch.go
+++ b/internal/infrastructure/statuspage/fetch.go
@@ -39,8 +39,12 @@ func (c *Client) Fetch(ctx context.Context) Snapshot {
 	go func() {
 		defer wg.Done()
 		maintenancesErr = c.fetchJSON(ctx, "scheduled-maintenances/active.json", &maintenancesResp)
-		if maintenancesErr == nil && len(maintenancesResp.ScheduledMaintenances) == 0 {
-			maintenancesErr = c.fetchJSON(ctx, "scheduled-maintenances/upcoming.json", &maintenancesResp)
+		if maintenancesErr != nil || len(maintenancesResp.ScheduledMaintenances) == 0 {
+			var upcoming maintenancesResponse
+			if err := c.fetchJSON(ctx, "scheduled-maintenances/upcoming.json", &upcoming); err == nil {
+				maintenancesResp = upcoming
+				maintenancesErr = nil
+			}
 		}
 	}()
 	wg.Wait()

--- a/internal/infrastructure/statuspage/fetch_test.go
+++ b/internal/infrastructure/statuspage/fetch_test.go
@@ -1,0 +1,186 @@
+package statuspage
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func testServer(t *testing.T, handlers map[string]http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	for path, h := range handlers {
+		mux.HandleFunc(path, h)
+	}
+	return httptest.NewServer(mux)
+}
+
+func clientForServer(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	return &Client{
+		BaseURL:               srv.URL + "/api/v2/",
+		InsecureSkipHostCheck: true,
+	}
+}
+
+const summaryOperational = `{"status":{"indicator":"none","description":"All Systems Operational"}}`
+const summaryMaintenance = `{"status":{"indicator":"maintenance","description":"Service Under Maintenance"}}`
+
+const componentsAllOperational = `{"components":[
+{"name":"API / Website","status":"operational","group":true},
+{"name":"Authentication / Login","status":"operational","group":false},
+{"name":"Realtime Networking","status":"operational","group":true},
+{"name":"Japan (Tokyo)","status":"operational","group":false}
+]}`
+
+const componentsOneMaintenance = `{"components":[
+{"name":"Authentication / Login","status":"under_maintenance","group":false},
+{"name":"Japan (Tokyo)","status":"operational","group":false}
+]}`
+
+const emptyIncidents = `{"incidents":[]}`
+const emptyMaintenances = `{"scheduled_maintenances":[]}`
+const oneIncident = `{"incidents":[{"name":"API Degraded"}]}`
+const oneMaintenance = `{"scheduled_maintenances":[{"name":"Database Maintenance"}]}`
+
+func jsonHandler(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func statusHandler(status int, body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func TestFetch_allOperational(t *testing.T) {
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json":                         jsonHandler(summaryOperational),
+		"/api/v2/components.json":                      jsonHandler(componentsAllOperational),
+		"/api/v2/incidents/unresolved.json":            jsonHandler(emptyIncidents),
+		"/api/v2/scheduled-maintenances/active.json":   jsonHandler(emptyMaintenances),
+		"/api/v2/scheduled-maintenances/upcoming.json": jsonHandler(emptyMaintenances),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStateOK {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStateOK)
+	}
+	if len(got.Components) != 0 {
+		t.Fatalf("components: got %d want 0", len(got.Components))
+	}
+}
+
+func TestFetch_abnormalOneComponent(t *testing.T) {
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json":                       jsonHandler(summaryMaintenance),
+		"/api/v2/components.json":                    jsonHandler(componentsOneMaintenance),
+		"/api/v2/incidents/unresolved.json":          jsonHandler(oneIncident),
+		"/api/v2/scheduled-maintenances/active.json": jsonHandler(oneMaintenance),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStateOK {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStateOK)
+	}
+	if len(got.Components) != 1 {
+		t.Fatalf("components: got %d want 1", len(got.Components))
+	}
+	if got.Components[0].Name != "Authentication / Login" {
+		t.Fatalf("component name: got %q", got.Components[0].Name)
+	}
+	if got.Incidents[0].Name != "API Degraded" {
+		t.Fatalf("incident: got %q", got.Incidents[0].Name)
+	}
+}
+
+func TestFetch_summaryFailure(t *testing.T) {
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json": statusHandler(http.StatusServiceUnavailable, "down"),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStateUnavailable {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStateUnavailable)
+	}
+}
+
+func TestFetch_partialComponentsFailure(t *testing.T) {
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json":    jsonHandler(summaryOperational),
+		"/api/v2/components.json": statusHandler(http.StatusInternalServerError, "fail"),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStatePartial {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStatePartial)
+	}
+	if got.Summary.Indicator != "none" {
+		t.Fatalf("summary indicator: got %q", got.Summary.Indicator)
+	}
+}
+
+func TestFetch_invalidJSON(t *testing.T) {
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json": jsonHandler("{not-json"),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStateUnavailable {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStateUnavailable)
+	}
+}
+
+func TestFetch_bodyTooLarge(t *testing.T) {
+	huge := `{"status":{"indicator":"none","description":"` + strings.Repeat("x", serverStatusMaxBodyBytes) + `"}}`
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json": jsonHandler(huge),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStateUnavailable {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStateUnavailable)
+	}
+}
+
+func TestValidateHost_rejectsForeignHost(t *testing.T) {
+	u, err := url.Parse("https://evil.example/api/v2/summary.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateHost(u); err == nil || !strings.Contains(err.Error(), "host not allowed") {
+		t.Fatalf("expected host not allowed, got %v", err)
+	}
+}
+
+func TestFetch_non200(t *testing.T) {
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json": statusHandler(http.StatusServiceUnavailable, "unavailable"),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStateUnavailable {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStateUnavailable)
+	}
+}
+
+func TestValidateHost_rejectsHTTP(t *testing.T) {
+	u, _ := http.NewRequest(http.MethodGet, "http://status.vrchat.com/api/v2/summary.json", nil)
+	if err := validateHost(u.URL); err == nil {
+		t.Fatal("expected https error")
+	}
+}

--- a/internal/infrastructure/statuspage/fetch_test.go
+++ b/internal/infrastructure/statuspage/fetch_test.go
@@ -20,10 +20,7 @@ func testServer(t *testing.T, handlers map[string]http.HandlerFunc) *httptest.Se
 
 func clientForServer(t *testing.T, srv *httptest.Server) *Client {
 	t.Helper()
-	return &Client{
-		BaseURL:               srv.URL + "/api/v2/",
-		InsecureSkipHostCheck: true,
-	}
+	return NewTestClient(srv.URL + "/api/v2/")
 }
 
 const summaryOperational = `{"status":{"indicator":"none","description":"All Systems Operational"}}`
@@ -117,8 +114,10 @@ func TestFetch_summaryFailure(t *testing.T) {
 
 func TestFetch_partialComponentsFailure(t *testing.T) {
 	srv := testServer(t, map[string]http.HandlerFunc{
-		"/api/v2/summary.json":    jsonHandler(summaryOperational),
-		"/api/v2/components.json": statusHandler(http.StatusInternalServerError, "fail"),
+		"/api/v2/summary.json":                       jsonHandler(summaryOperational),
+		"/api/v2/components.json":                    statusHandler(http.StatusInternalServerError, "fail"),
+		"/api/v2/incidents/unresolved.json":          jsonHandler(oneIncident),
+		"/api/v2/scheduled-maintenances/active.json": jsonHandler(oneMaintenance),
 	})
 	defer srv.Close()
 
@@ -128,6 +127,12 @@ func TestFetch_partialComponentsFailure(t *testing.T) {
 	}
 	if got.Summary.Indicator != "none" {
 		t.Fatalf("summary indicator: got %q", got.Summary.Indicator)
+	}
+	if len(got.Incidents) != 1 || got.Incidents[0].Name != "API Degraded" {
+		t.Fatalf("incidents: %+v", got.Incidents)
+	}
+	if len(got.Maintenances) != 1 {
+		t.Fatalf("maintenances: %+v", got.Maintenances)
 	}
 }
 
@@ -182,5 +187,24 @@ func TestValidateHost_rejectsHTTP(t *testing.T) {
 	u, _ := http.NewRequest(http.MethodGet, "http://status.vrchat.com/api/v2/summary.json", nil)
 	if err := validateHost(u.URL); err == nil {
 		t.Fatal("expected https error")
+	}
+}
+
+func TestFetchJSON_rejectsAbsolutePath(t *testing.T) {
+	c := NewClient()
+	err := c.fetchJSON(context.Background(), "/summary.json", &summaryResponse{})
+	if err == nil || !strings.Contains(err.Error(), "path must be relative") {
+		t.Fatalf("expected relative path error, got %v", err)
+	}
+}
+
+func TestHeadlinesFromIncidents_returnsAllNonEmpty(t *testing.T) {
+	got := headlinesFromIncidents([]apiIncident{
+		{Name: "First"},
+		{Name: ""},
+		{Name: "Second"},
+	})
+	if len(got) != 2 || got[0].Name != "First" || got[1].Name != "Second" {
+		t.Fatalf("got %+v", got)
 	}
 }

--- a/internal/infrastructure/statuspage/fetch_test.go
+++ b/internal/infrastructure/statuspage/fetch_test.go
@@ -190,6 +190,32 @@ func TestValidateHost_rejectsHTTP(t *testing.T) {
 	}
 }
 
+func TestFetch_maintenancesFallbackWhenActiveFails(t *testing.T) {
+	srv := testServer(t, map[string]http.HandlerFunc{
+		"/api/v2/summary.json":                         jsonHandler(summaryOperational),
+		"/api/v2/components.json":                      jsonHandler(componentsAllOperational),
+		"/api/v2/incidents/unresolved.json":            jsonHandler(emptyIncidents),
+		"/api/v2/scheduled-maintenances/active.json":   statusHandler(http.StatusInternalServerError, "fail"),
+		"/api/v2/scheduled-maintenances/upcoming.json": jsonHandler(oneMaintenance),
+	})
+	defer srv.Close()
+
+	got := clientForServer(t, srv).Fetch(context.Background())
+	if got.FetchState != FetchStateOK {
+		t.Fatalf("FetchState: got %q want %q", got.FetchState, FetchStateOK)
+	}
+	if len(got.Maintenances) != 1 || got.Maintenances[0].Name != "Database Maintenance" {
+		t.Fatalf("maintenances: %+v", got.Maintenances)
+	}
+}
+
+func TestTruncateForErr_respectsRuneBoundary(t *testing.T) {
+	got := truncateForErr("日本語テスト", 3)
+	if got != "日本語…" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestFetchJSON_rejectsAbsolutePath(t *testing.T) {
 	c := NewClient()
 	err := c.fetchJSON(context.Background(), "/summary.json", &summaryResponse{})

--- a/internal/infrastructure/statuspage/models.go
+++ b/internal/infrastructure/statuspage/models.go
@@ -13,7 +13,7 @@ const componentStatusOperational = "operational"
 type Snapshot struct {
 	FetchState   string
 	Summary      Summary
-	Components   []Component
+	Components   []Component // non-operational leaf components only (see filterNonOperational)
 	Incidents    []Headline
 	Maintenances []Headline
 }

--- a/internal/infrastructure/statuspage/models.go
+++ b/internal/infrastructure/statuspage/models.go
@@ -1,0 +1,69 @@
+package statuspage
+
+// FetchState values returned to the frontend via ServerStatusDTO.
+const (
+	FetchStateOK          = "ok"
+	FetchStateUnavailable = "unavailable"
+	FetchStatePartial     = "partial"
+)
+
+const componentStatusOperational = "operational"
+
+// Snapshot is the aggregated server status for Dashboard display.
+type Snapshot struct {
+	FetchState   string
+	Summary      Summary
+	Components   []Component
+	Incidents    []Headline
+	Maintenances []Headline
+}
+
+// Summary is the overall status indicator from summary.json.
+type Summary struct {
+	Indicator   string
+	Description string
+}
+
+// Component is a non-group statuspage component (leaf).
+type Component struct {
+	Name   string
+	Status string
+}
+
+// Headline is a one-line incident or maintenance title.
+type Headline struct {
+	Name string
+}
+
+type summaryResponse struct {
+	Status struct {
+		Indicator   string `json:"indicator"`
+		Description string `json:"description"`
+	} `json:"status"`
+}
+
+type componentsResponse struct {
+	Components []apiComponent `json:"components"`
+}
+
+type apiComponent struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Group  bool   `json:"group"`
+}
+
+type incidentsResponse struct {
+	Incidents []apiIncident `json:"incidents"`
+}
+
+type apiIncident struct {
+	Name string `json:"name"`
+}
+
+type maintenancesResponse struct {
+	ScheduledMaintenances []apiMaintenance `json:"scheduled_maintenances"`
+}
+
+type apiMaintenance struct {
+	Name string `json:"name"`
+}


### PR DESCRIPTION
## Summary

- Add **Server status section** at the top of the Dashboard, above Quick launch, showing [status.vrchat.com](https://status.vrchat.com/) service health
- Fetch via Go (`GetServerStatus`) with 5-minute polling while the Dashboard is mounted; failures use `fetchState` on the DTO (no toast spam)
- When all components are operational, show a compact summary and external link; when abnormal, expand non-operational components plus incident/maintenance headlines
- Document domain terms in `CONTEXT.md` and implementation contract in ADR 0009

## Test plan

- [x] `make fmt` / `make test` / `make lint` / `make test-e2e`
- [ ] Open Dashboard while online — green “all operational” summary and link to status.vrchat.com
- [ ] Simulate fetch failure (offline) — section shows unavailable message, no `ElMessage`
- [ ] During official maintenance/outage — abnormal detail lists affected components (English names) with localized status labels

Closes #10


Made with [Cursor](https://cursor.com)