### PR TITLE
cleanup: remove Wails scaffold Greet (#188)

### DIFF
--- a/app.go
+++ b/app.go
@@ -508,11 +508,6 @@ func getDataDir() (string, error) {
 	return filepath.Join(configDir, "vrchat-tweaker"), nil
 }
 
-// Greet returns a greeting (sample binding).
-func (a *App) Greet(name string) string {
-	return fmt.Sprintf("Hello %s, Welcome to VRChat Tweaker!", name)
-}
-
 // --- Launcher bindings ---
 
 // LaunchProfiles returns all launch profiles.

--- a/frontend/e2e/fixtures/mock-wails.ts
+++ b/frontend/e2e/fixtures/mock-wails.ts
@@ -188,7 +188,6 @@ export function getMockWailsInitScript(options: MockWailsOptions = {}): string {
       window.go = window.go || {};
       window.go.main = window.go.main || {};
       window.go.main.App = {
-        Greet: () => Promise.resolve('Hello, Welcome!'),
         LaunchProfiles: () => Promise.resolve(launchProfiles),
         SaveLaunchProfile: (p) => {
           const idx = launchProfiles.findIndex(function(x) { return x.id === p.id; });

--- a/frontend/src/wails/__tests__/app.spec.ts
+++ b/frontend/src/wails/__tests__/app.spec.ts
@@ -19,8 +19,11 @@ function setWindowGoApp(app: Partial<AppBindings>): void {
   window.go = { main: { App: app as AppBindings } };
 }
 
-function mockWithGreet(): { Greet: Mock<AppBindings["Greet"]> } {
-  return { Greet: vi.fn() };
+function mockWithProbe(): {
+  GetLanguage: Mock<AppBindings["GetLanguage"]>;
+  RuntimeIsWindows: Mock<AppBindings["RuntimeIsWindows"]>;
+} {
+  return { GetLanguage: vi.fn(), RuntimeIsWindows: vi.fn() };
 }
 
 describe("app exports", () => {
@@ -34,7 +37,7 @@ describe("isWailsRuntime", () => {
 
   beforeEach(() => {
     prevGo = window.go;
-    setWindowGoApp(mockWithGreet());
+    setWindowGoApp(mockWithProbe());
   });
 
   afterEach(() => {
@@ -52,12 +55,12 @@ describe("isWailsRuntime", () => {
 });
 
 describe("callApp", () => {
-  let mockBindings: ReturnType<typeof mockWithGreet>;
+  let mockBindings: ReturnType<typeof mockWithProbe>;
   let prevGo: typeof window.go;
 
   beforeEach(() => {
     prevGo = window.go;
-    mockBindings = mockWithGreet();
+    mockBindings = mockWithProbe();
     setWindowGoApp(mockBindings);
   });
 
@@ -72,27 +75,27 @@ describe("callApp", () => {
   });
 
   it("invokes fn with bindings and returns its result", async () => {
-    mockBindings.Greet.mockResolvedValue("from-go");
-    const out = await callApp((a) => a.Greet("Alice"), "fallback");
-    expect(mockBindings.Greet).toHaveBeenCalledWith("Alice");
-    expect(out).toBe("from-go");
+    mockBindings.GetLanguage.mockResolvedValue("ja");
+    const out = await callApp((a) => a.GetLanguage(), "fallback");
+    expect(mockBindings.GetLanguage).toHaveBeenCalled();
+    expect(out).toBe("ja");
   });
 
   it("propagates rejection from the binding", async () => {
-    mockBindings.Greet.mockRejectedValue(new Error("backend failed"));
-    await expect(callApp((a) => a.Greet("Bob"), "fallback")).rejects.toThrow(
+    mockBindings.GetLanguage.mockRejectedValue(new Error("backend failed"));
+    await expect(callApp((a) => a.GetLanguage(), "fallback")).rejects.toThrow(
       "backend failed",
     );
   });
 });
 
 describe("App", () => {
-  let mockBindings: ReturnType<typeof mockWithGreet>;
+  let mockBindings: ReturnType<typeof mockWithProbe>;
   let prevGo: typeof window.go;
 
   beforeEach(() => {
     prevGo = window.go;
-    mockBindings = mockWithGreet();
+    mockBindings = mockWithProbe();
     setWindowGoApp(mockBindings);
   });
 
@@ -100,10 +103,16 @@ describe("App", () => {
     window.go = prevGo;
   });
 
-  it("greet delegates to Greet binding via callApp", async () => {
-    mockBindings.Greet.mockResolvedValue("Hello");
-    await expect(App.greet("Alice")).resolves.toBe("Hello");
-    expect(mockBindings.Greet).toHaveBeenCalledWith("Alice");
+  it("getLanguage delegates to GetLanguage binding via callApp", async () => {
+    mockBindings.GetLanguage.mockResolvedValue("en");
+    await expect(App.getLanguage()).resolves.toBe("en");
+    expect(mockBindings.GetLanguage).toHaveBeenCalled();
+  });
+
+  it("runtimeIsWindows delegates to RuntimeIsWindows binding via callApp", async () => {
+    mockBindings.RuntimeIsWindows.mockResolvedValue(true);
+    await expect(App.runtimeIsWindows()).resolves.toBe(true);
+    expect(mockBindings.RuntimeIsWindows).toHaveBeenCalled();
   });
 });
 
@@ -119,8 +128,12 @@ describe("App fallbacks without bindings", () => {
     window.go = prevGo;
   });
 
-  it("greet returns Hello fallback", async () => {
-    await expect(App.greet("Bob")).resolves.toBe("Hello Bob, Welcome!");
+  it("getLanguage returns empty string fallback", async () => {
+    await expect(App.getLanguage()).resolves.toBe("");
+  });
+
+  it("runtimeIsWindows returns false fallback", async () => {
+    await expect(App.runtimeIsWindows()).resolves.toBe(false);
   });
 
   it("parseLaunchArgsForGUI returns default DTO with PRIORITY_OMIT", async () => {
@@ -184,8 +197,8 @@ describe("callApp DEV binding race recovery", () => {
     injectWailsScript();
     window.go = undefined;
 
-    const mockBindings = mockWithGreet();
-    mockBindings.Greet.mockResolvedValue("from-wait");
+    const mockBindings = mockWithProbe();
+    mockBindings.GetLanguage.mockResolvedValue("from-wait");
 
     let frames = 0;
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
@@ -199,7 +212,7 @@ describe("callApp DEV binding race recovery", () => {
 
     const { callApp: freshCallApp } = await import("../app");
     await expect(
-      freshCallApp((a) => a.Greet("Wait"), "fallback"),
+      freshCallApp((a) => a.GetLanguage(), "fallback"),
     ).resolves.toBe("from-wait");
   });
 

--- a/frontend/src/wails/app.ts
+++ b/frontend/src/wails/app.ts
@@ -238,9 +238,6 @@ export async function callApp<T>(
 }
 
 export const App = {
-  async greet(name: string): Promise<string> {
-    return callApp((a) => a.Greet(name), `Hello ${name}, Welcome!`);
-  },
   async launchProfiles(): Promise<LaunchProfileDTO[]> {
     return callApp((a) => a.LaunchProfiles(), []);
   },


### PR DESCRIPTION
### 概要
Wails 雛形の Greet / App.greet を削除し、callApp テストのプローブを実バインディングに差し替える。

### 関連 Issue
Closes #188

### 変更内容
- Go `App.Greet` 削除
- Frontend `App.greet` / e2e mock 削除
- unit テストを GetLanguage / RuntimeIsWindows に変更

### テスト
- 変更箇所の unit テスト更新済み

Made with [Cursor](https://cursor.com)