### PR TITLE
fix(automation): schedule trigger blocked by stale friend condition

### DIFF
--- a/frontend/src/views/AutomationView.vue
+++ b/frontend/src/views/AutomationView.vue
@@ -116,7 +116,7 @@
                 <el-checkbox
                   v-for="d in weekdayOptions"
                   :key="d.value"
-                  :label="d.value"
+                  :value="d.value"
                 >
                   {{ d.label }}
                 </el-checkbox>
@@ -368,6 +368,7 @@ import { getRuntime } from "../wails/runtime";
 import {
   defaultAction,
   dtoToEditor,
+  editorToDto,
   newAutomationId,
   type EditorState,
 } from "./automationEditorMapping";
@@ -430,56 +431,6 @@ const actionOptions = computed(() => [
     label: t("automation.actionSetVRChatWindowSize"),
   },
 ]);
-
-function editorToDto(state: EditorState): AutomationItemDTO {
-  const dto: AutomationItemDTO = {
-    id: state.id,
-    name: state.name,
-    kind: state.kind,
-    isEnabled: state.isEnabled,
-  };
-  if (state.kind === "script") {
-    dto.scriptSource = state.scriptSource;
-    return dto;
-  }
-  dto.triggerType = state.triggerType;
-  if (state.triggerType === "schedule.tick") {
-    dto.scheduleJson = JSON.stringify({
-      weekdays: state.scheduleWeekdays,
-      hour: state.scheduleHour,
-      minute: state.scheduleMinute,
-    });
-  }
-  const conds: Array<{ type: string; vrcUserId?: string }> = [];
-  if (state.vrchatRunning) conds.push({ type: "vrchat_running" });
-  if (state.friendUserId) {
-    conds.push({ type: "friend_is", vrcUserId: state.friendUserId });
-  }
-  dto.conditionsJson = JSON.stringify(conds);
-  dto.actionsJson = JSON.stringify(
-    state.actions.map((a) => {
-      const payload: Record<string, string | number> = {};
-      if (a.type === "change_status") payload.status = a.status;
-      if (a.type === "set_power_plan") {
-        if (a.powerPlanMode === "guid" && a.powerPlanGuid) {
-          payload.guid = a.powerPlanGuid;
-        } else {
-          payload.preset = a.powerPlanPreset;
-        }
-      }
-      if (a.type === "set_vrchat_window_size") {
-        payload.width = a.windowWidth;
-        payload.height = a.windowHeight;
-      }
-      return {
-        type: a.type,
-        payload,
-        continueOnError: a.continueOnError || undefined,
-      };
-    }),
-  );
-  return dto;
-}
 
 function captureSnapshot() {
   savedSnapshot.value = editor.value ? JSON.stringify(editor.value) : "";

--- a/frontend/src/views/__tests__/automationEditorMapping.spec.ts
+++ b/frontend/src/views/__tests__/automationEditorMapping.spec.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   AutomationItemParseError,
+  defaultAction,
   dtoToEditor,
+  editorToDto,
   newAutomationId,
+  type EditorState,
 } from "../automationEditorMapping";
 import type { AutomationItemDTO } from "../../wails/app";
 
@@ -17,6 +20,24 @@ const base: AutomationItemDTO = {
     { type: "change_status", payload: { status: "busy" } },
   ]),
 };
+
+function baseEditor(overrides: Partial<EditorState> = {}): EditorState {
+  return {
+    id: "1",
+    name: "n",
+    kind: "rule",
+    isEnabled: true,
+    triggerType: "friend_joined",
+    scheduleWeekdays: [1, 2, 3, 4, 5],
+    scheduleHour: 0,
+    scheduleMinute: 0,
+    vrchatRunning: false,
+    friendUserId: "",
+    actions: [defaultAction()],
+    scriptSource: "",
+    ...overrides,
+  };
+}
 
 describe("dtoToEditor", () => {
   it("maps valid JSON fields", () => {
@@ -113,5 +134,37 @@ describe("newAutomationId", () => {
     expect(id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
     );
+  });
+});
+
+describe("editorToDto", () => {
+  it("omits friend_is when trigger is schedule.tick", () => {
+    const dto = editorToDto(
+      baseEditor({
+        triggerType: "schedule.tick",
+        friendUserId: "usr_leftover",
+        scheduleHour: 9,
+        scheduleMinute: 30,
+      }),
+    );
+    expect(dto.triggerType).toBe("schedule.tick");
+    expect(JSON.parse(dto.scheduleJson ?? "{}")).toEqual({
+      weekdays: [1, 2, 3, 4, 5],
+      hour: 9,
+      minute: 30,
+    });
+    expect(JSON.parse(dto.conditionsJson ?? "[]")).toEqual([]);
+  });
+
+  it("keeps friend_is for friend_joined", () => {
+    const dto = editorToDto(
+      baseEditor({
+        triggerType: "friend_joined",
+        friendUserId: "usr_x",
+      }),
+    );
+    expect(JSON.parse(dto.conditionsJson ?? "[]")).toEqual([
+      { type: "friend_is", vrcUserId: "usr_x" },
+    ]);
   });
 });

--- a/frontend/src/views/automationEditorMapping.ts
+++ b/frontend/src/views/automationEditorMapping.ts
@@ -77,6 +77,58 @@ function parseJsonArray<T>(raw: string, field: string): T[] {
   return value as T[];
 }
 
+/** Maps editor state into a persistable item DTO. */
+export function editorToDto(state: EditorState): AutomationItemDTO {
+  const dto: AutomationItemDTO = {
+    id: state.id,
+    name: state.name,
+    kind: state.kind,
+    isEnabled: state.isEnabled,
+  };
+  if (state.kind === "script") {
+    dto.scriptSource = state.scriptSource;
+    return dto;
+  }
+  dto.triggerType = state.triggerType;
+  if (state.triggerType === "schedule.tick") {
+    dto.scheduleJson = JSON.stringify({
+      weekdays: state.scheduleWeekdays,
+      hour: state.scheduleHour,
+      minute: state.scheduleMinute,
+    });
+  }
+  const conds: Array<{ type: string; vrcUserId?: string }> = [];
+  if (state.vrchatRunning) conds.push({ type: "vrchat_running" });
+  // friend_is only applies to friend_joined; leftover picker state must not block schedule/process.
+  if (state.triggerType === "friend_joined" && state.friendUserId) {
+    conds.push({ type: "friend_is", vrcUserId: state.friendUserId });
+  }
+  dto.conditionsJson = JSON.stringify(conds);
+  dto.actionsJson = JSON.stringify(
+    state.actions.map((a) => {
+      const payload: Record<string, string | number> = {};
+      if (a.type === "change_status") payload.status = a.status;
+      if (a.type === "set_power_plan") {
+        if (a.powerPlanMode === "guid" && a.powerPlanGuid) {
+          payload.guid = a.powerPlanGuid;
+        } else {
+          payload.preset = a.powerPlanPreset;
+        }
+      }
+      if (a.type === "set_vrchat_window_size") {
+        payload.width = a.windowWidth;
+        payload.height = a.windowHeight;
+      }
+      return {
+        type: a.type,
+        payload,
+        continueOnError: a.continueOnError || undefined,
+      };
+    }),
+  );
+  return dto;
+}
+
 /** Maps a persisted item into editor state. Throws AutomationItemParseError on bad JSON. */
 export function dtoToEditor(dto: AutomationItemDTO): EditorState {
   if (dto.kind !== "script" && dto.kind !== "rule") {

--- a/internal/domain/automation/evaluate.go
+++ b/internal/domain/automation/evaluate.go
@@ -11,6 +11,8 @@ import (
 type Event struct {
 	Type    string
 	Payload map[string]interface{}
+	// At is the evaluation wall time (schedule ticks). Zero means time.Now at eval.
+	At time.Time
 }
 
 // VRChatProcessChecker reports whether VRChat is running.
@@ -29,11 +31,46 @@ func EvalItem(item *AutomationItem, ctx *EvalContext) (bool, error) {
 	if item.TriggerType != ctx.TriggerType {
 		return false, nil
 	}
+	if item.TriggerType == EventScheduleTick {
+		sched, err := ParseSchedule(item.ScheduleJSON)
+		if err != nil {
+			return false, err
+		}
+		now := ctx.Now
+		if now.IsZero() {
+			now = time.Now()
+		}
+		if !ScheduleMatches(sched, now) {
+			return false, nil
+		}
+	}
 	conds, err := ParseConditions(item.ConditionsJSON)
 	if err != nil {
 		return false, err
 	}
+	conds = CompatibleConditions(item.TriggerType, conds)
 	return MatchConditions(conds, ctx), nil
+}
+
+// CompatibleConditions drops conditions that cannot apply to the trigger
+// (e.g. leftover friend_is after switching a rule to schedule.tick).
+func CompatibleConditions(trigger string, conds []Condition) []Condition {
+	if len(conds) == 0 {
+		return conds
+	}
+	out := make([]Condition, 0, len(conds))
+	for _, c := range conds {
+		if c.Type == "friend_is" && trigger != EventFriendJoined {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// NextMinuteBoundary returns the start of the next wall-clock minute after now.
+func NextMinuteBoundary(now time.Time) time.Time {
+	return now.Truncate(ScheduleTickResolution).Add(ScheduleTickResolution)
 }
 
 // ParseConditions decodes conditions JSON.

--- a/internal/domain/automation/evaluate.go
+++ b/internal/domain/automation/evaluate.go
@@ -54,10 +54,8 @@ func EvalItem(item *AutomationItem, ctx *EvalContext) (bool, error) {
 
 // CompatibleConditions drops conditions that cannot apply to the trigger
 // (e.g. leftover friend_is after switching a rule to schedule.tick).
+// Always returns a non-nil slice so callers can json.Marshal to "[]" not "null".
 func CompatibleConditions(trigger string, conds []Condition) []Condition {
-	if len(conds) == 0 {
-		return conds
-	}
 	out := make([]Condition, 0, len(conds))
 	for _, c := range conds {
 		if c.Type == "friend_is" && trigger != EventFriendJoined {
@@ -69,6 +67,8 @@ func CompatibleConditions(trigger string, conds []Condition) []Condition {
 }
 
 // NextMinuteBoundary returns the start of the next wall-clock minute after now.
+// Truncate operates on the absolute instant; for minute resolution this matches
+// local clock minutes in every fixed-offset zone.
 func NextMinuteBoundary(now time.Time) time.Time {
 	return now.Truncate(ScheduleTickResolution).Add(ScheduleTickResolution)
 }

--- a/internal/domain/automation/evaluate_schedule_test.go
+++ b/internal/domain/automation/evaluate_schedule_test.go
@@ -1,0 +1,81 @@
+package automation
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestEvalItem_schedule_staleFriendIsIgnored(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.Local) // Friday
+	sched, err := json.Marshal(ScheduleRule{Weekdays: []int{5}, Hour: 12, Minute: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conds, err := json.Marshal([]Condition{{Type: "friend_is", VRCUserID: "usr_leftover"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := &AutomationItem{
+		ID:             "a",
+		Kind:           KindRule,
+		IsEnabled:      true,
+		TriggerType:    EventScheduleTick,
+		ScheduleJSON:   string(sched),
+		ConditionsJSON: string(conds),
+		ActionsJSON:    `[{"type":"change_status","payload":{"status":"busy"}}]`,
+	}
+	ok, err := EvalItem(item, &EvalContext{
+		TriggerType: EventScheduleTick,
+		Payload:     nil,
+		Now:         now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("stale friend_is on schedule.tick must not block evaluation")
+	}
+}
+
+func TestEvalItem_schedule_requiresOwnScheduleMatch(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.Local) // Friday 12:00
+	sched, err := json.Marshal(ScheduleRule{Weekdays: []int{5}, Hour: 18, Minute: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := &AutomationItem{
+		ID:           "late",
+		Kind:         KindRule,
+		IsEnabled:    true,
+		TriggerType:  EventScheduleTick,
+		ScheduleJSON: string(sched),
+		ActionsJSON:  `[{"type":"change_status","payload":{"status":"busy"}}]`,
+	}
+	ok, err := EvalItem(item, &EvalContext{
+		TriggerType: EventScheduleTick,
+		Now:         now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("item scheduled for 18:00 must not match 12:00 tick")
+	}
+}
+
+func TestParseSchedule_emptyWeekdaysRejected(t *testing.T) {
+	_, err := ParseSchedule(`{"weekdays":[],"hour":0,"minute":0}`)
+	if err == nil {
+		t.Fatal("empty weekdays must be rejected")
+	}
+}
+
+func TestNextMinuteBoundary(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 45, 0, time.Local)
+	got := NextMinuteBoundary(now)
+	want := time.Date(2026, 7, 24, 12, 1, 0, 0, time.Local)
+	if !got.Equal(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}

--- a/internal/domain/automation/evaluate_schedule_test.go
+++ b/internal/domain/automation/evaluate_schedule_test.go
@@ -79,3 +79,13 @@ func TestNextMinuteBoundary(t *testing.T) {
 		t.Fatalf("got %v want %v", got, want)
 	}
 }
+
+func TestCompatibleConditions_emptyIsNonNil(t *testing.T) {
+	got := CompatibleConditions(EventScheduleTick, nil)
+	if got == nil {
+		t.Fatal("want non-nil empty slice for json.Marshal to []")
+	}
+	if len(got) != 0 {
+		t.Fatalf("len=%d", len(got))
+	}
+}

--- a/internal/domain/automation/item.go
+++ b/internal/domain/automation/item.go
@@ -69,6 +69,9 @@ func (s ScheduleRule) Validate() error {
 	if s.Minute < 0 || s.Minute > 59 {
 		return fmt.Errorf("minute must be 0-59")
 	}
+	if len(s.Weekdays) == 0 {
+		return fmt.Errorf("weekdays required")
+	}
 	seen := make(map[int]struct{}, len(s.Weekdays))
 	for _, d := range s.Weekdays {
 		if d < 0 || d > 6 {

--- a/internal/domain/automation/rule_engine.go
+++ b/internal/domain/automation/rule_engine.go
@@ -3,6 +3,7 @@ package automation
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // EvalContext provides data for rule evaluation.
@@ -11,6 +12,7 @@ type EvalContext struct {
 	Payload         map[string]interface{}
 	VRChatRunning   bool
 	VRChatRunningOK bool
+	Now             time.Time // wall time for schedule matching; zero → time.Now
 }
 
 // EvalResult represents the outcome of rule evaluation.

--- a/internal/usecase/automation_engine.go
+++ b/internal/usecase/automation_engine.go
@@ -120,6 +120,10 @@ func (uc *AutomationUseCase) buildEvalContext(ctx context.Context, ev automation
 	ec := &automation.EvalContext{
 		TriggerType: ev.Type,
 		Payload:     ev.Payload,
+		Now:         ev.At,
+	}
+	if ec.Now.IsZero() {
+		ec.Now = time.Now()
 	}
 	if uc.procChecker != nil {
 		running, err := uc.procChecker.VRChatRunning()
@@ -343,26 +347,28 @@ func (uc *AutomationUseCase) appendRunLog(e automation.RunLogEntry) {
 
 func (uc *AutomationUseCase) schedulerLoop(ctx context.Context) {
 	defer uc.schedulerWG.Done()
-	ticker := time.NewTicker(automation.ScheduleTickResolution)
-	defer ticker.Stop()
 	var lastKey string
 	for {
+		now := time.Now()
+		next := automation.NextMinuteBoundary(now)
+		timer := time.NewTimer(time.Until(next))
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return
-		case t := <-ticker.C:
+		case <-timer.C:
 			func() {
 				defer func() {
 					if rec := recover(); rec != nil {
 						log.Printf("automation: scheduler panic: %v", rec)
 					}
 				}()
-				key := t.Format("2006-01-02T15:04")
+				key := next.Format("2006-01-02T15:04")
 				if key == lastKey {
 					return
 				}
 				lastKey = key
-				uc.fireScheduleTick(ctx, t)
+				uc.fireScheduleTick(ctx, next)
 			}()
 		}
 	}
@@ -383,8 +389,8 @@ func (uc *AutomationUseCase) fireScheduleTick(ctx context.Context, t time.Time) 
 			continue
 		}
 		if automation.ScheduleMatches(sched, t) {
-			// One schedule.tick per minute; handleEvent evaluates all matching items.
-			uc.PublishEvent(automation.Event{Type: automation.EventScheduleTick, Payload: nil})
+			// One schedule.tick per minute; handleEvent re-checks each item's schedule.
+			uc.PublishEvent(automation.Event{Type: automation.EventScheduleTick, At: t})
 			return
 		}
 	}

--- a/internal/usecase/automation_platform_test.go
+++ b/internal/usecase/automation_platform_test.go
@@ -140,6 +140,59 @@ func TestAutomation_schedule_wrongWeekday(t *testing.T) {
 	}
 }
 
+func TestAutomation_scheduleTick_runsMatchingRule(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.Local) // Friday
+	sched, err := json.Marshal(automation.ScheduleRule{Weekdays: []int{5}, Hour: 12, Minute: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conds, err := json.Marshal([]automation.Condition{{Type: "friend_is", VRCUserID: "usr_leftover"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := &mockAutomationItemRepo{}
+	repo.items = []*automation.AutomationItem{{
+		ID: "a", Name: "sched", Kind: automation.KindRule, IsEnabled: true,
+		TriggerType:    automation.EventScheduleTick,
+		ScheduleJSON:   string(sched),
+		ConditionsJSON: string(conds),
+		ActionsJSON:    `[{"type":"change_status","payload":{"status":"busy"}}]`,
+	}}
+	setter := &mockStatusSetter{}
+	uc := newTestAutomationUseCase(repo, setter)
+	uc.handleEvent(ctx, automation.Event{Type: automation.EventScheduleTick, At: now})
+	if got := setter.getCalled(); len(got) != 1 || got[0] != "busy" {
+		t.Fatalf("want [busy], got %v", got)
+	}
+}
+
+func TestAutomation_scheduleTick_skipsNonMatchingItem(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.Local)
+	matchSched, _ := json.Marshal(automation.ScheduleRule{Weekdays: []int{5}, Hour: 12, Minute: 0})
+	otherSched, _ := json.Marshal(automation.ScheduleRule{Weekdays: []int{5}, Hour: 18, Minute: 0})
+	repo := &mockAutomationItemRepo{}
+	repo.items = []*automation.AutomationItem{
+		{
+			ID: "noon", Name: "noon", Kind: automation.KindRule, IsEnabled: true,
+			TriggerType: automation.EventScheduleTick, ScheduleJSON: string(matchSched),
+			ActionsJSON: `[{"type":"change_status","payload":{"status":"busy"}}]`,
+		},
+		{
+			ID: "eve", Name: "eve", Kind: automation.KindRule, IsEnabled: true,
+			TriggerType: automation.EventScheduleTick, ScheduleJSON: string(otherSched),
+			ActionsJSON: `[{"type":"change_status","payload":{"status":"ask me"}}]`,
+		},
+	}
+	setter := &mockStatusSetter{}
+	uc := newTestAutomationUseCase(repo, setter)
+	uc.handleEvent(ctx, automation.Event{Type: automation.EventScheduleTick, At: now})
+	if got := setter.getCalled(); len(got) != 1 || got[0] != "busy" {
+		t.Fatalf("want only noon rule, got %v", got)
+	}
+}
+
 func mustParseSchedule(raw string) *automation.ScheduleRule {
 	s, err := automation.ParseSchedule(raw)
 	if err != nil {

--- a/internal/usecase/automation_platform_test.go
+++ b/internal/usecase/automation_platform_test.go
@@ -193,6 +193,28 @@ func TestAutomation_scheduleTick_skipsNonMatchingItem(t *testing.T) {
 	}
 }
 
+func TestAutomation_save_emptyConditionsJSONIsArray(t *testing.T) {
+	ctx := context.Background()
+	repo := &mockAutomationItemRepo{}
+	uc := newTestAutomationUseCase(repo, nil)
+	sched, err := json.Marshal(automation.ScheduleRule{Weekdays: []int{1}, Hour: 9, Minute: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := &automation.AutomationItem{
+		ID: "s1", Name: "sched", Kind: automation.KindRule, IsEnabled: true,
+		TriggerType:  automation.EventScheduleTick,
+		ScheduleJSON: string(sched),
+		ActionsJSON:  `[{"type":"change_status","payload":{"status":"busy"}}]`,
+	}
+	if err := uc.SaveItem(ctx, item); err != nil {
+		t.Fatal(err)
+	}
+	if item.ConditionsJSON != "[]" {
+		t.Fatalf("ConditionsJSON=%q, want []", item.ConditionsJSON)
+	}
+}
+
 func mustParseSchedule(raw string) *automation.ScheduleRule {
 	s, err := automation.ParseSchedule(raw)
 	if err != nil {

--- a/internal/usecase/automation_usecase.go
+++ b/internal/usecase/automation_usecase.go
@@ -135,7 +135,7 @@ func (uc *AutomationUseCase) GetItem(ctx context.Context, id string) (*automatio
 
 // SaveItem validates and persists an item.
 func (uc *AutomationUseCase) SaveItem(ctx context.Context, item *automation.AutomationItem) error {
-	if err := validateAutomationItem(item); err != nil {
+	if err := sanitizeAndValidateAutomationItem(item); err != nil {
 		return err
 	}
 	if item.ID == "" {
@@ -267,7 +267,9 @@ func itemToLegacyRule(item *automation.AutomationItem) *automation.AutomationRul
 	return r
 }
 
-func validateAutomationItem(item *automation.AutomationItem) error {
+// sanitizeAndValidateAutomationItem validates an item and normalizes fields
+// that must be consistent on disk (e.g. strips incompatible conditions).
+func sanitizeAndValidateAutomationItem(item *automation.AutomationItem) error {
 	if item == nil {
 		return ErrAutomationInvalidItem
 	}

--- a/internal/usecase/automation_usecase.go
+++ b/internal/usecase/automation_usecase.go
@@ -294,6 +294,13 @@ func validateAutomationItem(item *automation.AutomationItem) error {
 		if _, err := automation.ParseConditions(item.ConditionsJSON); err != nil {
 			return fmt.Errorf("%w: conditions: %v", ErrAutomationInvalidItem, err)
 		}
+		conds, _ := automation.ParseConditions(item.ConditionsJSON)
+		conds = automation.CompatibleConditions(item.TriggerType, conds)
+		b, err := json.Marshal(conds)
+		if err != nil {
+			return fmt.Errorf("%w: conditions: %v", ErrAutomationInvalidItem, err)
+		}
+		item.ConditionsJSON = string(b)
 		if _, err := automation.ParseActions(item.ActionsJSON); err != nil {
 			return fmt.Errorf("%w: actions: %v", ErrAutomationInvalidItem, err)
 		}

--- a/internal/usecase/automation_usecase.go
+++ b/internal/usecase/automation_usecase.go
@@ -291,10 +291,10 @@ func validateAutomationItem(item *automation.AutomationItem) error {
 				return fmt.Errorf("%w: %v", ErrAutomationInvalidItem, err)
 			}
 		}
-		if _, err := automation.ParseConditions(item.ConditionsJSON); err != nil {
+		conds, err := automation.ParseConditions(item.ConditionsJSON)
+		if err != nil {
 			return fmt.Errorf("%w: conditions: %v", ErrAutomationInvalidItem, err)
 		}
-		conds, _ := automation.ParseConditions(item.ConditionsJSON)
 		conds = automation.CompatibleConditions(item.TriggerType, conds)
 		b, err := json.Marshal(conds)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Schedule rules no longer keep a leftover friend-only condition after switching triggers, so `schedule.tick` can evaluate again.
- Each schedule item is matched against its own weekday/time; the scheduler wakes on wall-clock minute boundaries.
- Empty weekday lists are rejected on save; save path strips incompatible conditions from existing items.

## Test plan
- [ ] Create a rule as friend-joined, pick a friend, switch trigger to schedule, save, wait for the scheduled minute → run log shows the item
- [ ] Two schedule rules at different times: only the matching one runs at that minute
- [ ] Save a schedule rule with no weekdays selected → validation error
- [ ] `go test ./internal/domain/automation/ ./internal/usecase/`
- [ ] `cd frontend && pnpm exec vitest run src/views/__tests__/automationEditorMapping.spec.ts`


Made with [Cursor](https://cursor.com)