### PR TITLE
cleanup: import Element Plus icons at use sites (#189)

### DIFF
--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -5,7 +5,6 @@ import { createI18n } from "vue-i18n";
 import ElementPlus from "element-plus";
 import "element-plus/dist/index.css";
 import "element-plus/theme-chalk/dark/css-vars.css";
-import * as ElementPlusIconsVue from "@element-plus/icons-vue";
 import "../src/assets/style.css";
 import en from "../src/i18n/locales/en.json";
 import ja from "../src/i18n/locales/ja.json";
@@ -54,9 +53,6 @@ setup((app) => {
   app.use(router);
   app.use(storybookI18n);
   app.use(ElementPlus);
-  for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
-    app.component(key, component);
-  }
 });
 
 const preview: Preview = {

--- a/frontend/src/components/VrcUserCacheDetail.vue
+++ b/frontend/src/components/VrcUserCacheDetail.vue
@@ -270,6 +270,7 @@
 </template>
 
 <script setup lang="ts">
+import { CopyDocument } from "@element-plus/icons-vue";
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import EncounterHistoryList from "./EncounterHistoryList.vue";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,7 +3,6 @@ import { createRouter, createWebHashHistory } from "vue-router";
 import ElementPlus from "element-plus";
 import "element-plus/dist/index.css";
 import "element-plus/theme-chalk/dark/css-vars.css";
-import * as ElementPlusIconsVue from "@element-plus/icons-vue";
 import App from "./App.vue";
 import "./assets/style.css";
 import type { RouteRecordRaw } from "vue-router";
@@ -107,7 +106,4 @@ const app = createApp(App);
 app.use(router);
 app.use(i18n);
 app.use(ElementPlus);
-for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
-  app.component(key, component);
-}
 app.mount("#app");

--- a/frontend/src/test/setupVitest.ts
+++ b/frontend/src/test/setupVitest.ts
@@ -1,6 +1,5 @@
 import { config } from "@vue/test-utils";
 import ElementPlus from "element-plus";
-import * as ElementPlusIconsVue from "@element-plus/icons-vue";
 import { createI18n } from "vue-i18n";
 import en from "../i18n/locales/en.json";
 import ja from "../i18n/locales/ja.json";
@@ -16,11 +15,8 @@ const testI18n = createI18n({
   globalInjection: true,
 });
 
-// テスト環境で Element Plus・vue-i18n・アイコンをグローバル登録
+// テスト環境で Element Plus・vue-i18n をグローバル登録
 config.global.plugins = [ElementPlus, testI18n];
-config.global.components = Object.fromEntries(
-  Object.entries(ElementPlusIconsVue),
-);
 
 /**
  * jsdom does not implement ResizeObserver; TanStack Virtual and the gallery grid rely on it.

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -113,6 +113,7 @@
 </template>
 
 <script setup lang="ts">
+import { Search } from "@element-plus/icons-vue";
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";

--- a/frontend/src/views/GalleryView.vue
+++ b/frontend/src/views/GalleryView.vue
@@ -228,6 +228,7 @@
 </template>
 
 <script setup lang="ts">
+import { Search } from "@element-plus/icons-vue";
 import { useVirtualizer, type VirtualItem } from "@tanstack/vue-virtual";
 import {
   ref,

--- a/frontend/src/views/friends/FriendsViewToolbar.vue
+++ b/frontend/src/views/friends/FriendsViewToolbar.vue
@@ -49,6 +49,7 @@
 </template>
 
 <script setup lang="ts">
+import { Search } from "@element-plus/icons-vue";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();


### PR DESCRIPTION
### 概要
Element Plus アイコンの全件グローバル登録をやめ、使用箇所で明示 import する。

### 関連 Issue
Closes #189

### 変更内容
- `main.ts` / Vitest setup / Storybook preview の全登録を削除
- Search / CopyDocument を利用コンポーネントで import

### テスト
- ブランチ上で frontend の関連変更のみ（エージェント実装済み）

Made with [Cursor](https://cursor.com)