### PR TITLE
fix: MultiOutputLogWatcher cancel race under -race (#213)

### DIFF
--- a/internal/infrastructure/logwatcher/multi_output_log_watcher.go
+++ b/internal/infrastructure/logwatcher/multi_output_log_watcher.go
@@ -216,13 +216,18 @@ func (w *MultiOutputLogWatcher) startTail(ctx context.Context, path string, stat
 	state.readOffset.Store(startOffset)
 	tailCtx, cancel := context.WithCancel(ctx)
 	myGen := state.tailGen.Add(1)
+	// cancel is owned only by the poll loop (startTail/stopTail from run()). Tail defer must not clear it.
+	if state.cancel != nil {
+		state.cancel()
+	}
 	state.cancel = cancel
 	state.tailing.Store(true)
 
 	handler := w.handlerFactory(path)
 	if handler == nil {
-		state.tailing.Store(false)
+		state.cancel()
 		state.cancel = nil
+		state.tailing.Store(false)
 		return
 	}
 	go func() {
@@ -232,7 +237,6 @@ func (w *MultiOutputLogWatcher) startTail(ctx context.Context, path string, stat
 			}
 			if state.tailGen.Load() == myGen {
 				state.tailing.Store(false)
-				state.cancel = nil
 			}
 		}()
 		tailOutputLogFile(tailCtx, path, startOffset, w.parser, handler, w.logger, func(offset int64, lineTime time.Time) {

--- a/internal/infrastructure/logwatcher/multi_output_log_watcher_test.go
+++ b/internal/infrastructure/logwatcher/multi_output_log_watcher_test.go
@@ -394,3 +394,33 @@ func TestMultiOutputLogWatcher_TailGoroutineExitClearsTailing(t *testing.T) {
 	cancel()
 	time.Sleep(50 * time.Millisecond)
 }
+
+// Exercises stopTail overlapping tail-goroutine exit (the DATA RACE on cancel seen in CI).
+// Requires `go test -race`; without a brief yield after startTail, stopTail usually wins the gen bump first.
+func TestMultiOutputLogWatcher_StopTailNoRaceWithTailExit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output_log_race.txt")
+	if err := writeTestFile(path, ""); err != nil {
+		t.Fatal(err)
+	}
+	w := newMultiWatcherForTest(t, dir, func(string) EventHandler {
+		return testEventHandler(func(activity.ParsedEvent) {})
+	}, MultiOutputLogWatcherCallbacks{})
+
+	for range 200 {
+		state := &trackedLogFile{}
+		ctx, cancel := context.WithCancel(context.Background())
+		w.startTail(ctx, path, state, 0)
+		// Let the tail goroutine enter tailOutputLogFile so cancel+stopTail can overlap its defer.
+		time.Sleep(10 * time.Microsecond)
+		cancel()
+		w.stopTail(state)
+		deadline := time.Now().Add(time.Second)
+		for state.tailing.Load() && time.Now().Before(deadline) {
+			time.Sleep(time.Millisecond)
+		}
+		if state.tailing.Load() {
+			t.Fatal("tailing stuck true after cancel+stopTail")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Fix data race on `trackedLogFile.cancel` between `stopTail` and the tail goroutine defer (closes #213)
- Keep cancel ownership on the poll loop (`startTail`/`stopTail` from `run()`); release previous cancel on restart
- Add `-race` regression test that overlaps cancel + `stopTail` with tail exit

## Test plan
- [x] `go test -race ./internal/infrastructure/logwatcher/ -run TestMultiOutputLogWatcher_StopTailNoRaceWithTailExit -count=50` (with `GOMAXPROCS=8`)
- [x] Confirm same test fails with the old `state.cancel = nil` in defer
- [x] `go test -race ./internal/infrastructure/logwatcher/`
- [x] `make lint-back` (with CI-style stub `frontend/dist`)
- [ ] CI Go Backend job passes with `-race`


Made with [Cursor](https://cursor.com)