### PR TITLE
feat(activity): Encounter friend mark on Encounter log (#153)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -222,6 +222,10 @@ _Avoid_: 匿名ユーザー, 不明ユーザー（VRChat の匿名インスタ�
 Activity に並べる User encounter の時系列一覧。画面上の見出しは「遭遇ログ」。入室・退室・表示名・ワールド名の4列（インスタンス ID は含めない）。入室時刻の新しい順が既定。表示名での絞り込みと、ユーザー・ワールド別の深掘りへの導線を持つ。
 _Avoid_: 遭遇履歴（ユーザー／ワールド別の絞り込み画面全体を指す場合があるため）, ログ, タイムライン
 
+**Encounter friend mark**:
+Encounter log 上で、当該 User encounter の相手が **Encounter log の再取得時点**で Listable friend であることを示す印。遭遇当時のフレンド関係のスナップショットではない（解除後は過去行からも消え、後から Listable friend になった相手は過去行にも付く）。Friends 同期だけでは Encounter log を再取得せず、マークも更新しない。未ログイン・キャッシュ未同期・users_cache に行が無いとき、および判定不能のときは付かない。印は表示名テキストを書き換えない（列の表示名は User encounter＝ログ由来のまま）。表示名の左に固定幅のスロットを取り、非 Listable friend 行は空にして名前の左端を揃える。v1 では Encounter log のみ（Encounter history には付けない）。
+_Avoid_: フレンドマーク（Friends のお気に入り★と混同しやすいため）, 遭遇時フレンド（当時スナップショットを含意するため）, フレンドアイコン（表示形式の俗称）, リアルタイムフレンド印（Friends 同期即時反映を含意するため）
+
 **Display name filter**:
 Encounter log 上の唯一の絞り込み。表示名の部分一致のみ（クライアント側）。ワールドや期間での絞り込みは Encounter history 側に任せる。
 _Avoid_: 検索, フィルタ（Gallery の World search や Date range filter と混同しやすいため）

--- a/bindings.go
+++ b/bindings.go
@@ -155,6 +155,7 @@ type UserEncounterDTO struct {
 	UserFirstSeenAt   string `json:"userFirstSeenAt,omitempty"`
 	UserLastContactAt string `json:"userLastContactAt,omitempty"`
 	IsFirstEncounter  bool   `json:"isFirstEncounter"`
+	IsListableFriend  bool   `json:"isListableFriend"`
 	JoinedAt          string `json:"joinedAt"`
 	LeftAt            string `json:"leftAt,omitempty"`
 }
@@ -171,6 +172,7 @@ func toEncounterDTOsFromContext(list []*activity.EncounterWithContext) []UserEnc
 			WorldID:          e.WorldID,
 			WorldDisplayName: row.WorldDisplayName,
 			IsFirstEncounter: row.IsFirstEncounter,
+			IsListableFriend: row.IsListableFriend,
 			JoinedAt:         formatRFC3339(e.JoinedAt),
 		}
 		if e.LeftAt != nil {

--- a/frontend/src/components/VrcUserCacheDetail.stories.ts
+++ b/frontend/src/components/VrcUserCacheDetail.stories.ts
@@ -16,6 +16,7 @@ const storyEncounters: UserEncounterDTO[] = [
     joinedAt: "2026-01-15T12:00:00+09:00",
     leftAt: "2026-01-15T13:30:00+09:00",
     isFirstEncounter: false,
+    isListableFriend: true,
   },
 ];
 

--- a/frontend/src/components/__tests__/EncounterHistoryList.spec.ts
+++ b/frontend/src/components/__tests__/EncounterHistoryList.spec.ts
@@ -21,6 +21,7 @@ const sampleEncounter: UserEncounterDTO = {
   joinedAt: "2025-01-01T12:00:00Z",
   leftAt: "2025-01-01T13:00:00Z",
   isFirstEncounter: false,
+  isListableFriend: false,
 };
 
 describe("EncounterHistoryList", () => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -206,7 +206,8 @@
     "colJoin": "Joined",
     "colLeave": "Left",
     "colDisplayName": "Display name",
-    "colWorldName": "World name"
+    "colWorldName": "World name",
+    "friendMark": "Friend"
   },
   "encounterHistory": {
     "titleUser": "Encounters by user",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -206,7 +206,8 @@
     "colJoin": "入室",
     "colLeave": "退室",
     "colDisplayName": "表示名",
-    "colWorldName": "ワールド名"
+    "colWorldName": "ワールド名",
+    "friendMark": "フレンド"
   },
   "encounterHistory": {
     "titleUser": "ユーザー別 遭遇履歴",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -206,7 +206,8 @@
     "colJoin": "입장",
     "colLeave": "퇴장",
     "colDisplayName": "표시 이름",
-    "colWorldName": "월드 이름"
+    "colWorldName": "월드 이름",
+    "friendMark": "친구"
   },
   "encounterHistory": {
     "titleUser": "사용자별 조우 기록",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -206,7 +206,8 @@
     "colJoin": "进入",
     "colLeave": "离开",
     "colDisplayName": "显示名称",
-    "colWorldName": "世界名称"
+    "colWorldName": "世界名称",
+    "friendMark": "好友"
   },
   "encounterHistory": {
     "titleUser": "按用户的相遇记录",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -206,7 +206,8 @@
     "colJoin": "進入",
     "colLeave": "離開",
     "colDisplayName": "顯示名稱",
-    "colWorldName": "世界名稱"
+    "colWorldName": "世界名稱",
+    "friendMark": "好友"
   },
   "encounterHistory": {
     "titleUser": "依使用者的相遇紀錄",

--- a/frontend/src/stories/fixtures/encounters.ts
+++ b/frontend/src/stories/fixtures/encounters.ts
@@ -11,6 +11,19 @@ export const sampleActivityEncounters: UserEncounterDTO[] = [
     joinedAt: new Date(Date.now() - 3_600_000).toISOString(),
     leftAt: new Date(Date.now() - 1_800_000).toISOString(),
     isFirstEncounter: false,
+    isListableFriend: true,
+  },
+  {
+    id: "story-2",
+    vrcUserId: "usr_story_stranger",
+    displayName: "通りすがり",
+    instanceId: "inst_story",
+    worldId: "wrld_story",
+    worldDisplayName: "Sample World",
+    joinedAt: new Date(Date.now() - 7_200_000).toISOString(),
+    leftAt: new Date(Date.now() - 5_400_000).toISOString(),
+    isFirstEncounter: false,
+    isListableFriend: false,
   },
 ];
 
@@ -25,6 +38,7 @@ export const encounterByUserSample: UserEncounterDTO[] = [
     joinedAt: "2026-03-01T12:00:00+09:00",
     leftAt: "2026-03-01T13:00:00+09:00",
     isFirstEncounter: false,
+    isListableFriend: false,
   },
 ];
 
@@ -39,6 +53,7 @@ export const encounterByWorldSample: UserEncounterDTO[] = [
     joinedAt: "2026-03-02T09:00:00+09:00",
     leftAt: "2026-03-02T10:30:00+09:00",
     isFirstEncounter: false,
+    isListableFriend: false,
   },
 ];
 
@@ -53,5 +68,6 @@ export const userProfileEncounters: UserEncounterDTO[] = [
     joinedAt: "2026-02-01T10:00:00+09:00",
     leftAt: "2026-02-01T11:00:00+09:00",
     isFirstEncounter: false,
+    isListableFriend: false,
   },
 ];

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -64,18 +64,32 @@
             min-width="120"
           >
             <template #default="{ row }">
-              <el-button
-                v-if="row.vrcUserId"
-                link
-                type="primary"
-                class="timeline-link"
-                @click="openUserFromEncounter(row)"
-              >
-                {{ row.displayName }}
-              </el-button>
-              <span v-else class="timeline-name-muted">{{
-                row.displayName
-              }}</span>
+              <div class="encounter-name-cell">
+                <span class="encounter-friend-mark-slot">
+                  <el-icon
+                    v-if="row.isListableFriend"
+                    class="encounter-friend-mark"
+                    data-testid="encounter-friend-mark"
+                    role="img"
+                    :title="t('activity.friendMark')"
+                    :aria-label="t('activity.friendMark')"
+                  >
+                    <UserFilled />
+                  </el-icon>
+                </span>
+                <el-button
+                  v-if="row.vrcUserId"
+                  link
+                  type="primary"
+                  class="timeline-link"
+                  @click="openUserFromEncounter(row)"
+                >
+                  {{ row.displayName }}
+                </el-button>
+                <span v-else class="timeline-name-muted">{{
+                  row.displayName
+                }}</span>
+              </div>
             </template>
           </el-table-column>
           <el-table-column :label="t('activity.colWorldName')" min-width="120">
@@ -113,7 +127,7 @@
 </template>
 
 <script setup lang="ts">
-import { Search } from "@element-plus/icons-vue";
+import { Search, UserFilled } from "@element-plus/icons-vue";
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
@@ -443,9 +457,32 @@ onUnmounted(() => {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
+  min-width: 0;
 }
 
 .timeline-name-muted {
+  color: var(--text-secondary);
+}
+
+.encounter-name-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.encounter-friend-mark-slot {
+  flex: 0 0 12px;
+  width: 12px;
+  height: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.encounter-friend-mark {
+  font-size: 12px;
   color: var(--text-secondary);
 }
 </style>

--- a/frontend/src/views/__tests__/ActivityView.spec.ts
+++ b/frontend/src/views/__tests__/ActivityView.spec.ts
@@ -379,6 +379,44 @@ describe("ActivityView", () => {
     });
   });
 
+  it("shows encounter friend mark only for listable friends", async () => {
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "u1",
+        displayName: "FriendUser",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+        isListableFriend: true,
+      },
+      {
+        id: "2",
+        vrcUserId: "u2",
+        displayName: "Stranger",
+        instanceId: "inst",
+        joinedAt: "2024-01-02T12:00:00.000Z",
+        isListableFriend: false,
+      },
+      {
+        id: "3",
+        vrcUserId: "",
+        displayName: "Anonymous",
+        instanceId: "inst",
+        joinedAt: "2024-01-03T12:00:00.000Z",
+        isListableFriend: false,
+      },
+    ]);
+    const { wrapper } = await mountActivity();
+
+    const slots = wrapper.findAll(".encounter-friend-mark-slot");
+    expect(slots).toHaveLength(3);
+
+    const marks = wrapper.findAll('[data-testid="encounter-friend-mark"]');
+    expect(marks).toHaveLength(1);
+    expect(marks[0]!.attributes("aria-label")).toBe("フレンド");
+    expect(marks[0]!.attributes("title")).toBe("フレンド");
+  });
+
   it("loads encounters, stats, and retention days on mount", async () => {
     await mountActivity();
     expect(mockEncounters).toHaveBeenCalled();

--- a/frontend/src/views/__tests__/EncounterHistoryDetailView.spec.ts
+++ b/frontend/src/views/__tests__/EncounterHistoryDetailView.spec.ts
@@ -22,6 +22,7 @@ const sampleEncounter: UserEncounterDTO = {
   joinedAt: "2025-01-01T12:00:00Z",
   leftAt: "2025-01-01T13:00:00Z",
   isFirstEncounter: false,
+  isListableFriend: false,
 };
 
 describe("EncounterHistoryDetailView", () => {

--- a/internal/domain/activity/entity.go
+++ b/internal/domain/activity/entity.go
@@ -32,6 +32,8 @@ type EncounterWithContext struct {
 	UserFirstSeenAt   *time.Time
 	UserLastContactAt *time.Time
 	IsFirstEncounter  bool
+	// IsListableFriend is true when users_cache marks the user as a Listable friend at list time.
+	IsListableFriend bool
 }
 
 // EncounterFilter provides optional filtering for encounter list queries.

--- a/internal/infrastructure/sqlite/activity_repo.go
+++ b/internal/infrastructure/sqlite/activity_repo.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"vrchat-tweaker/internal/domain/activity"
+	"vrchat-tweaker/internal/domain/identity"
 )
 
 // PlaySessionRepository persists play sessions in SQLite.
@@ -233,7 +234,7 @@ func (r *UserEncounterRepository) List(ctx context.Context, filter *activity.Enc
 // ListWithContext returns encounters with world display name and user cache timestamps.
 func (r *UserEncounterRepository) ListWithContext(ctx context.Context, filter *activity.EncounterFilter) ([]*activity.EncounterWithContext, error) {
 	query := `SELECT e.id, e.vrc_user_id, e.display_name, e.instance_id, e.world_id, e.joined_at, e.left_at, IFNULL(e.log_source_path, ''),
-		w.display_name, u.first_seen_at, u.last_contact_at
+		w.display_name, u.first_seen_at, u.last_contact_at, u.user_kind, u.display_name
 		FROM user_encounters e
 		LEFT JOIN world_info w ON w.world_id = e.world_id
 		LEFT JOIN users_cache u ON u.vrc_user_id = e.vrc_user_id
@@ -607,9 +608,9 @@ func buildUserEncounter(id, vrcUserID, displayName string, instanceID, worldID s
 func scanEncounterWithContextRow(rows *sql.Rows) (*activity.EncounterWithContext, error) {
 	var id, vrcUserID, displayName, joinedAtStr, logSource string
 	var instanceID, worldID, leftAt sql.NullString
-	var worldDN, firstSeen, lastContact sql.NullString
+	var worldDN, firstSeen, lastContact, userKind, cacheDisplayName sql.NullString
 	if err := rows.Scan(&id, &vrcUserID, &displayName, &instanceID, &worldID, &joinedAtStr, &leftAt, &logSource,
-		&worldDN, &firstSeen, &lastContact); err != nil {
+		&worldDN, &firstSeen, &lastContact, &userKind, &cacheDisplayName); err != nil {
 		return nil, err
 	}
 	jt, _ := time.Parse(time.RFC3339, joinedAtStr)
@@ -658,5 +659,13 @@ func scanEncounterWithContextRow(rows *sql.Rows) (*activity.EncounterWithContext
 			out.IsFirstEncounter = true
 		}
 	}
+	cache := &identity.UserCache{}
+	if userKind.Valid {
+		cache.UserKind = identity.UserKind(userKind.String)
+	}
+	if cacheDisplayName.Valid {
+		cache.DisplayName = cacheDisplayName.String
+	}
+	out.IsListableFriend = identity.IsListableFriend(cache)
 	return out, nil
 }

--- a/internal/infrastructure/sqlite/user_encounter_repository_test.go
+++ b/internal/infrastructure/sqlite/user_encounter_repository_test.go
@@ -319,6 +319,77 @@ func TestUserEncounterRepository_ListWithContext_joinsWorldAndUserCache(t *testi
 	if !row.IsFirstEncounter {
 		t.Fatal("expected IsFirstEncounter")
 	}
+	if !row.IsListableFriend {
+		t.Fatal("expected IsListableFriend for user_kind=friend with display name")
+	}
+}
+
+func TestUserEncounterRepository_ListWithContext_isListableFriend(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if schemaErr := applySchema(db); schemaErr != nil {
+		t.Fatal(schemaErr)
+	}
+
+	userRepo := NewUserCacheRepository(db)
+	encRepo := NewUserEncounterRepository(db)
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	if saveErr := userRepo.Save(ctx, &identity.UserCache{
+		VRCUserID: "usr_friend", DisplayName: "FriendName", Status: "active",
+		UserKind: identity.UserKindFriend, LastUpdated: t0,
+	}); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	if saveErr := userRepo.Save(ctx, &identity.UserCache{
+		VRCUserID: "usr_contact", DisplayName: "ContactName", Status: "active",
+		UserKind: identity.UserKindContact, LastUpdated: t0,
+	}); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	if saveErr := userRepo.Save(ctx, &identity.UserCache{
+		VRCUserID: "usr_empty_friend", DisplayName: "   ", Status: "active",
+		UserKind: identity.UserKindFriend, LastUpdated: t0,
+	}); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+
+	cases := []struct {
+		id, vrcUserID, displayName string
+		want                       bool
+	}{
+		{"enc_friend", "usr_friend", "FriendName", true},
+		{"enc_contact", "usr_contact", "ContactName", false},
+		{"enc_empty", "usr_empty_friend", "LoggedName", false},
+		{"enc_miss", "usr_missing", "NoCache", false},
+	}
+	for _, tc := range cases {
+		if encErr := encRepo.Save(ctx, &activity.UserEncounter{
+			ID: tc.id, VRCUserID: tc.vrcUserID, DisplayName: tc.displayName,
+			InstanceID: "i", WorldID: "w", JoinedAt: t0,
+		}); encErr != nil {
+			t.Fatal(encErr)
+		}
+	}
+
+	list, err := encRepo.ListWithContext(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, row := range list {
+		got[row.Encounter.ID] = row.IsListableFriend
+	}
+	for _, tc := range cases {
+		if got[tc.id] != tc.want {
+			t.Errorf("%s: IsListableFriend=%v, want %v", tc.id, got[tc.id], tc.want)
+		}
+	}
 }
 
 func TestUserEncounterRepository_ListWithContext_firstEncounterWithinOneSecond(t *testing.T) {


### PR DESCRIPTION
## Summary
- Encounter log で、再取得時点の **Listable friend** に **Encounter friend mark**（`UserFilled`）を表示する（#153）
- 共有 DTO に `isListableFriend` を追加。Encounter history にはフィールドが届くが UI では出さない
- 全行固定幅スロットで名前の左端を揃え、印があるときだけ a11y ラベルを付ける

## Test plan
- [ ] `make test` / `make lint`（ローカルで実施済み）
- [ ] Activity の Encounter log で Listable friend 行にのみマークが出る
- [ ] 非 Listable friend / `vrcUserId` なしはアイコンなし（空スロットで左端揃え）
- [ ] ホバー／スクリーンリーダーで「フレンド」相当ラベル
- [ ] Encounter history 側にマークが出ない
- [ ] Storybook `ActivityView` / WithSampleData で混在表示を確認


Made with [Cursor](https://cursor.com)