### PR TITLE
cleanup: use concrete VRChat config repository (#192)

### DIFF
--- a/app.go
+++ b/app.go
@@ -17,7 +17,6 @@ import (
 	"vrchat-tweaker/internal/domain/automation"
 	"vrchat-tweaker/internal/domain/launcher"
 	"vrchat-tweaker/internal/domain/media"
-	"vrchat-tweaker/internal/domain/vrchatconfig"
 	"vrchat-tweaker/internal/infrastructure/desktop"
 	"vrchat-tweaker/internal/infrastructure/diag"
 	"vrchat-tweaker/internal/infrastructure/filesystem"
@@ -45,7 +44,7 @@ type App struct {
 	dbMaintenance    *usecase.DBMaintenanceUseCase
 	ytdlp            *usecase.YTDLPMaintainUseCase
 	serverStatus     *statuspage.Client
-	vrchatConfigRepo vrchatconfig.ConfigRepository
+	vrchatConfigRepo *filesystem.VRChatConfigFileRepository
 
 	galleryScanMu     sync.Mutex
 	galleryScanCancel context.CancelFunc

--- a/internal/domain/vrchatconfig/config.go
+++ b/internal/domain/vrchatconfig/config.go
@@ -37,11 +37,3 @@ type VRChatConfig struct {
 	DynamicBoneMaxAffectedTransformCount int `json:"dynamic_bone_max_affected_transform_count,omitempty"`
 	DynamicBoneMaxColliderCheckCount     int `json:"dynamic_bone_max_collider_check_count,omitempty"`
 }
-
-// ConfigRepository provides CRUD operations for VRChat config.json.
-type ConfigRepository interface {
-	Exists() (bool, error)
-	Read() (*VRChatConfig, error)
-	Write(cfg *VRChatConfig) error
-	Delete() error
-}


### PR DESCRIPTION
### 概要
`ConfigRepository` interface を削除し、App が具象の file repository を直接保持する。

### 関連 Issue
Closes #192

### 変更内容
- domain の ConfigRepository interface 削除
- App のフィールド型を具象に変更

### テスト
- Go 変更のみ（エージェント実装済み）

Made with [Cursor](https://cursor.com)