### PR TITLE
cleanup: use concrete LogParser in logwatcher (#194)

### DIFF
--- a/internal/infrastructure/logwatcher/event_handler.go
+++ b/internal/infrastructure/logwatcher/event_handler.go
@@ -1,8 +1,6 @@
 package logwatcher
 
 import (
-	"time"
-
 	"vrchat-tweaker/internal/domain/activity"
 	"vrchat-tweaker/internal/infrastructure/diag"
 )
@@ -23,9 +21,4 @@ func (f EventHandlerFunc) Handle(event activity.ParsedEvent) {
 	if f != nil {
 		f(event)
 	}
-}
-
-// LogParser parses a log line into events.
-type LogParser interface {
-	ParseLine(line string, baseTime time.Time) ([]activity.ParsedEvent, error)
 }

--- a/internal/infrastructure/logwatcher/helpers_test.go
+++ b/internal/infrastructure/logwatcher/helpers_test.go
@@ -3,22 +3,7 @@ package logwatcher
 import (
 	"os"
 	"sync"
-	"time"
-
-	"vrchat-tweaker/internal/domain/activity"
 )
-
-type stubParser struct {
-	events []activity.ParsedEvent
-	err    error
-}
-
-func (p stubParser) ParseLine(string, time.Time) ([]activity.ParsedEvent, error) {
-	if p.err != nil {
-		return nil, p.err
-	}
-	return p.events, nil
-}
 
 type raceSafeLogBuffer struct {
 	mu   sync.Mutex
@@ -26,29 +11,16 @@ type raceSafeLogBuffer struct {
 }
 
 func (b *raceSafeLogBuffer) logger() Logger {
-	return func(format string, args ...any) {
-		b.mu.Lock()
-		b.logs = append(b.logs, format)
-		b.mu.Unlock()
-	}
+	return func(format string, args ...any) { b.mu.Lock(); b.logs = append(b.logs, format); b.mu.Unlock() }
 }
-
-func (b *raceSafeLogBuffer) len() int {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return len(b.logs)
-}
-
-func writeTestFile(path, content string) error {
-	return os.WriteFile(path, []byte(content), 0600)
-}
-
+func (b *raceSafeLogBuffer) len() int          { b.mu.Lock(); defer b.mu.Unlock(); return len(b.logs) }
+func writeTestFile(path, content string) error { return os.WriteFile(path, []byte(content), 0600) }
 func appendToTestFile(path, content string) error {
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
+	defer f.Close()
 	_, err = f.Write([]byte(content))
 	return err
 }

--- a/internal/infrastructure/logwatcher/multi_output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/multi_output_log_watcher.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"vrchat-tweaker/internal/domain/activity"
 	"vrchat-tweaker/internal/infrastructure/diag"
 )
 
@@ -20,7 +21,7 @@ type MultiOutputLogWatcherCallbacks struct {
 // MultiOutputLogWatcher polls a log directory and tails every output_log*.txt that is growing.
 type MultiOutputLogWatcher struct {
 	watchDir       string
-	parser         LogParser
+	parser         *activity.LogParser
 	handlerFactory func(logPath string) EventHandler
 	callbacks      MultiOutputLogWatcherCallbacks
 	logger         Logger
@@ -42,7 +43,7 @@ type trackedLogFile struct {
 // NewMultiOutputLogWatcher creates a directory-only watcher for parallel output_log sources.
 func NewMultiOutputLogWatcher(
 	watchDir string,
-	parser LogParser,
+	parser *activity.LogParser,
 	handlerFactory func(logPath string) EventHandler,
 	callbacks MultiOutputLogWatcherCallbacks,
 	logger Logger,

--- a/internal/infrastructure/logwatcher/output_log_line.go
+++ b/internal/infrastructure/logwatcher/output_log_line.go
@@ -12,7 +12,7 @@ var errNilDispatchArg = errors.New("logwatcher: nil parser or handler")
 // dispatchOutputLogLine parses a trimmed non-empty line and dispatches events.
 // Caller logs parseErr if non-nil. baseTime is for checkpoint (ParseVRChatTimestamp result).
 // parser and handler must be non-nil; otherwise errNilDispatchArg is returned.
-func dispatchOutputLogLine(lineTrimmed string, parser LogParser, handler EventHandler) (baseTime time.Time, parseErr error) {
+func dispatchOutputLogLine(lineTrimmed string, parser *activity.LogParser, handler EventHandler) (baseTime time.Time, parseErr error) {
 	if parser == nil || handler == nil {
 		return time.Time{}, errNilDispatchArg
 	}

--- a/internal/infrastructure/logwatcher/output_log_line_test.go
+++ b/internal/infrastructure/logwatcher/output_log_line_test.go
@@ -23,7 +23,7 @@ func TestDispatchOutputLogLine_nilParser(t *testing.T) {
 
 func TestDispatchOutputLogLine_nilHandler(t *testing.T) {
 	t.Parallel()
-	_, err := dispatchOutputLogLine("line", stubParser{}, nil)
+	_, err := dispatchOutputLogLine("line", activity.NewLogParser(), nil)
 	if !errors.Is(err, errNilDispatchArg) {
 		t.Fatalf("err = %v, want %v", err, errNilDispatchArg)
 	}

--- a/internal/infrastructure/logwatcher/process_output_log.go
+++ b/internal/infrastructure/logwatcher/process_output_log.go
@@ -16,14 +16,14 @@ type SessionCorrelatorWarmer interface {
 }
 
 // ProcessOutputLogFile reads an entire output_log file from the beginning and dispatches parsed events.
-func ProcessOutputLogFile(ctx context.Context, path string, parser LogParser, handler EventHandler, logger Logger) error {
+func ProcessOutputLogFile(ctx context.Context, path string, parser *activity.LogParser, handler EventHandler, logger Logger) error {
 	_, err := ProcessOutputLogFileFromOffset(ctx, path, 0, parser, handler, logger, nil)
 	return err
 }
 
 // WarmSessionCorrelatorFromLogFile replays log lines in [0, endOffset) into correlator only.
 // Used before bootstrap resume so mid-file checkpoints keep correct world/instance context.
-func WarmSessionCorrelatorFromLogFile(ctx context.Context, path string, endOffset int64, parser LogParser, warmer SessionCorrelatorWarmer, logger Logger) error {
+func WarmSessionCorrelatorFromLogFile(ctx context.Context, path string, endOffset int64, parser *activity.LogParser, warmer SessionCorrelatorWarmer, logger Logger) error {
 	if endOffset <= 0 || warmer == nil {
 		return nil
 	}
@@ -78,7 +78,7 @@ func WarmSessionCorrelatorFromLogFile(ctx context.Context, path string, endOffse
 type ProgressCallback func(byteOffset int64, line string)
 
 // ProcessOutputLogFileFromOffset reads from startOffset and returns the final byte offset in the file.
-func ProcessOutputLogFileFromOffset(ctx context.Context, path string, startOffset int64, parser LogParser, handler EventHandler, logger Logger, onProgress ProgressCallback) (int64, error) {
+func ProcessOutputLogFileFromOffset(ctx context.Context, path string, startOffset int64, parser *activity.LogParser, handler EventHandler, logger Logger, onProgress ProgressCallback) (int64, error) {
 	if logger == nil {
 		logger = diag.Nop
 	}

--- a/internal/infrastructure/logwatcher/process_output_log_test.go
+++ b/internal/infrastructure/logwatcher/process_output_log_test.go
@@ -94,10 +94,9 @@ func TestProcessOutputLogFileFromOffset_ParseErrorContinues(t *testing.T) {
 	if err := writeTestFile(path, "bad line\n"); err != nil {
 		t.Fatal(err)
 	}
-	parser := stubParser{err: errors.New("parse fail")}
 	buf := &raceSafeLogBuffer{}
 	_, err := ProcessOutputLogFileFromOffset(
-		context.Background(), path, 0, parser, EventHandlerFunc(func(activity.ParsedEvent) {}),
+		context.Background(), path, 0, nil, EventHandlerFunc(func(activity.ParsedEvent) {}),
 		buf.logger(),
 		nil,
 	)
@@ -117,7 +116,7 @@ func TestProcessOutputLogFileFromOffset_ContextCancel(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := ProcessOutputLogFileFromOffset(ctx, path, 0, stubParser{}, EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil)
+	_, err := ProcessOutputLogFileFromOffset(ctx, path, 0, activity.NewLogParser(), EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v", err)
 	}
@@ -126,10 +125,11 @@ func TestProcessOutputLogFileFromOffset_ContextCancel(t *testing.T) {
 func TestProcessOutputLogFileFromOffset_NegativeOffsetClamped(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "output_log.txt")
-	if err := writeTestFile(path, "only\n"); err != nil {
+	line := "2026.03.21 11:32:16 Debug      -  [Behaviour] OnPlayerJoined Alice (usr_abc)\n"
+	if err := writeTestFile(path, line); err != nil {
 		t.Fatal(err)
 	}
-	parser := stubParser{events: []activity.ParsedEvent{&activity.EncounterEvent{DisplayName: "X"}}}
+	parser := activity.NewLogParser()
 	var got activity.ParsedEvent
 	h := EventHandlerFunc(func(ev activity.ParsedEvent) { got = ev })
 	pos, err := ProcessOutputLogFileFromOffset(context.Background(), path, -5, parser, h, nil, nil)
@@ -139,7 +139,7 @@ func TestProcessOutputLogFileFromOffset_NegativeOffsetClamped(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected event")
 	}
-	if pos != int64(len("only\n")) {
+	if pos != int64(len(line)) {
 		t.Fatalf("pos = %d", pos)
 	}
 }
@@ -148,7 +148,7 @@ func TestProcessOutputLogFileFromOffset_openError(t *testing.T) {
 	_, err := ProcessOutputLogFileFromOffset(
 		context.Background(),
 		filepath.Join(t.TempDir(), "missing.txt"),
-		0, stubParser{}, EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil,
+		0, activity.NewLogParser(), EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected open error")
@@ -162,7 +162,7 @@ func TestProcessOutputLogFileFromOffset_offsetBeyondSize(t *testing.T) {
 		t.Fatal(err)
 	}
 	pos, err := ProcessOutputLogFileFromOffset(
-		context.Background(), path, 100, stubParser{}, EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil,
+		context.Background(), path, 100, activity.NewLogParser(), EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +179,7 @@ func TestProcessOutputLogFileFromOffset_readError(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err := ProcessOutputLogFileFromOffset(
-		context.Background(), path, 0, stubParser{}, EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil,
+		context.Background(), path, 0, activity.NewLogParser(), EventHandlerFunc(func(activity.ParsedEvent) {}), nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected read error on directory path")
@@ -193,7 +193,7 @@ func TestProcessOutputLogFileFromOffset_progressCallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	pos, err := ProcessOutputLogFileFromOffset(
-		context.Background(), path, 0, stubParser{}, EventHandlerFunc(func(activity.ParsedEvent) {}), nil,
+		context.Background(), path, 0, activity.NewLogParser(), EventHandlerFunc(func(activity.ParsedEvent) {}), nil,
 		func(offset int64, line string) {
 			if offset != 2 || line != "x" {
 				t.Fatalf("progress offset=%d line=%q", offset, line)

--- a/internal/infrastructure/logwatcher/tail_output_log_file.go
+++ b/internal/infrastructure/logwatcher/tail_output_log_file.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"time"
+
+	"vrchat-tweaker/internal/domain/activity"
 )
 
 const (
@@ -21,7 +23,7 @@ func tailOutputLogFile(
 	ctx context.Context,
 	path string,
 	startOffset int64,
-	parser LogParser,
+	parser *activity.LogParser,
 	handler EventHandler,
 	logger Logger,
 	checkpoint tailCheckpoint,


### PR DESCRIPTION
### 概要
logwatcher の `LogParser` interface を削除し、`*activity.LogParser` を直接受け取る。

### 関連 Issue
Closes #194

### 変更内容
- LogParser interface 削除
- watcher / process / warm / tests を具象型に更新

### テスト
- `go test ./internal/infrastructure/logwatcher/`

Made with [Cursor](https://cursor.com)