### PR TITLE
feat(video): yt-dlp 置換と Cookie を実験的機能1カードにまとめる (#220)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -426,9 +426,17 @@ _Avoid_: バッジ, タグ一覧（行全体のラベル付きセクションと
 
 ## yt-dlp
 
-VRChat の動画プレイヤーが裏で使う yt-dlp 向けの用語。**yt-dlp Tools replace maintain**（[Issue #9](https://github.com/JO3QMA/vrctweaker/issues/9)、[ADR 0008](docs/adr/0008-ytdlp-tools-replace-maintain.md)）は Accepted・製品実装済み。**yt-dlp Cookie linkage**（[Issue #8](https://github.com/JO3QMA/vrctweaker/issues/8)、[ADR 0007](docs/adr/0007-ytdlp-cookie-linkage.md)）は Accepted・製品実装済み（制限付き再生には Official yt-dlp cache 経由が前提。同梱版単体では Cookie オプション非対応）。起動前ワンショットの直置き試作は [PR #40](https://github.com/JO3QMA/vrctweaker/pull/40)（望む動作に未達）。
+VRChat の動画プレイヤーが裏で使う yt-dlp 向けの用語。**yt-dlp Tools replace maintain**（[Issue #9](https://github.com/JO3QMA/vrctweaker/issues/9)、[ADR 0008](docs/adr/0008-ytdlp-tools-replace-maintain.md)）は Accepted・製品実装済み。**yt-dlp Cookie linkage**（[Issue #8](https://github.com/JO3QMA/vrctweaker/issues/8)、[ADR 0007](docs/adr/0007-ytdlp-cookie-linkage.md)）は Accepted・製品実装済み（制限付き再生には Official yt-dlp cache 経由が前提。同梱版単体では Cookie オプション非対応）。起動前ワンショットの直置き試作は [PR #40](https://github.com/JO3QMA/vrctweaker/pull/40)（望む動作に未達）。動画タブ上の両機能の UI 括りは **yt-dlp experimental features**（[Issue #220](https://github.com/JO3QMA/vrctweaker/issues/220)。用語・レイアウト合意は本 CONTEXT。新規 ADR は作らない）。
 
 ### Language
+
+**yt-dlp experimental features**:
+動画タブ上で **yt-dlp Tools replace maintain** と **yt-dlp Cookie linkage** をまとめる 1 つの UI カード（外側のみ `el-card`。内側はネストしたカードにせず、`<section>` ＋小見出しで区切る）。外側の見出しは日本語「yt-dlp (実験的機能)」／英語 `yt-dlp (Experimental features)`（他ロケールも同趣旨）。カード内は上から **置換（小見出し: 日本語「yt-dlp の置換」／英語 `yt-dlp replacement`）→ Cookie（小見出し: 日本語「Cookie を利用する」／英語 `Use cookies`）** の順。置換ブロックのスイッチ横には機能名ラベル（旧 `replaceLabel`＝「yt-dlp の置換」）を出さない（小見出しと重複させない。effective 状態表示は残す）。初期ロードはブロック単位: 置換の loading は置換ブロックだけを覆い、Cookie は独立に取得・表示する（カード全体の共通 loading や API 結合はしない）。旧カード見出し「yt-dlp を置き換える」「yt-dlp Cookie 連携」／英語旧 `Replace yt-dlp`・`yt-dlp Cookie linkage` は使わない。表示条件は現状どおり: 外側カードは動画タブで常に出し、置換ブロックは非対応時も警告を示し、Cookie ブロックは対応環境（または操作エラー表示が必要なとき）だけ出す。各ブロック直下の常時警告（置換の公式差し替え非推奨文・Cookie の BAN／捨て垢文）は統合せず現状どおり残す。各機能の意味・操作・risk acknowledgment・effective state・**Cookie linkage official hint** の振る舞いは変えない（レイアウトと小見出し文言の直し）。
+_Avoid_: 実験的機能（単独・対象が曖昧なため）, yt-dlp section（実験性を落とすため）, Settings / Config（載せない）, yt-dlp を置き換える / yt-dlp Cookie 連携（旧小見出し）, Cookie を上・置換を下（official hint の「上の」前提が崩れるため）, 内側のネスト `el-card`（二重枠）, 両方未対応で外側ごと隠す（置換の非対応案内が消えるため）, カード先頭への警告統合（機能別リスクが曖昧になるため）, 小見出しとスイッチ横の「yt-dlp の置換」二重表示, 外側カード全体を置換 loading で隠す（Cookie 表示を遅らせるため）
+
+**yt-dlp experimental features v1 scope**:
+[Issue #220](https://github.com/JO3QMA/vrctweaker/issues/220) で届ける範囲。動画タブの **yt-dlp experimental features** 1 カード化（小見出し・i18n・hint 呼び揃え・スイッチ横機能名ラベル削除・Vitest／Storybook／E2E 追随・死キー整理）に限定する。v1 では含めないもの: Go／usecase／Wails 契約の変更、risk acknowledgment や effective state の意味変更、Settings／Config への移設、常時警告の統合、loading／API の共通化、機能の追加・削除、新規 ADR、ADR 0007／0008 の製品方針書き換え。
+_Avoid_: yt-dlp experimental features（v1 範囲を指すときは scope とセットで書く）, 将来拡張（スコープ外リストの総称として曖昧なため）
 
 **VRChat-bundled yt-dlp**:
 VRChat が Tools 配下に置く yt-dlp 実行ファイル。公式 yt-dlp を削った／独自オプション付きのビルドであり、調査時点では `--cookies` / `--cookies-from-browser` を受け付けない。起動やログインの過程で Tools 上の差し替えを同梱版へ戻しうることがある。
@@ -459,8 +467,8 @@ Tweaker が yt-dlp user config へ Cookie 参照オプションを書き込み�
 _Avoid_: Cookie 同期, ログイン連携（VRChat 認証と混同しやすいため）, yt-dlp 実行, Config（VRChat config.json 編集と混同しやすいため）, yt-dlp Tools replace / maintain（別問題）, Settings（Cookie は載せない）
 
 **Cookie linkage official hint**:
-Cookie linkage の UI 上で、Tools replace effective state が偽のときに出す案内。Official（Cookie 対応）exe が Tools から参照されていないと制限付き再生の目的を満たせない旨と、同一画面の Tools replace 操作への案内。有効化や yt-dlp user config への書き込みは妨げない。
-_Avoid_: 必須ゲート, maintain 必須（ハード依存を連想させるため）, Cookie linkage risk acknowledgment（BAN 警告とは別）
+Cookie linkage の UI 上で、Tools replace effective state が偽のときに出す案内。Official（Cookie 対応）exe が Tools から参照されていないと制限付き再生の目的を満たせない旨と、同一 **yt-dlp experimental features** カード内の置換ブロック（小見出し「yt-dlp の置換」／英語 `yt-dlp replacement`）への案内。有効化や yt-dlp user config への書き込みは妨げない。hint 文言内の呼び方は当該小見出しに揃える（英語旧 `Tools replace` 呼びは使わない）。
+_Avoid_: 必須ゲート, maintain 必須（ハード依存を連想させるため）, Cookie linkage risk acknowledgment（BAN 警告とは別）, Tools replace（hint 内の旧呼び）
 
 **yt-dlp user config**:
 yt-dlp が読むユーザー向け設定ファイル。Cookie 参照オプションの置き場。Windows での書き込み正本は `%APPDATA%\yt-dlp\config`（拡張子なし）。`config` が無く `%APPDATA%\yt-dlp\config.txt` だけがあるときは、そのファイルを Effective／upsert の対象とする（新規作成時は常に `config`）。VRChat の `config.json`（Config 画面の対象）とは別物。無ければ親ディレクトリごと作成してよい。Managed cookie options 削除後に他行が無く空ならファイル自体を削除してよい。

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -29,6 +29,7 @@ test.describe("VRChat Tweaker", () => {
     await page.goto("/");
     await page.getByRole("menuitem", { name: "動画" }).click();
     await expect(page.locator("h1")).toContainText("動画");
+    await expect(page.getByTestId("ytdlp-experimental-features")).toBeVisible();
     await expect(page.getByTestId("ytdlp-maintain-switch")).toBeVisible();
   });
 

--- a/frontend/src/components/CookieLinkageSection.vue
+++ b/frontend/src/components/CookieLinkageSection.vue
@@ -1,7 +1,7 @@
 <template>
   <section
     v-if="cookieSupported || cookieActionError"
-    class="cookie-section video-block"
+    class="cookie-section"
     data-testid="video-cookie-linkage"
     :aria-labelledby="cookieSupported ? 'ytdlp-cookie-heading' : undefined"
   >

--- a/frontend/src/components/CookieLinkageSection.vue
+++ b/frontend/src/components/CookieLinkageSection.vue
@@ -1,8 +1,9 @@
 <template>
-  <div
+  <section
     v-if="cookieSupported || cookieActionError"
-    class="cookie-section"
+    class="cookie-section video-block"
     data-testid="video-cookie-linkage"
+    :aria-labelledby="cookieSupported ? 'ytdlp-cookie-heading' : undefined"
   >
     <el-alert
       v-if="cookieActionError"
@@ -12,10 +13,10 @@
       show-icon
       class="cookie-action-error"
     />
-    <el-card v-if="cookieSupported" class="cookie-card" shadow="never">
-      <template #header>
-        <span>{{ t("video.cookieLinkage.section") }}</span>
-      </template>
+    <template v-if="cookieSupported">
+      <h2 id="ytdlp-cookie-heading" class="video-block-title">
+        {{ t("video.cookieLinkage.section") }}
+      </h2>
       <el-alert
         type="warning"
         :closable="false"
@@ -104,8 +105,8 @@
           </div>
         </el-form-item>
       </el-form>
-    </el-card>
-  </div>
+    </template>
+  </section>
 </template>
 
 <script setup lang="ts">
@@ -321,11 +322,15 @@ onMounted(async () => {
 
 <style scoped>
 .cookie-section {
-  margin-top: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
   width: 100%;
 }
-.cookie-card {
-  width: 100%;
+.video-block-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
 }
 .cookie-always-warn,
 .cookie-official-hint,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -899,11 +899,10 @@
   },
   "video": {
     "title": "Video",
-    "maintainSection": "Replace yt-dlp",
+    "experimentalFeatures": "yt-dlp (Experimental features)",
     "unsupported": "Not available in this environment.",
     "alwaysWarn": "Replacing VRChat’s bundled yt-dlp with the official yt-dlp build may be unsupported by VRChat. Enable at your own risk. This feature may require Windows Developer Mode or running as administrator.",
     "replaceLabel": "yt-dlp replacement",
-    "switchOff": "OFF",
     "statusPrefix": "Status: ",
     "effectiveOfficial": "Using official yt-dlp latest",
     "effectiveBundled": "VRChat bundled build",
@@ -941,9 +940,9 @@
       "notInitialized": "Video settings are not initialized yet."
     },
     "cookieLinkage": {
-      "section": "yt-dlp Cookie linkage",
+      "section": "Use cookies",
       "alwaysWarn": "Automated access may risk account restrictions under YouTube and similar ToS. Always use a throwaway (sub) account in the browser you select.",
-      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable Tools replace above.",
+      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable yt-dlp replacement above.",
       "unsupportedForm": "yt-dlp config has an unsupported Cookie form. Choosing an option below and saving replaces it with a simple setting.",
       "enableLabel": "Link browser login cookies to yt-dlp",
       "lockHint": "With browser source, an open browser may lock the cookie store. Close the browser or use a cookies file instead.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -899,11 +899,10 @@
   },
   "video": {
     "title": "動画",
-    "maintainSection": "yt-dlp を置き換える",
+    "experimentalFeatures": "yt-dlp (実験的機能)",
     "unsupported": "この環境では利用できません。",
     "alwaysWarn": "yt-dlp 公式最新版への差し替えは VRChat 非推奨の可能性があります。自己責任で有効化してください。この機能には Windows の開発者モード、または管理者権限が必要な場合があります。",
     "replaceLabel": "yt-dlp の置換",
-    "switchOff": "OFF",
     "statusPrefix": "状態: ",
     "effectiveOfficial": "yt-dlp 公式最新版を使用中",
     "effectiveBundled": "VRChat 同梱版",
@@ -941,7 +940,7 @@
       "notInitialized": "動画設定がまだ初期化されていません。"
     },
     "cookieLinkage": {
-      "section": "yt-dlp Cookie 連携",
+      "section": "Cookie を利用する",
       "alwaysWarn": "YouTube などの規約上、自動ツールからのアクセスでアカウントが制限されるリスクがあります。必ず捨て垢（サブアカウント）でログインしたブラウザを指定してください。",
       "officialHint": "Tools 上の yt-dlp が公式版を指していないと、制限付き動画の再生には効かないことがあります。上の「yt-dlp の置換」を有効にしてください。",
       "unsupportedForm": "config に未対応の Cookie 指定があります。下の方式を選んで保存すると、単純な設定に置き換えます。",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -899,11 +899,10 @@
   },
   "video": {
     "title": "비디오",
-    "maintainSection": "yt-dlp 바꾸기",
+    "experimentalFeatures": "yt-dlp (실험적 기능)",
     "unsupported": "Not available in this environment.",
     "alwaysWarn": "Replacing VRChat’s bundled yt-dlp with the official yt-dlp build may be unsupported by VRChat. Enable at your own risk. This feature may require Windows Developer Mode or running as administrator.",
     "replaceLabel": "yt-dlp 치환",
-    "switchOff": "OFF",
     "statusPrefix": "Status: ",
     "effectiveOfficial": "Using official yt-dlp latest",
     "effectiveBundled": "VRChat bundled build",
@@ -941,9 +940,9 @@
       "notInitialized": "Video settings are not initialized yet."
     },
     "cookieLinkage": {
-      "section": "yt-dlp Cookie linkage",
+      "section": "Cookie 사용",
       "alwaysWarn": "Automated access may risk account restrictions under YouTube and similar ToS. Always use a throwaway (sub) account in the browser you select.",
-      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable Tools replace above.",
+      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable yt-dlp replacement above.",
       "unsupportedForm": "yt-dlp config has an unsupported Cookie form. Choosing a option below and saving replaces it with a simple setting.",
       "enableLabel": "Link browser login cookies to yt-dlp",
       "lockHint": "With browser source, an open browser may lock the cookie store. Close the browser or use a cookies file instead.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -899,11 +899,10 @@
   },
   "video": {
     "title": "视频",
-    "maintainSection": "替换 yt-dlp",
+    "experimentalFeatures": "yt-dlp（实验性功能）",
     "unsupported": "Not available in this environment.",
     "alwaysWarn": "Replacing VRChat’s bundled yt-dlp with the official yt-dlp build may be unsupported by VRChat. Enable at your own risk. This feature may require Windows Developer Mode or running as administrator.",
     "replaceLabel": "yt-dlp 替换",
-    "switchOff": "OFF",
     "statusPrefix": "Status: ",
     "effectiveOfficial": "Using official yt-dlp latest",
     "effectiveBundled": "VRChat bundled build",
@@ -941,9 +940,9 @@
       "notInitialized": "Video settings are not initialized yet."
     },
     "cookieLinkage": {
-      "section": "yt-dlp Cookie linkage",
+      "section": "使用 Cookie",
       "alwaysWarn": "Automated access may risk account restrictions under YouTube and similar ToS. Always use a throwaway (sub) account in the browser you select.",
-      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable Tools replace above.",
+      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable yt-dlp replacement above.",
       "unsupportedForm": "yt-dlp config has an unsupported Cookie form. Choosing a option below and saving replaces it with a simple setting.",
       "enableLabel": "Link browser login cookies to yt-dlp",
       "lockHint": "With browser source, an open browser may lock the cookie store. Close the browser or use a cookies file instead.",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -899,11 +899,10 @@
   },
   "video": {
     "title": "影片",
-    "maintainSection": "取代 yt-dlp",
+    "experimentalFeatures": "yt-dlp（實驗性功能）",
     "unsupported": "Not available in this environment.",
     "alwaysWarn": "Replacing VRChat’s bundled yt-dlp with the official yt-dlp build may be unsupported by VRChat. Enable at your own risk. This feature may require Windows Developer Mode or running as administrator.",
     "replaceLabel": "yt-dlp 取代",
-    "switchOff": "OFF",
     "statusPrefix": "Status: ",
     "effectiveOfficial": "Using official yt-dlp latest",
     "effectiveBundled": "VRChat bundled build",
@@ -941,9 +940,9 @@
       "notInitialized": "Video settings are not initialized yet."
     },
     "cookieLinkage": {
-      "section": "yt-dlp Cookie linkage",
+      "section": "使用 Cookie",
       "alwaysWarn": "Automated access may risk account restrictions under YouTube and similar ToS. Always use a throwaway (sub) account in the browser you select.",
-      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable Tools replace above.",
+      "officialHint": "Cookie options may not help age-restricted playback unless Tools points at official yt-dlp. Enable yt-dlp replacement above.",
       "unsupportedForm": "yt-dlp config has an unsupported Cookie form. Choosing a option below and saving replaces it with a simple setting.",
       "enableLabel": "Link browser login cookies to yt-dlp",
       "lockHint": "With browser source, an open browser may lock the cookie store. Close the browser or use a cookies file instead.",

--- a/frontend/src/views/VideoView.vue
+++ b/frontend/src/views/VideoView.vue
@@ -12,7 +12,6 @@
       </template>
 
       <section
-        class="video-block"
         data-testid="ytdlp-replace-section"
         aria-labelledby="ytdlp-replace-heading"
       >

--- a/frontend/src/views/VideoView.vue
+++ b/frontend/src/views/VideoView.vue
@@ -2,155 +2,171 @@
   <div class="video-view">
     <h1 class="page-title">{{ t("video.title") }}</h1>
 
-    <el-card class="video-card" shadow="never">
+    <el-card
+      class="video-card"
+      shadow="never"
+      data-testid="ytdlp-experimental-features"
+    >
       <template #header>
-        <span>{{ t("video.maintainSection") }}</span>
+        <span>{{ t("video.experimentalFeatures") }}</span>
       </template>
 
-      <div v-if="loading" class="muted">{{ t("common.loading") }}</div>
-      <template v-else>
-        <!-- 1. 注意・エラー（タイトル直下・1箇所） -->
-        <div class="video-alerts" data-testid="ytdlp-alert-area">
-          <el-alert
-            v-if="actionError"
-            type="error"
-            :closable="false"
-            show-icon
-            class="block-hint"
-            data-testid="ytdlp-error-banner"
-            :title="actionError"
-          />
-          <el-alert
-            v-else-if="!status.supported"
-            type="warning"
-            :closable="false"
-            show-icon
-            :title="userFacingReason(status.unsupportedReason ?? '')"
-          />
-          <template v-else>
+      <section
+        class="video-block"
+        data-testid="ytdlp-replace-section"
+        aria-labelledby="ytdlp-replace-heading"
+      >
+        <h2 id="ytdlp-replace-heading" class="video-block-title">
+          {{ t("video.replaceLabel") }}
+        </h2>
+
+        <div v-if="loading" class="muted">{{ t("common.loading") }}</div>
+        <template v-else>
+          <!-- 1. 注意・エラー（置換ブロック直下・1箇所） -->
+          <div class="video-alerts" data-testid="ytdlp-alert-area">
             <el-alert
-              type="warning"
-              :closable="false"
-              show-icon
-              class="block-hint"
-              :title="t('video.alwaysWarn')"
-            />
-            <el-alert
-              v-if="bannerError"
+              v-if="actionError"
               type="error"
               :closable="false"
               show-icon
               class="block-hint"
               data-testid="ytdlp-error-banner"
-              :title="bannerError"
+              :title="actionError"
             />
-          </template>
-        </div>
-
-        <template v-if="status.supported">
-          <!-- 2. 操作エリア -->
-          <section class="video-ops" data-testid="ytdlp-ops">
-            <div class="video-switch-row">
-              <span class="switch-label">{{ t("video.replaceLabel") }}</span>
-              <el-switch
-                v-model="maintainOn"
-                data-testid="ytdlp-maintain-switch"
-                :disabled="busy"
-                @change="onMaintainChange"
+            <el-alert
+              v-else-if="!status.supported"
+              type="warning"
+              :closable="false"
+              show-icon
+              :title="userFacingReason(status.unsupportedReason ?? '')"
+            />
+            <template v-else>
+              <el-alert
+                type="warning"
+                :closable="false"
+                show-icon
+                class="block-hint"
+                :title="t('video.alwaysWarn')"
               />
-              <span class="switch-status" data-testid="ytdlp-effective-inline">
-                {{ t("video.statusPrefix") }}{{ effectiveStatusText }}
-              </span>
-            </div>
+              <el-alert
+                v-if="bannerError"
+                type="error"
+                :closable="false"
+                show-icon
+                class="block-hint"
+                data-testid="ytdlp-error-banner"
+                :title="bannerError"
+              />
+            </template>
+          </div>
 
-            <div class="video-actions" data-testid="ytdlp-action-grid">
-              <el-button
-                data-testid="ytdlp-check-latest"
-                :loading="checkLoading"
-                :disabled="busy"
-                @click="checkLatest"
-              >
-                {{ t("video.checkLatest") }}
-              </el-button>
-              <el-button
-                type="primary"
-                data-testid="ytdlp-update-cache"
-                :loading="updateLoading"
-                :disabled="busy"
-                @click="updateCache"
-              >
-                {{ t("video.updateCache") }}
-              </el-button>
-              <el-button
-                data-testid="ytdlp-open-cache-folder"
-                :disabled="busy"
-                @click="openCacheFolder"
-              >
-                <el-icon class="btn-icon"><FolderOpened /></el-icon>
-                {{ t("video.openCacheFolder") }}
-              </el-button>
-              <el-button
-                data-testid="ytdlp-open-tools-folder"
-                :disabled="busy"
-                @click="openToolsFolder"
-              >
-                <el-icon class="btn-icon"><FolderOpened /></el-icon>
-                {{ t("video.openToolsFolder") }}
-              </el-button>
-            </div>
+          <template v-if="status.supported">
+            <!-- 2. 操作エリア -->
+            <section class="video-ops" data-testid="ytdlp-ops">
+              <div class="video-switch-row">
+                <el-switch
+                  v-model="maintainOn"
+                  data-testid="ytdlp-maintain-switch"
+                  :disabled="busy"
+                  @change="onMaintainChange"
+                />
+                <span
+                  class="switch-status"
+                  data-testid="ytdlp-effective-inline"
+                >
+                  {{ t("video.statusPrefix") }}{{ effectiveStatusText }}
+                </span>
+              </div>
 
-            <p
-              v-if="flashOk"
-              class="flash flash-ok"
-              data-testid="ytdlp-flash-ok"
-            >
-              {{ flashOk }}
-            </p>
-          </section>
+              <div class="video-actions" data-testid="ytdlp-action-grid">
+                <el-button
+                  data-testid="ytdlp-check-latest"
+                  :loading="checkLoading"
+                  :disabled="busy"
+                  @click="checkLatest"
+                >
+                  {{ t("video.checkLatest") }}
+                </el-button>
+                <el-button
+                  type="primary"
+                  data-testid="ytdlp-update-cache"
+                  :loading="updateLoading"
+                  :disabled="busy"
+                  @click="updateCache"
+                >
+                  {{ t("video.updateCache") }}
+                </el-button>
+                <el-button
+                  data-testid="ytdlp-open-cache-folder"
+                  :disabled="busy"
+                  @click="openCacheFolder"
+                >
+                  <el-icon class="btn-icon"><FolderOpened /></el-icon>
+                  {{ t("video.openCacheFolder") }}
+                </el-button>
+                <el-button
+                  data-testid="ytdlp-open-tools-folder"
+                  :disabled="busy"
+                  @click="openToolsFolder"
+                >
+                  <el-icon class="btn-icon"><FolderOpened /></el-icon>
+                  {{ t("video.openToolsFolder") }}
+                </el-button>
+              </div>
 
-          <!-- 3. 詳細（バージョンのみ・初期は折りたたみ） -->
-          <section class="video-status" data-testid="ytdlp-status">
-            <button
-              type="button"
-              class="details-toggle"
-              data-testid="ytdlp-details-toggle"
-              :aria-expanded="detailsExpanded"
-              :aria-controls="detailsPanelId"
-              @click="detailsExpanded = !detailsExpanded"
-            >
-              <el-icon class="details-toggle-icon" aria-hidden="true">
-                <CaretBottom v-if="detailsExpanded" />
-                <CaretRight v-else />
-              </el-icon>
-              <span>{{ t("video.detailsToggle") }}</span>
-            </button>
-            <div
-              v-show="detailsExpanded"
-              :id="detailsPanelId"
-              class="details-panel"
-              role="region"
-            >
-              <dl class="video-dl">
-                <dt>{{ t("video.cacheVersion") }}</dt>
-                <dd data-testid="ytdlp-cache-version">
-                  {{ status.cacheVersion || t("video.cacheMissing") }}
-                </dd>
-                <dt>{{ t("video.latest") }}</dt>
-                <dd data-testid="ytdlp-latest-version">
-                  {{
-                    status.latestVersion
-                      ? status.latestVersion
-                      : t("video.latestUnchecked")
-                  }}
-                </dd>
-              </dl>
-            </div>
-          </section>
+              <p
+                v-if="flashOk"
+                class="flash flash-ok"
+                data-testid="ytdlp-flash-ok"
+              >
+                {{ flashOk }}
+              </p>
+            </section>
+
+            <!-- 3. 詳細（バージョンのみ・初期は折りたたみ） -->
+            <section class="video-status" data-testid="ytdlp-status">
+              <button
+                type="button"
+                class="details-toggle"
+                data-testid="ytdlp-details-toggle"
+                :aria-expanded="detailsExpanded"
+                :aria-controls="detailsPanelId"
+                @click="detailsExpanded = !detailsExpanded"
+              >
+                <el-icon class="details-toggle-icon" aria-hidden="true">
+                  <CaretBottom v-if="detailsExpanded" />
+                  <CaretRight v-else />
+                </el-icon>
+                <span>{{ t("video.detailsToggle") }}</span>
+              </button>
+              <div
+                v-show="detailsExpanded"
+                :id="detailsPanelId"
+                class="details-panel"
+                role="region"
+              >
+                <dl class="video-dl">
+                  <dt>{{ t("video.cacheVersion") }}</dt>
+                  <dd data-testid="ytdlp-cache-version">
+                    {{ status.cacheVersion || t("video.cacheMissing") }}
+                  </dd>
+                  <dt>{{ t("video.latest") }}</dt>
+                  <dd data-testid="ytdlp-latest-version">
+                    {{
+                      status.latestVersion
+                        ? status.latestVersion
+                        : t("video.latestUnchecked")
+                    }}
+                  </dd>
+                </dl>
+              </div>
+            </section>
+          </template>
         </template>
-      </template>
-    </el-card>
+      </section>
 
-    <CookieLinkageSection />
+      <CookieLinkageSection />
+    </el-card>
   </div>
 </template>
 
@@ -459,6 +475,11 @@ onMounted(() => {
   margin-top: 1rem;
   width: 100%;
 }
+.video-block-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
 .video-alerts {
   margin-bottom: 1rem;
 }
@@ -474,9 +495,6 @@ onMounted(() => {
   align-items: center;
   gap: 0.75rem 1rem;
   margin-bottom: 1rem;
-}
-.switch-label {
-  font-weight: 600;
 }
 .switch-status {
   color: var(--text-secondary);

--- a/frontend/src/views/__tests__/VideoView.spec.ts
+++ b/frontend/src/views/__tests__/VideoView.spec.ts
@@ -81,6 +81,36 @@ describe("VideoView", () => {
     });
   }
 
+  it("groups replace and cookie under one experimental features card", async () => {
+    vi.mocked(App.getYTDLPCookieLinkageStatus).mockResolvedValue({
+      supported: true,
+      enabled: false,
+      sourceKind: "",
+      riskAcknowledged: false,
+      browser: "chrome",
+    });
+    const wrapper = mountView();
+    await flushPromises();
+    const card = wrapper.get('[data-testid="ytdlp-experimental-features"]');
+    expect(card.text()).toContain("yt-dlp (実験的機能)");
+    expect(card.text()).toContain("yt-dlp の置換");
+    expect(card.text()).toContain("Cookie を利用する");
+    expect(card.find('[data-testid="ytdlp-replace-section"]').exists()).toBe(
+      true,
+    );
+    expect(card.find('[data-testid="video-cookie-linkage"]').exists()).toBe(
+      true,
+    );
+    // One outer card only (no nested el-card for cookie)
+    expect(wrapper.findAll(".el-card").length).toBe(1);
+    expect(wrapper.get("#ytdlp-replace-heading").text()).toBe("yt-dlp の置換");
+    expect(wrapper.get("#ytdlp-cookie-heading").text()).toBe(
+      "Cookie を利用する",
+    );
+    // No switch-side feature name label (hint may still mention 置換)
+    expect(wrapper.find(".switch-label").exists()).toBe(false);
+  });
+
   it("loads without paths, ON/OFF labels, or duplicate detail rows", async () => {
     const wrapper = mountView();
     await flushPromises();
@@ -98,6 +128,8 @@ describe("VideoView", () => {
       wrapper.find('[data-testid="ytdlp-cache-version"]').isVisible(),
     ).toBe(false);
     expect(wrapper.text()).not.toContain("置き換え設定");
+    expect(wrapper.text()).not.toContain("yt-dlp を置き換える");
+    expect(wrapper.text()).not.toContain("yt-dlp Cookie 連携");
   });
 
   it("uses a 2x2 action grid", async () => {


### PR DESCRIPTION
## Summary
- 動画タブの **yt-dlp Tools replace maintain** と **yt-dlp Cookie linkage** を、外側1枚の **yt-dlp experimental features** カードにまとめる（Issue #220）
- 小見出しを「yt-dlp の置換」／「Cookie を利用する」（EN: `yt-dlp replacement` / `Use cookies`）に揃え、置換スイッチ横の機能名ラベルは削除
- Cookie linkage official hint の呼びを小見出しに揃え、振る舞い（risk ack / effective / loading 分離）は変更しない
- `CONTEXT.md` に用語・v1 scope を追記（新規 ADR なし）

## Test plan
- [ ] 動画タブで外側カード見出しが「yt-dlp (実験的機能)」であること
- [ ] カード内が上から置換 → Cookie の順で、ネストした `el-card` が無いこと
- [ ] 置換の常時警告・Cookie の常時警告が各ブロック直下に残ること
- [ ] Tools が Official でないとき、Cookie の official hint が「上の『yt-dlp の置換』」案内になること
- [ ] 非対応環境でも外側カードと置換の非対応案内が出ること／Cookie は未対応なら非表示
- [ ] `pnpm run test`（VideoView）と `make test-e2e`（video 遷移）が通ること

Closes #220


Made with [Cursor](https://cursor.com)