### PR TITLE
chore(agents): OCR review prevention at implement time

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -78,6 +78,7 @@ GitHub Issue の URL・番号、または `docs/ai_dlc/issues/` 等の Issue ド
 
 - `.cursor/rules/post-change-fmt.mdc`: コード変更後は `make fmt`（常時適用）
 - `.cursor/rules/tdd-workflow.mdc`: TDD と検証ループ（常時適用）
+- `.cursor/rules/ocr-review-prevention.mdc`: 直近 OCR/PR 指摘の再発予防（実装完了前セルフチェック、常時適用）
 - `.cursor/rules/go-conventions.mdc`: Go の規約
 - `.cursor/rules/vue-conventions.mdc`: Vue/TypeScript の規約
 - `.cursor/rules/element-plus-ui.mdc`: Element Plus を UI フレームワークとして使う方針（`frontend` の Vue/TS）

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -45,4 +45,5 @@ description: >-
 
 ## 実装完了後
 
-実装が終わったら、QA エージェントまたは `make fmt && make test && make lint` で検証する。エラー時は修正し、全てパスするまで繰り返す。
+1. **`.cursor/rules/ocr-review-prevention.mdc` を自己チェック**し、該当する指摘パターンが残っていれば先に直す
+2. QA エージェントまたは `make fmt && make test && make lint` で検証する。エラー時は修正し、全てパスするまで繰り返す

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -11,6 +11,7 @@ description: >-
 
 ## レビュー観点
 
+- **OCR 再発予防（Critical 優先）**: `.cursor/rules/ocr-review-prevention.mdc` — mutex+I/O、channel ライフサイクル、Scanner/Marshal/RowsAffected、パス改行・junction、`(nil,nil)` 契約、Vue gen/raw エラー/`includes` 過広、死んだ i18n
 - **正確性**: ロジックの誤り、エッジケースの考慮
 - **セキュリティ**: 認証情報の露出、入力検証、インジェクション
 - **可読性**: 命名、コメント、構造

--- a/.cursor/rules/ocr-review-prevention.mdc
+++ b/.cursor/rules/ocr-review-prevention.mdc
@@ -1,0 +1,40 @@
+---
+description: >-
+  Prevent recurring OCR/PR review findings at implement time (concurrency,
+  FS/TOCTOU, nil/SQL contracts, Vue error UI). Harvested from recent reviews.
+alwaysApply: true
+---
+
+# OCR review prevention (implement before PR)
+
+Catch the patterns OCR keeps filing. Design-time depth: user skill
+`grill-review-ready`. This rule is the short implement-time gate.
+
+## Go / usecase / sqlite
+
+- [ ] No I/O or Settings calls while holding `uc.mu` (copy state, unlock, then call)
+- [ ] Channel lifecycle: close and send cannot race; Start→Stop→Start recreates channels and clears limiter maps
+- [ ] Cancellable work uses `context` (not bare `time.After` that leaks the worker)
+- [ ] After `bufio.Scanner`, check `sc.Err()`
+- [ ] Reject `\n` / `\r` inside paths or config lines before persist (TrimSpace is not enough)
+- [ ] Atomic replace preserves previous file mode when replacing an existing file
+- [ ] `json.Marshal` errors checked; `sql.NullString` uses `.Valid`
+- [ ] Delete/Update: treat `RowsAffected == 0` as not-found (not silent success)
+- [ ] Migrate / claim-next runs in a transaction
+- [ ] `(nil, nil)` vs error vs empty DTO is consistent through usecase → Wails for sibling methods
+- [ ] Validate JSON blobs and domain ranges (e.g. schedule hour/minute) before store
+- [ ] Junction / reparse ≠ symlink; do not `RemoveAll` through junctions as plain dirs
+- [ ] No `ponytail:` markers in committed code (TODO/FIXME or delete)
+
+## Vue / i18n / Storybook
+
+- [ ] Generation counter only for state-changing async; dialog-only ops capture, do not bump
+- [ ] Error classifiers match fixed backend prefixes / sentinels — not broad `includes(...)`
+- [ ] Never put raw backend errors (paths, OS detail) into `te()` or user-visible alerts
+- [ ] Async handlers: unmount / gen guard; `ElMessageBox` cancel/close/Error all handled
+- [ ] Storybook + E2E mocks match DTO/bindings; cover error/unsupported UI branches
+- [ ] Remove dead i18n keys when classifiers or labels move; keep all locales in sync
+
+## Before declaring done
+
+Diff the change set against this checklist. Failures → fix now, do not defer to PR review.

--- a/.cursor/skills/feature-implementation-pipeline/SKILL.md
+++ b/.cursor/skills/feature-implementation-pipeline/SKILL.md
@@ -77,7 +77,7 @@ docs/features の機能仕様を読み、実装計画→実装→レビュー→
 2. `mcp_task` を呼ぶ:
    - `subagent_type`: `generalPurpose`
    - `description`: `Code review of implementation changes`
-   - `prompt`: [reviewer.md の本文] + 改行 + `git diff で変更を確認し、 Critical/Suggestion/Nice でレビューせよ。`
+   - `prompt`: [reviewer.md の本文] + 改行 + `git diff で変更を確認し、.cursor/rules/ocr-review-prevention.mdc を必須観点に含めて Critical/Suggestion/Nice でレビューせよ。`
 
 ### Step 4: QA（品質保証・検証ループ）
 


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/ocr-review-prevention.mdc` (always-on checklist from recent OCR findings)
- Wire implementer self-check, reviewer Critical priorities, and feature-implementation-pipeline Review prompt
- Document the rule in `.cursor/AGENTS.md`

## Test plan
- [ ] Open a feature-style change in this repo and confirm the prevention rule is visible to the agent
- [ ] Run implementer/reviewer flow (or `/run-review`) and confirm OCR prevention is in the review axes
- [ ] No app/runtime code changed — docs/agent config only


Made with [Cursor](https://cursor.com)