### PR TITLE
cleanup: drop chart.js from playtime chart (#190)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.2",
     "@tanstack/vue-virtual": "^3.13.23",
-    "chart.js": "^4.5.1",
     "element-plus": "^2.13.6",
     "vue": "^3.4.21",
     "vue-i18n": "^11.3.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@tanstack/vue-virtual':
         specifier: ^3.13.23
         version: 3.13.32(vue@3.5.39(typescript@6.0.3))
-      chart.js:
-        specifier: ^4.5.1
-        version: 4.5.1
       element-plus:
         specifier: ^2.13.6
         version: 2.14.3(vue@3.5.39(typescript@6.0.3))
@@ -517,9 +514,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@kurkle/color@0.3.4':
-    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
@@ -1487,10 +1481,6 @@ packages:
 
   character-parser@2.2.0:
     resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
-
-  chart.js@4.5.1:
-    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
-    engines: {pnpm: '>=8'}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -3323,8 +3313,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kurkle/color@0.3.4': {}
-
   '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7)':
     dependencies:
       '@types/mdx': 2.0.14
@@ -4216,10 +4204,6 @@ snapshots:
   character-parser@2.2.0:
     dependencies:
       is-regex: 1.2.1
-
-  chart.js@4.5.1:
-    dependencies:
-      '@kurkle/color': 0.3.4
 
   check-error@2.1.3: {}
 

--- a/frontend/src/components/PlayTimeChart.vue
+++ b/frontend/src/components/PlayTimeChart.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="playtime-chart-wrap">
-    <canvas
-      ref="canvasRef"
-      @mousemove="onMove"
-      @mouseleave="hoverIndex = null"
-    />
+    <canvas ref="canvasRef" @mousemove="onMove" @mouseleave="onLeave" />
     <div
       v-if="hoverIndex != null && tip"
       class="playtime-chart-tip"
@@ -27,6 +23,7 @@ import {
 } from "vue";
 import { useI18n } from "vue-i18n";
 import { formatPlayDurationHMS } from "../utils/formatPlayDuration";
+import { clampCenteredTipX, syncCanvasBuffer } from "./playTimeChartGeometry";
 
 export interface PlayTimeDayPoint {
   date: string;
@@ -45,6 +42,18 @@ const hoverIndex = ref<number | null>(null);
 let resizeObserver: ResizeObserver | null = null;
 
 const PAD = { top: 36, left: 48, right: 14, bottom: 44 };
+/** Approximate tip width for translateX(-50%) edge clamping. */
+const TIP_WIDTH = 120;
+
+type PlotMetrics = {
+  cssW: number;
+  cssH: number;
+  plotW: number;
+  plotH: number;
+  maxY: number;
+};
+
+let plotCache: PlotMetrics | null = null;
 
 function readCssVar(name: string, fallback: string): string {
   const v = getComputedStyle(document.documentElement)
@@ -70,19 +79,19 @@ function niceMax(seconds: number): number {
   return Math.ceil(raw / step) * step;
 }
 
-function layout(canvas: HTMLCanvasElement) {
-  const dpr = window.devicePixelRatio || 1;
+/** Measure plot geometry without touching the canvas buffer. */
+function measurePlot(canvas: HTMLCanvasElement): PlotMetrics {
   const cssW = canvas.clientWidth || 300;
   const cssH = canvas.clientHeight || 280;
-  canvas.width = Math.floor(cssW * dpr);
-  canvas.height = Math.floor(cssH * dpr);
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   const plotW = cssW - PAD.left - PAD.right;
   const plotH = cssH - PAD.top - PAD.bottom;
   const maxY = niceMax(Math.max(0, ...props.series.map((s) => s.seconds)));
-  return { ctx, cssW, cssH, plotW, plotH, maxY };
+  return { cssW, cssH, plotW, plotH, maxY };
+}
+
+function refreshPlot(canvas: HTMLCanvasElement): PlotMetrics {
+  plotCache = measurePlot(canvas);
+  return plotCache;
 }
 
 function pointAt(
@@ -101,9 +110,14 @@ function pointAt(
 function draw(): void {
   const canvas = canvasRef.value;
   if (!canvas) return;
-  const L = layout(canvas);
-  if (!L) return;
-  const { ctx, cssW, cssH, plotW, plotH, maxY } = L;
+  const L = refreshPlot(canvas);
+  const dpr = window.devicePixelRatio || 1;
+  syncCanvasBuffer(canvas, L.cssW, L.cssH, dpr);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  const { cssW, cssH, plotW, plotH, maxY } = L;
   const textMuted = readCssVar("--text-secondary", "#a0a0a0");
   const border = readCssVar("--border", "#333333");
   const accent = readCssVar("--accent", "#5b9bd5");
@@ -160,22 +174,18 @@ const tip = computed(() => {
   const i = hoverIndex.value;
   const canvas = canvasRef.value;
   if (i == null || !props.series[i] || !canvas) return null;
-  const cssW = canvas.clientWidth || 300;
-  const cssH = canvas.clientHeight || 280;
-  const plotW = cssW - PAD.left - PAD.right;
-  const plotH = cssH - PAD.top - PAD.bottom;
-  const maxY = niceMax(Math.max(0, ...props.series.map((s) => s.seconds)));
+  const L = plotCache ?? measurePlot(canvas);
   const p = props.series[i];
   const { x, y } = pointAt(
     i,
     props.series.length,
-    plotW,
-    plotH,
-    maxY,
+    L.plotW,
+    L.plotH,
+    L.maxY,
     p.seconds,
   );
   return {
-    x,
+    x: clampCenteredTipX(x, L.cssW, TIP_WIDTH, PAD.left, PAD.right),
     y: Math.max(8, y - 48),
     date: p.date,
     duration: formatPlayDurationHMS(p.seconds, {
@@ -192,8 +202,8 @@ function onMove(ev: MouseEvent): void {
     hoverIndex.value = null;
     return;
   }
-  const L = layout(canvas);
-  if (!L) return;
+  // Use cached metrics; never resize the buffer on mousemove.
+  const L = plotCache ?? refreshPlot(canvas);
   const rect = canvas.getBoundingClientRect();
   const mx = ev.clientX - rect.left;
   let best = 0;
@@ -213,12 +223,20 @@ function onMove(ev: MouseEvent): void {
       best = i;
     }
   });
-  hoverIndex.value = bestDist < 40 ? best : null;
+  const next = bestDist < 40 ? best : null;
+  if (hoverIndex.value === next) return;
+  hoverIndex.value = next;
+  draw();
+}
+
+function onLeave(): void {
+  if (hoverIndex.value == null) return;
+  hoverIndex.value = null;
   draw();
 }
 
 watch(
-  () => [props.series, locale.value, hoverIndex.value] as const,
+  () => [props.series, locale.value] as const,
   () => {
     void nextTick(() => draw());
   },

--- a/frontend/src/components/PlayTimeChart.vue
+++ b/frontend/src/components/PlayTimeChart.vue
@@ -23,7 +23,11 @@ import {
 } from "vue";
 import { useI18n } from "vue-i18n";
 import { formatPlayDurationHMS } from "../utils/formatPlayDuration";
-import { clampCenteredTipX, syncCanvasBuffer } from "./playTimeChartGeometry";
+import {
+  clampCenteredTipX,
+  clampedPlotSize,
+  syncCanvasBuffer,
+} from "./playTimeChartGeometry";
 
 export interface PlayTimeDayPoint {
   date: string;
@@ -83,8 +87,7 @@ function niceMax(seconds: number): number {
 function measurePlot(canvas: HTMLCanvasElement): PlotMetrics {
   const cssW = canvas.clientWidth || 300;
   const cssH = canvas.clientHeight || 280;
-  const plotW = cssW - PAD.left - PAD.right;
-  const plotH = cssH - PAD.top - PAD.bottom;
+  const { plotW, plotH } = clampedPlotSize(cssW, cssH, PAD);
   const maxY = niceMax(Math.max(0, ...props.series.map((s) => s.seconds)));
   return { cssW, cssH, plotW, plotH, maxY };
 }

--- a/frontend/src/components/PlayTimeChart.vue
+++ b/frontend/src/components/PlayTimeChart.vue
@@ -1,14 +1,31 @@
 <template>
   <div class="playtime-chart-wrap">
-    <canvas ref="canvasRef" />
+    <canvas
+      ref="canvasRef"
+      @mousemove="onMove"
+      @mouseleave="hoverIndex = null"
+    />
+    <div
+      v-if="hoverIndex != null && tip"
+      class="playtime-chart-tip"
+      :style="{ left: tip.x + 'px', top: tip.y + 'px' }"
+    >
+      <div>{{ tip.date }}</div>
+      <div>{{ tip.duration }}</div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onBeforeUnmount, nextTick } from "vue";
+import {
+  ref,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+  computed,
+} from "vue";
 import { useI18n } from "vue-i18n";
-import Chart from "chart.js/auto";
-import type { Chart as ChartType } from "chart.js";
 import { formatPlayDurationHMS } from "../utils/formatPlayDuration";
 
 export interface PlayTimeDayPoint {
@@ -24,7 +41,10 @@ const props = defineProps<{
 const { t, locale } = useI18n();
 
 const canvasRef = ref<HTMLCanvasElement | null>(null);
-let chart: ChartType<"line"> | null = null;
+const hoverIndex = ref<number | null>(null);
+let resizeObserver: ResizeObserver | null = null;
+
+const PAD = { top: 36, left: 48, right: 14, bottom: 44 };
 
 function readCssVar(name: string, fallback: string): string {
   const v = getComputedStyle(document.documentElement)
@@ -43,142 +63,180 @@ function formatYAxisTickSeconds(sec: number): string {
   return `${sec}${t("chart.second")}`;
 }
 
-function buildChartOptions() {
-  const textMuted = readCssVar("--text-secondary", "#a0a0a0");
-  const border = readCssVar("--border", "#333333");
-  const bgTertiary = readCssVar("--bg-tertiary", "#1a1a1a");
-
-  return {
-    responsive: true,
-    maintainAspectRatio: false,
-    /* 上下: 軸ラベル・ポイントが canvas 端で欠けないよう余白を確保 */
-    layout: {
-      padding: {
-        top: 36,
-        left: 10,
-        right: 14,
-        bottom: 44,
-      },
-    },
-    interaction: {
-      mode: "index" as const,
-      intersect: false,
-    },
-    scales: {
-      y: {
-        beginAtZero: true,
-        ticks: {
-          color: textMuted,
-          padding: 6,
-          callback: (tickValue: string | number) =>
-            formatYAxisTickSeconds(Number(tickValue)),
-        },
-        grid: { color: border },
-      },
-      x: {
-        ticks: {
-          color: textMuted,
-          maxRotation: 45,
-          minRotation: 0,
-          padding: 4,
-        },
-        grid: { color: border },
-      },
-    },
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        backgroundColor: bgTertiary,
-        titleColor: textMuted,
-        bodyColor: readCssVar("--text-primary", "#e0e0e0"),
-        borderColor: border,
-        borderWidth: 1,
-        callbacks: {
-          title: (items: { dataIndex: number }[]) => {
-            const idx = items[0]?.dataIndex ?? 0;
-            return props.series[idx]?.date ?? "";
-          },
-          label: (ctx: { parsed: { y: number | null } }) => {
-            const y = ctx.parsed.y;
-            if (y == null) return "";
-            return formatPlayDurationHMS(y, {
-              hour: t("chart.hour"),
-              minute: t("chart.minute"),
-              second: t("chart.second"),
-            });
-          },
-        },
-      },
-    },
-  };
+function niceMax(seconds: number): number {
+  if (seconds <= 0) return 60;
+  const raw = seconds * 1.1;
+  const step = raw <= 60 ? 10 : raw <= 3600 ? 300 : 1800;
+  return Math.ceil(raw / step) * step;
 }
 
-function createOrUpdateChart(): void {
-  const canvas = canvasRef.value;
-  if (!canvas) {
-    return;
-  }
-  if (props.series.length === 0) {
-    chart?.destroy();
-    chart = null;
-    return;
-  }
+function layout(canvas: HTMLCanvasElement) {
+  const dpr = window.devicePixelRatio || 1;
+  const cssW = canvas.clientWidth || 300;
+  const cssH = canvas.clientHeight || 280;
+  canvas.width = Math.floor(cssW * dpr);
+  canvas.height = Math.floor(cssH * dpr);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  const plotW = cssW - PAD.left - PAD.right;
+  const plotH = cssH - PAD.top - PAD.bottom;
+  const maxY = niceMax(Math.max(0, ...props.series.map((s) => s.seconds)));
+  return { ctx, cssW, cssH, plotW, plotH, maxY };
+}
 
-  const labels = props.series.map((s) => s.label);
-  const data = props.series.map((s) => s.seconds);
+function pointAt(
+  i: number,
+  n: number,
+  plotW: number,
+  plotH: number,
+  maxY: number,
+  seconds: number,
+) {
+  const x = PAD.left + (n <= 1 ? plotW / 2 : (i / (n - 1)) * plotW);
+  const y = PAD.top + plotH - (seconds / maxY) * plotH;
+  return { x, y };
+}
+
+function draw(): void {
+  const canvas = canvasRef.value;
+  if (!canvas) return;
+  const L = layout(canvas);
+  if (!L) return;
+  const { ctx, cssW, cssH, plotW, plotH, maxY } = L;
+  const textMuted = readCssVar("--text-secondary", "#a0a0a0");
+  const border = readCssVar("--border", "#333333");
   const accent = readCssVar("--accent", "#5b9bd5");
 
-  if (chart) {
-    chart.data.labels = labels;
-    const ds = chart.data.datasets[0];
-    if (ds) {
-      ds.data = data;
-      ds.borderColor = accent;
-      ds.backgroundColor = accent + "33";
-    }
-    chart.options = buildChartOptions();
-    chart.update();
-    return;
+  ctx.clearRect(0, 0, cssW, cssH);
+  if (props.series.length === 0) return;
+
+  const ticks = 4;
+  ctx.strokeStyle = border;
+  ctx.fillStyle = textMuted;
+  ctx.lineWidth = 1;
+  ctx.font = "12px sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  for (let i = 0; i <= ticks; i++) {
+    const v = (maxY * i) / ticks;
+    const y = PAD.top + plotH - (v / maxY) * plotH;
+    ctx.beginPath();
+    ctx.moveTo(PAD.left, y);
+    ctx.lineTo(PAD.left + plotW, y);
+    ctx.stroke();
+    ctx.fillText(formatYAxisTickSeconds(v), PAD.left - 6, y);
   }
 
-  chart = new Chart(canvas, {
-    type: "line",
-    data: {
-      labels,
-      datasets: [
-        {
-          label: "",
-          data,
-          borderColor: accent,
-          backgroundColor: accent + "33",
-          fill: false,
-          tension: 0.2,
-          pointRadius: 4,
-          pointHoverRadius: 6,
-          /* 最大値付近の点がチャート領域の上端で欠けないように */
-          clip: false,
-        },
-      ],
-    },
-    options: buildChartOptions(),
+  const n = props.series.length;
+  ctx.beginPath();
+  props.series.forEach((s, i) => {
+    const { x, y } = pointAt(i, n, plotW, plotH, maxY, s.seconds);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.fillStyle = accent;
+  props.series.forEach((s, i) => {
+    const { x, y } = pointAt(i, n, plotW, plotH, maxY, s.seconds);
+    ctx.beginPath();
+    ctx.arc(x, y, hoverIndex.value === i ? 5 : 3.5, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  ctx.fillStyle = textMuted;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  props.series.forEach((s, i) => {
+    const { x } = pointAt(i, n, plotW, plotH, maxY, s.seconds);
+    ctx.fillText(s.label, x, PAD.top + plotH + 8);
   });
 }
 
+const tip = computed(() => {
+  const i = hoverIndex.value;
+  const canvas = canvasRef.value;
+  if (i == null || !props.series[i] || !canvas) return null;
+  const cssW = canvas.clientWidth || 300;
+  const cssH = canvas.clientHeight || 280;
+  const plotW = cssW - PAD.left - PAD.right;
+  const plotH = cssH - PAD.top - PAD.bottom;
+  const maxY = niceMax(Math.max(0, ...props.series.map((s) => s.seconds)));
+  const p = props.series[i];
+  const { x, y } = pointAt(
+    i,
+    props.series.length,
+    plotW,
+    plotH,
+    maxY,
+    p.seconds,
+  );
+  return {
+    x,
+    y: Math.max(8, y - 48),
+    date: p.date,
+    duration: formatPlayDurationHMS(p.seconds, {
+      hour: t("chart.hour"),
+      minute: t("chart.minute"),
+      second: t("chart.second"),
+    }),
+  };
+});
+
+function onMove(ev: MouseEvent): void {
+  const canvas = canvasRef.value;
+  if (!canvas || props.series.length === 0) {
+    hoverIndex.value = null;
+    return;
+  }
+  const L = layout(canvas);
+  if (!L) return;
+  const rect = canvas.getBoundingClientRect();
+  const mx = ev.clientX - rect.left;
+  let best = 0;
+  let bestDist = Infinity;
+  props.series.forEach((s, i) => {
+    const { x } = pointAt(
+      i,
+      props.series.length,
+      L.plotW,
+      L.plotH,
+      L.maxY,
+      s.seconds,
+    );
+    const d = Math.abs(x - mx);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  });
+  hoverIndex.value = bestDist < 40 ? best : null;
+  draw();
+}
+
 watch(
-  () => [props.series, locale.value] as const,
+  () => [props.series, locale.value, hoverIndex.value] as const,
   () => {
-    void nextTick(() => createOrUpdateChart());
+    void nextTick(() => draw());
   },
   { deep: true },
 );
 
 onMounted(() => {
-  void nextTick(() => createOrUpdateChart());
+  void nextTick(() => draw());
+  const canvas = canvasRef.value;
+  if (canvas && typeof ResizeObserver !== "undefined") {
+    resizeObserver = new ResizeObserver(() => draw());
+    resizeObserver.observe(canvas);
+  }
 });
 
 onBeforeUnmount(() => {
-  chart?.destroy();
-  chart = null;
+  resizeObserver?.disconnect();
+  resizeObserver = null;
 });
 </script>
 
@@ -187,5 +245,26 @@ onBeforeUnmount(() => {
   position: relative;
   width: 100%;
   height: 280px;
+}
+
+.playtime-chart-wrap canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.playtime-chart-tip {
+  position: absolute;
+  transform: translateX(-50%);
+  pointer-events: none;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #333);
+  background: var(--bg-tertiary, #1a1a1a);
+  color: var(--text-primary, #e0e0e0);
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: nowrap;
+  z-index: 1;
 }
 </style>

--- a/frontend/src/components/playTimeChartGeometry.spec.ts
+++ b/frontend/src/components/playTimeChartGeometry.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { clampCenteredTipX, syncCanvasBuffer } from "./playTimeChartGeometry";
+
+describe("clampCenteredTipX", () => {
+  const padLeft = 48;
+  const padRight = 14;
+  const tipWidth = 120;
+
+  it("keeps center x when tip fits inside the container", () => {
+    expect(clampCenteredTipX(150, 300, tipWidth, padLeft, padRight)).toBe(150);
+  });
+
+  it("clamps near the left edge so tip stays inside", () => {
+    const min = padLeft + tipWidth / 2;
+    expect(clampCenteredTipX(10, 300, tipWidth, padLeft, padRight)).toBe(min);
+  });
+
+  it("clamps near the right edge so tip stays inside", () => {
+    const max = 300 - padRight - tipWidth / 2;
+    expect(clampCenteredTipX(290, 300, tipWidth, padLeft, padRight)).toBe(max);
+  });
+});
+
+describe("syncCanvasBuffer", () => {
+  it("assigns width/height only when the buffer size changes", () => {
+    const canvas = { width: 600, height: 560 };
+    const first = syncCanvasBuffer(canvas, 300, 280, 2);
+    expect(first.resized).toBe(false);
+    expect(canvas.width).toBe(600);
+
+    const second = syncCanvasBuffer(canvas, 400, 280, 2);
+    expect(second.resized).toBe(true);
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(560);
+  });
+});

--- a/frontend/src/components/playTimeChartGeometry.spec.ts
+++ b/frontend/src/components/playTimeChartGeometry.spec.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { clampCenteredTipX, syncCanvasBuffer } from "./playTimeChartGeometry";
+import {
+  clampCenteredTipX,
+  clampedPlotSize,
+  syncCanvasBuffer,
+} from "./playTimeChartGeometry";
+
+describe("clampedPlotSize", () => {
+  const pad = { top: 36, left: 48, right: 14, bottom: 44 };
+
+  it("subtracts padding for normal sizes", () => {
+    expect(clampedPlotSize(300, 280, pad)).toEqual({
+      plotW: 238,
+      plotH: 200,
+    });
+  });
+
+  it("clamps to zero when container is smaller than padding", () => {
+    expect(clampedPlotSize(50, 70, pad)).toEqual({ plotW: 0, plotH: 0 });
+  });
+});
 
 describe("clampCenteredTipX", () => {
   const padLeft = 48;

--- a/frontend/src/components/playTimeChartGeometry.ts
+++ b/frontend/src/components/playTimeChartGeometry.ts
@@ -1,0 +1,42 @@
+/** Canvas buffer size fields mutated by syncCanvasBuffer. */
+export type CanvasBuffer = {
+  width: number;
+  height: number;
+};
+
+/**
+ * Clamp tip center X so a translateX(-50%) tip of tipWidth stays inside the chart.
+ */
+export function clampCenteredTipX(
+  x: number,
+  cssW: number,
+  tipWidth: number,
+  padLeft: number,
+  padRight: number,
+): number {
+  const half = tipWidth / 2;
+  const min = padLeft + half;
+  const max = cssW - padRight - half;
+  if (max < min) return cssW / 2;
+  return Math.max(min, Math.min(max, x));
+}
+
+/**
+ * Resize canvas backing store only when CSS size × DPR actually changes.
+ * Assigning width/height always clears the bitmap, even to the same values.
+ */
+export function syncCanvasBuffer(
+  canvas: CanvasBuffer,
+  cssW: number,
+  cssH: number,
+  dpr: number,
+): { resized: boolean; width: number; height: number } {
+  const width = Math.floor(cssW * dpr);
+  const height = Math.floor(cssH * dpr);
+  const resized = canvas.width !== width || canvas.height !== height;
+  if (resized) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+  return { resized, width, height };
+}

--- a/frontend/src/components/playTimeChartGeometry.ts
+++ b/frontend/src/components/playTimeChartGeometry.ts
@@ -4,6 +4,25 @@ export type CanvasBuffer = {
   height: number;
 };
 
+export type ChartPad = {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+};
+
+/** Plot area size; never negative when the container is smaller than padding. */
+export function clampedPlotSize(
+  cssW: number,
+  cssH: number,
+  pad: ChartPad,
+): { plotW: number; plotH: number } {
+  return {
+    plotW: Math.max(0, cssW - pad.left - pad.right),
+    plotH: Math.max(0, cssH - pad.top - pad.bottom),
+  };
+}
+
 /**
  * Clamp tip center X so a translateX(-50%) tip of tipWidth stays inside the chart.
  */


### PR DESCRIPTION
### 概要
`PlayTimeChart` を Canvas 2D 実装に置き換え、`chart.js` 依存を削除する。

### 関連 Issue
Closes #190

### 変更内容
- PlayTimeChart.vue を自前描画（折れ線・軸・ホバー tip）
- package.json から chart.js を削除

### テスト
- `pnpm run test -- src/views/__tests__/ActivityView.spec.ts`
- `make fmt`

Made with [Cursor](https://cursor.com)