### PR TITLE
feat(frontend): VtButton design system (ADR 0017)

### DIFF
--- a/.cursor/rules/button-design-system.mdc
+++ b/.cursor/rules/button-design-system.mdc
@@ -1,0 +1,51 @@
+---
+description: VtButton 4 variant ボタンデザインシステム（ADR 0017）。新規・改修で触った画面は VtButton を使う
+globs: "frontend/**/*.{vue,ts}"
+alwaysApply: false
+---
+
+# Button design system (VtButton)
+
+正本: [ADR 0017](../docs/adr/0017-button-design-system-vtbutton.md)、用語: [`CONTEXT.md`](../CONTEXT.md) Design system 節。
+
+## 使うもの
+
+- 画面の操作ボタン: **`VtButton`**（`frontend/src/components/VtButton.vue`）
+- **`variant` は必須**: `primary` | `secondary` | `tertiary` | `danger`
+- `disabled` / `loading` / `size` / `data-testid` 等はそのまま渡す（透過）
+- Danger + 同一 Action group に Primary があるときだけ `plain`（例: ログアウト）
+
+## variant の意味
+
+| variant | いつ | Element Plus 内部 |
+|---------|------|-------------------|
+| `primary` | Action group の主操作（**1 つだけ**） | `type="primary"` |
+| `secondary` | 起動・更新・複製・参照・非破棄キャンセル | 無指定（中立塗り） |
+| `tertiary` | 再読み込み・パネル閉じ・下書き行の除去 | `text` |
+| `danger` | 永続データの破壊・破壊確認の OK | `type="danger"`（`plain` 可） |
+
+## 状態
+
+- **disabled**: 様式ではない。`:disabled="true"`
+- **loading**: 押したボタンのみ `:loading="true"`
+
+## 例外（VtButton にしない）
+
+- **Semantic button**: Presence 色ボタンなど色がドメイン意味を持つ UI
+- **`ElMessageBox`**: `frontend/src/components/vtButtonClasses.ts` の定数を使う
+  - `VT_BUTTON_DANGER_CONFIRM_CLASS` — 破壊確認 OK
+  - `VT_BUTTON_SECONDARY_CANCEL_CLASS` — キャンセル（空 = 既定 Secondary 見た目）
+
+## 移行
+
+- 新規・改修で触ったファイルは **VtButton** へ。未触りの `el-button` 直書きは一括置換しない
+- ESLint 禁止は v1 では入れない
+
+## Storybook
+
+`VtButton.stories.ts` が見た目の正本。変更時はストーリーも更新する。
+
+## 関連
+
+- Element Plus 一般: `.cursor/rules/element-plus-ui.mdc`
+- Storybook: `.cursor/rules/storybook-wails-ui.mdc`

--- a/.cursor/rules/element-plus-ui.mdc
+++ b/.cursor/rules/element-plus-ui.mdc
@@ -15,6 +15,7 @@ alwaysApply: false
 ## 実装の指針
 
 - ボタン・フォーム・ダイアログ・テーブル・タグなどは **Element Plus コンポーネントを優先**し、素の HTML で同等物を作らない（デザインと挙動の一貫性のため）。
+- **操作ボタン**は **`VtButton`** を使う（`.cursor/rules/button-design-system.mdc`、ADR 0017）。`el-button` 直書きは移行期のみ併存可。
 - 仕様・props・スロットは **[Element Plus 公式ドキュメント](https://element-plus.org/)** を正とする（バージョンは `frontend/package.json` の依存に合わせる）。
 
 ## DOM とセレクタ（テスト・E2E）

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -690,6 +690,68 @@ _Avoid_: Activity ログ, output_log（遭遇ログや生ログと混同しや�
 Automation が評価・実行される前提条件。v1 では **VRCTweaker プロセスが起動している間のみ**有効（トレイ常駐を含む）。OS サービスやスケジューラ単体でのバックグラウンド実行は v1 スコープ外とし、UI では起動中のみ有効である旨を示す。将来のサービス化は別判断。
 _Avoid_: 常時実行, バックグラウンドサービス（v1 で含意しないため）, Tweaker 終了後も動く（誤期待を招くため）
 
+## Design system
+
+ボタン様式などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。実装契約は ADR を正本とする。色コード・個別 props など実装詳細はここに書かない。
+
+### Language
+
+**VtButton**:
+VRCTweaker の標準操作ボタンコンポーネント。画面に置く **Primary / Secondary / Tertiary / Danger** は VtButton の `variant` で指定する（**必須**。省略時の暗黙既定は持たない）。`el-button` の直接利用は新規・改修時に VtButton へ寄せる。**Semantic button** は VtButton の variant に含めない（専用 UI を別に持つ）。
+_Avoid_: ボタン（`<button>` 素要素や `el-button` 直呼びと混同しやすいため）, Button component（汎用 React/Vue の俗称）
+
+**Button variant**:
+VtButton で選ぶ 4 様式のいずれか: `primary` / `secondary` / `tertiary` / `danger`。**Primary button** 等の用語と 1 対 1 で対応する。
+_Avoid_: type（Element Plus の `type` prop と混同しやすいため）, スタイル（CSS クラスだけを指す印象）
+
+**VtButton adoption**:
+VtButton への移行方針。新規画面・改修で触ったファイルでは **VtButton を使う**。**Semantic button** は専用 UI のまま移行対象外。未着手の既存 `el-button` 直書きは一括置換しない（触ったところから順次）。遵守は `.cursor/rules/` で案内し、移行期は ESLint では強制しない。見た目の正本は **VtButton Storybook catalog**。
+_Avoid_: 全面置換, el-button 禁止（即時一括・CI 強制を含意するため）
+
+**VtButton Storybook catalog**:
+VtButton の Storybook 一覧。4 **Button variant** それぞれについて通常・**Button disabled state**・**Button loading state** を載せ、Action group の並び例（例: Primary + Secondary、Danger 確認 + Secondary キャンセル）も 1 ストーリー以上含める。
+_Avoid_: ボタン一覧（Semantic button を含意しうるため）, 全画面 Storybook（コンポーネントカタログに限定）
+
+**Dialog confirm button**:
+`ElMessageBox` 等、テンプレートに **VtButton** を置けない確認ダイアログのボタン。**Danger button** / **Secondary button** の見た目に、VtButton 実装と共有する class 定数で揃える。**VtButton adoption** の対象外。
+_Avoid_: モーダルボタン（将来の自作ダイアログ置換を含意しうるため）, MessageBox（実装 API 名だけを指す印象）
+
+**Action group**:
+画面上でひとまとまりに並ぶ操作ボタンの群。ダイアログのフッター、フォーム下部のボタン列、ツールバー、カード内のアクション行など。**Primary button** の「高々 1 つ」は Action group 単位で数える。
+_Avoid_: 画面全体, ツールバー（Action group の一例に過ぎないため）
+
+**Primary button**:
+Action group 内で主として進めたい操作を示すボタン様式。同一 Action group には高々 1 つだけ置く。見た目は強調色の塗り。
+_Avoid_: メインボタン（色だけを指す印象）, CTA（マーケ用語）
+
+**Secondary button**:
+Action group 内の実行操作を示すボタン様式。Primary より優先度は低いが、押すと状態が変わる・処理が走る操作に使う（起動、更新、複製、参照、編集を破棄しないキャンセルなど）。見た目は中立色の塗り。
+_Avoid_: サブボタン（見た目だけを指す印象）, デフォルトボタン（実装語）
+
+**Tertiary button**:
+補助・低優先の操作を示すボタン様式。テキストリンクに近い軽さでよい。一覧内の軽操作、ログの再読み込み、編集パネルを閉じるだけの操作、**Draft row removal** など。**Danger button** に当たる削除は含めない。見た目は背景なし（テキストリンクに近い）。
+_Avoid_: ゴーストボタン（見た目だけを指す印象）, リンク（`router-link` や `<a>` と混同しやすいため）
+
+**Danger button**:
+**永続データ**に対する取り消しが難しい破壊操作を示すボタン様式。プロファイル削除、ルール削除、ログアウト、キャッシュ全消去、DB クリアなど。破壊を主目的とする確認ダイアログでは、確認側を Danger としキャンセルを Secondary とする。その Action group には **Primary button** を置かない（Danger が強調）。見た目は警告色の塗り。同一 Action group に **Primary button** があるときは枠線のみの弱い強調も可。
+_Avoid_: 警告ボタン（非破壊の注意喚起と混同しやすいため）, 赤ボタン（色だけを指す印象）
+
+**Draft row removal**:
+保存前の下書き（フォーム編集中の一覧行など）から 1 行を外す操作。永続ストアからはまだ消えない。**Tertiary button** でよい。確認ダイアログは原則不要。
+_Avoid_: 削除（**Danger button** の永続削除と混同しやすいため）, 行削除（永続か下書きかが分からないため）
+
+**Button disabled state**:
+操作できない／させたくないボタンに付ける状態。ボタン様式（Primary / Secondary / Tertiary / Danger）ではなく、いずれの様式にも重ねる。実装では標準の `disabled` 属性（または同等）で表す。未ログイン、変更なし、対象なしなど。無効理由はラベル・ツールチップ・周辺文言で伝える。
+_Avoid_: Disabled ボタン（第 5 の様式名）, Disabled 様式
+
+**Button loading state**:
+非同期処理中に、**押したボタンだけ**に付ける一時状態。処理完了までそのボタンは操作できなくなる（**Button disabled state** と同型の扱い）。別様式にはしない。Action group 内の他ボタンまで一括で無効化するのは原則としない。
+_Avoid_: Loading ボタン（様式名）, 画面全体ロック（ボタン状態の話と混同しやすいため）
+
+**Semantic button**:
+色や形状そのものがドメイン上の意味を伝えるボタン。4 様式（Primary / Secondary / Tertiary / Danger）の配置ルールは当てはめない。**Button disabled state** とアクセシビリティ（ラベル・`aria-label` 等）は当てはめる。例: **Presence change section** のプレゼンス色ボタン（Join Me / Active / Ask Me / Busy）。お気に入りトグルやアイコンのみの追加ボタンは Semantic button にせず、Tertiary または Secondary に寄せる。
+_Avoid_: カラーボタン（装飾だけを指す印象）, 例外ボタン（ルール逃れの総称）
+
 ## Agent contribution
 
 Issue・PR・コミットなど Git に残るテキストを書くときの用語。

--- a/docs/adr/0017-button-design-system-vtbutton.md
+++ b/docs/adr/0017-button-design-system-vtbutton.md
@@ -1,0 +1,106 @@
+# ADR 0017: Button design system (VtButton)
+
+## Status
+
+Accepted（grill-with-docs で合意）
+
+## Context
+
+- 画面ごとに `el-button` の `type` / `plain` / `text` の使い方がばらつき、主操作・破壊操作・補助操作の優先度が読み取りにくい
+- Element Plus は `primary` / `danger` / `text` 等の見た目 API を持つが、**意味論（いつどれを使うか）**はフレームワークが規定しない
+- ダークテーマの中立塗り・disabled トークンは `frontend/src/assets/style.css` で既に定義済み
+- **Presence change section** のプレゼンス色ボタンなど、色そのものがドメイン意味を持つ UI は 4 様式の対象外にすべき
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Design system** セクション（**Primary button**、**VtButton**、**Semantic button** 等）を正本とする。
+
+## Decision
+
+### 1. 4 様式 + 状態
+
+| 概念 | 役割 |
+|------|------|
+| **Primary** | Action group 内の主操作（**高々 1 つ**） |
+| **Secondary** | 実行操作（起動・更新・複製・参照・編集を破棄しないキャンセル） |
+| **Tertiary** | 補助・低優先（再読み込み、パネル閉じ、**Draft row removal**） |
+| **Danger** | **永続データ**の破壊操作。破壊確認ダイアログでは確認 = Danger、キャンセル = Secondary。**Primary は置かない** |
+| **disabled** | 様式ではない状態。標準の `disabled`（または同等） |
+| **loading** | 押したボタンだけに付ける一時状態（実質 disabled） |
+
+### 2. VtButton コンポーネント
+
+- 新規: `frontend/src/components/VtButton.vue`
+- **`variant` は必須**: `'primary' | 'secondary' | 'tertiary' | 'danger'`（暗黙既定なし）
+- 内部は `el-button` をラップ。`disabled`・`loading`・`size`・`data-testid` 等は **透過**（`$attrs` / `inheritAttrs`）
+- 画面テンプレートでは **VtButton を使う**。`el-button` 直書きは **VtButton adoption**（触ったところから順次）まで併存可
+- **ESLint による `el-button` 禁止は v1 では入れない**。遵守は `.cursor/rules/` で案内
+
+### 3. Element Plus マッピング（実装正本）
+
+| `variant` | `el-button` 相当 |
+|-----------|------------------|
+| `primary` | `type="primary"` |
+| `secondary` | 無指定（中立色塗り。`style.css` の既定） |
+| `tertiary` | `text` |
+| `danger` | `type="danger"` |
+| `danger`（弱い強調） | `type="danger"` + `plain` — **同一 Action group に Primary があるときのみ**（例: Settings のログアウト） |
+
+`VtButton` は上記以外の `type`（`success` / `warning` / `info`）を **公開しない**。
+
+### 4. 例外
+
+| 種別 | 扱い |
+|------|------|
+| **Semantic button** | VtButton の variant に含めない。専用 UI（例: Presence 色ボタン）。disabled と a11y ラベルは適用 |
+| **Dialog confirm button** | `ElMessageBox` 等は VtButton 非対応。class 定数で Danger / Secondary 見た目を共有（下記） |
+| お気に入り★・`+` アイコン追加 | Semantic 例外にせず **Tertiary** または **Secondary** |
+
+### 5. MessageBox class 定数
+
+`VtButton.vue` と同ディレクトリ（または隣接モジュール）に export する:
+
+- `VT_BUTTON_DANGER_CONFIRM_CLASS` → 破壊確認の OK（`el-button--danger` 相当）
+- `VT_BUTTON_SECONDARY_CANCEL_CLASS` → キャンセル（中立塗り相当。必要なら `plain` 併用をここで固定）
+
+既存の `confirmButtonClass: "el-button--danger"` は定数へ寄せる（全面置換は adoption 方針に従い触ったファイルから）。
+
+### 6. Storybook
+
+- `frontend/src/components/VtButton.stories.ts`
+- **VtButton Storybook catalog**: 4 variant ×（通常 / disabled / loading）+ Action group 並び例ストーリー
+- 見た目の正本は Storybook（`.cursor/rules/storybook-wails-ui.mdc` に従う）
+
+### 7. Agent / 実装ルール
+
+- `.cursor/rules/` にボタン規約を追記（`element-plus-ui.mdc` 拡張または `button-design-system.mdc` 新設）
+- マッピング表・例外・MessageBox 定数・adoption 方針を記載
+
+## Considered options
+
+| 案 | 却下理由 |
+|----|----------|
+| `el-button` 規約のみ（ラッパーなし） | variant 必須・マッピングの強制力が弱く、画面追加のたびに `type` / `plain` / `text` の誤用が再発しやすい |
+| 一括 `el-button` → VtButton 移行 | リグレッションリスクと PR スコープが大きい |
+| 移行期から ESLint 禁止 | 未移行の既存 `el-button` と矛盾し CI が常時赤になる |
+
+## v1 scope
+
+**含む:**
+
+- `VtButton.vue` + 単体テスト + Storybook catalog
+- MessageBox 用 class 定数
+- `.cursor/rules/` 更新
+- `CONTEXT.md` / 本 ADR
+
+**含まない:**
+
+- 全画面の一括置換
+- ESLint `el-button` 禁止
+- `VtConfirmDialog` による MessageBox 置換
+- `success` / `warning` / `info` variant の追加
+- Semantic button の VtButton 統合
+
+## Consequences
+
+- 新規・改修 PR では VtButton + 必須 `variant` が期待される
+- 破壊確認は引き続き `ElMessageBox` だが、class は定数経由で VtButton と揃える
+- Presence 色など Semantic UI は現行コンポーネントを維持

--- a/frontend/src/components/PresenceChangeSection.vue
+++ b/frontend/src/components/PresenceChangeSection.vue
@@ -26,13 +26,14 @@
       <p class="presence-change-error-text">
         {{ t("dashboard.presenceChange.loadError") }}
       </p>
-      <el-button
+      <VtButton
+        variant="secondary"
         size="small"
         data-testid="presence-change-retry"
         @click="retryLoad"
       >
         {{ t("dashboard.presenceChange.retry") }}
-      </el-button>
+      </VtButton>
     </div>
 
     <template v-else>
@@ -84,8 +85,8 @@
           :disabled="!loggedIn || applying"
           @select="onDescriptionSelect"
         />
-        <el-button
-          type="primary"
+        <VtButton
+          variant="primary"
           class="presence-apply-btn"
           data-testid="presence-change-apply"
           :disabled="!loggedIn || !isDirty || applying"
@@ -93,7 +94,7 @@
           @click="applyPresenceChange"
         >
           {{ t("dashboard.presenceChange.apply") }}
-        </el-button>
+        </VtButton>
       </div>
     </template>
   </el-card>
@@ -107,6 +108,7 @@ import { App, type PresenceChangeSectionDTO } from "../wails/app";
 import { getRuntime } from "../wails/runtime";
 import { formatError } from "../utils/formatError";
 import { useSessionUnlock } from "../composables/useSessionUnlock";
+import VtButton from "./VtButton.vue";
 
 const SELF_CACHE_CHANGED_DEBOUNCE_MS = 300;
 

--- a/frontend/src/components/VtButton.stories.css
+++ b/frontend/src/components/VtButton.stories.css
@@ -1,0 +1,18 @@
+.vt-button-story-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.vt-button-story-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.vt-button-story-actions-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}

--- a/frontend/src/components/VtButton.stories.ts
+++ b/frontend/src/components/VtButton.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import VtButton from "./VtButton.vue";
+import { VT_BUTTON_VARIANTS, type VtButtonProps } from "./vtButtonVariants";
 import "./VtButton.stories.css";
 
 const catalogParameters = {
@@ -16,7 +17,7 @@ const meta = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["primary", "secondary", "tertiary", "danger"],
+      options: [...VT_BUTTON_VARIANTS],
     },
     plain: { control: "boolean" },
   },
@@ -25,50 +26,25 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
-  args: { variant: "primary" },
-  render: (args) => ({
-    components: { VtButton },
-    setup: () => ({ args }),
-    template: `<VtButton v-bind="args">Primary</VtButton>`,
-  }),
-};
+function variantStory(label: string, args: VtButtonProps): Story {
+  return {
+    args,
+    render: (storyArgs) => ({
+      components: { VtButton },
+      setup: () => ({ args: storyArgs }),
+      template: `<VtButton v-bind="args">${label}</VtButton>`,
+    }),
+  };
+}
 
-export const Secondary: Story = {
-  args: { variant: "secondary" },
-  render: (args) => ({
-    components: { VtButton },
-    setup: () => ({ args }),
-    template: `<VtButton v-bind="args">Secondary</VtButton>`,
-  }),
-};
-
-export const Tertiary: Story = {
-  args: { variant: "tertiary" },
-  render: (args) => ({
-    components: { VtButton },
-    setup: () => ({ args }),
-    template: `<VtButton v-bind="args">Tertiary</VtButton>`,
-  }),
-};
-
-export const Danger: Story = {
-  args: { variant: "danger" },
-  render: (args) => ({
-    components: { VtButton },
-    setup: () => ({ args }),
-    template: `<VtButton v-bind="args">Danger</VtButton>`,
-  }),
-};
-
-export const DangerPlain: Story = {
-  args: { variant: "danger", plain: true },
-  render: (args) => ({
-    components: { VtButton },
-    setup: () => ({ args }),
-    template: `<VtButton v-bind="args">Danger plain</VtButton>`,
-  }),
-};
+export const Primary = variantStory("Primary", { variant: "primary" });
+export const Secondary = variantStory("Secondary", { variant: "secondary" });
+export const Tertiary = variantStory("Tertiary", { variant: "tertiary" });
+export const Danger = variantStory("Danger", { variant: "danger" });
+export const DangerPlain = variantStory("Danger plain", {
+  variant: "danger",
+  plain: true,
+});
 
 export const DisabledStates: Story = {
   parameters: catalogParameters,

--- a/frontend/src/components/VtButton.stories.ts
+++ b/frontend/src/components/VtButton.stories.ts
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import VtButton from "./VtButton.vue";
+import "./VtButton.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
 
 const meta = {
   title: "Components/VtButton",
@@ -66,11 +71,11 @@ export const DangerPlain: Story = {
 };
 
 export const DisabledStates: Story = {
-  args: { variant: "primary" },
+  parameters: catalogParameters,
   render: () => ({
     components: { VtButton },
     template: `
-      <div style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center;">
+      <div class="vt-button-story-row">
         <VtButton variant="primary" disabled>Primary</VtButton>
         <VtButton variant="secondary" disabled>Secondary</VtButton>
         <VtButton variant="tertiary" disabled>Tertiary</VtButton>
@@ -81,11 +86,11 @@ export const DisabledStates: Story = {
 };
 
 export const LoadingStates: Story = {
-  args: { variant: "primary" },
+  parameters: catalogParameters,
   render: () => ({
     components: { VtButton },
     template: `
-      <div style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center;">
+      <div class="vt-button-story-row">
         <VtButton variant="primary" loading>Primary</VtButton>
         <VtButton variant="secondary" loading>Secondary</VtButton>
         <VtButton variant="tertiary" loading>Tertiary</VtButton>
@@ -97,11 +102,11 @@ export const LoadingStates: Story = {
 
 export const ActionGroupPrimarySecondary: Story = {
   name: "Action group: Primary + Secondary",
-  args: { variant: "primary" },
+  parameters: catalogParameters,
   render: () => ({
     components: { VtButton },
     template: `
-      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+      <div class="vt-button-story-actions">
         <VtButton variant="secondary">Launch</VtButton>
         <VtButton variant="primary">Save</VtButton>
       </div>
@@ -111,11 +116,11 @@ export const ActionGroupPrimarySecondary: Story = {
 
 export const ActionGroupDangerConfirm: Story = {
   name: "Action group: Danger confirm + Secondary cancel",
-  args: { variant: "danger" },
+  parameters: catalogParameters,
   render: () => ({
     components: { VtButton },
     template: `
-      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+      <div class="vt-button-story-actions">
         <VtButton variant="secondary">Cancel</VtButton>
         <VtButton variant="danger">Delete</VtButton>
       </div>
@@ -125,11 +130,11 @@ export const ActionGroupDangerConfirm: Story = {
 
 export const ActionGroupPrimaryDangerPlain: Story = {
   name: "Action group: Primary + Danger plain",
-  args: { variant: "primary" },
+  parameters: catalogParameters,
   render: () => ({
     components: { VtButton },
     template: `
-      <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+      <div class="vt-button-story-actions-wrap">
         <VtButton variant="primary">Refresh profile</VtButton>
         <VtButton variant="danger" plain>Logout</VtButton>
       </div>

--- a/frontend/src/components/VtButton.stories.ts
+++ b/frontend/src/components/VtButton.stories.ts
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import VtButton from "./VtButton.vue";
+
+const meta = {
+  title: "Components/VtButton",
+  component: VtButton,
+  tags: ["autodocs"],
+  args: {
+    variant: "primary",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary", "tertiary", "danger"],
+    },
+    plain: { control: "boolean" },
+  },
+} satisfies Meta<typeof VtButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { variant: "primary" },
+  render: (args) => ({
+    components: { VtButton },
+    setup: () => ({ args }),
+    template: `<VtButton v-bind="args">Primary</VtButton>`,
+  }),
+};
+
+export const Secondary: Story = {
+  args: { variant: "secondary" },
+  render: (args) => ({
+    components: { VtButton },
+    setup: () => ({ args }),
+    template: `<VtButton v-bind="args">Secondary</VtButton>`,
+  }),
+};
+
+export const Tertiary: Story = {
+  args: { variant: "tertiary" },
+  render: (args) => ({
+    components: { VtButton },
+    setup: () => ({ args }),
+    template: `<VtButton v-bind="args">Tertiary</VtButton>`,
+  }),
+};
+
+export const Danger: Story = {
+  args: { variant: "danger" },
+  render: (args) => ({
+    components: { VtButton },
+    setup: () => ({ args }),
+    template: `<VtButton v-bind="args">Danger</VtButton>`,
+  }),
+};
+
+export const DangerPlain: Story = {
+  args: { variant: "danger", plain: true },
+  render: (args) => ({
+    components: { VtButton },
+    setup: () => ({ args }),
+    template: `<VtButton v-bind="args">Danger plain</VtButton>`,
+  }),
+};
+
+export const DisabledStates: Story = {
+  args: { variant: "primary" },
+  render: () => ({
+    components: { VtButton },
+    template: `
+      <div style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center;">
+        <VtButton variant="primary" disabled>Primary</VtButton>
+        <VtButton variant="secondary" disabled>Secondary</VtButton>
+        <VtButton variant="tertiary" disabled>Tertiary</VtButton>
+        <VtButton variant="danger" disabled>Danger</VtButton>
+      </div>
+    `,
+  }),
+};
+
+export const LoadingStates: Story = {
+  args: { variant: "primary" },
+  render: () => ({
+    components: { VtButton },
+    template: `
+      <div style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center;">
+        <VtButton variant="primary" loading>Primary</VtButton>
+        <VtButton variant="secondary" loading>Secondary</VtButton>
+        <VtButton variant="tertiary" loading>Tertiary</VtButton>
+        <VtButton variant="danger" loading>Danger</VtButton>
+      </div>
+    `,
+  }),
+};
+
+export const ActionGroupPrimarySecondary: Story = {
+  name: "Action group: Primary + Secondary",
+  args: { variant: "primary" },
+  render: () => ({
+    components: { VtButton },
+    template: `
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <VtButton variant="secondary">Launch</VtButton>
+        <VtButton variant="primary">Save</VtButton>
+      </div>
+    `,
+  }),
+};
+
+export const ActionGroupDangerConfirm: Story = {
+  name: "Action group: Danger confirm + Secondary cancel",
+  args: { variant: "danger" },
+  render: () => ({
+    components: { VtButton },
+    template: `
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <VtButton variant="secondary">Cancel</VtButton>
+        <VtButton variant="danger">Delete</VtButton>
+      </div>
+    `,
+  }),
+};
+
+export const ActionGroupPrimaryDangerPlain: Story = {
+  name: "Action group: Primary + Danger plain",
+  args: { variant: "primary" },
+  render: () => ({
+    components: { VtButton },
+    template: `
+      <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+        <VtButton variant="primary">Refresh profile</VtButton>
+        <VtButton variant="danger" plain>Logout</VtButton>
+      </div>
+    `,
+  }),
+};

--- a/frontend/src/components/VtButton.vue
+++ b/frontend/src/components/VtButton.vue
@@ -3,11 +3,15 @@ import { computed } from "vue";
 
 export type VtButtonVariant = "primary" | "secondary" | "tertiary" | "danger";
 
-const props = defineProps<{
-  variant: VtButtonVariant;
-  /** Danger only: outline when a Primary button is in the same action group. */
-  plain?: boolean;
-}>();
+export type VtButtonProps =
+  | { variant: "primary" | "secondary" | "tertiary" }
+  | {
+      variant: "danger";
+      /** Outline when a Primary button is in the same action group. */
+      plain?: boolean;
+    };
+
+const props = defineProps<VtButtonProps>();
 
 defineOptions({
   inheritAttrs: false,

--- a/frontend/src/components/VtButton.vue
+++ b/frontend/src/components/VtButton.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+export type VtButtonVariant = "primary" | "secondary" | "tertiary" | "danger";
+
+const props = defineProps<{
+  variant: VtButtonVariant;
+  /** Danger only: outline when a Primary button is in the same action group. */
+  plain?: boolean;
+}>();
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const buttonType = computed(() => {
+  if (props.variant === "primary") return "primary";
+  if (props.variant === "danger") return "danger";
+  return undefined;
+});
+
+const isText = computed(() => props.variant === "tertiary");
+
+const isPlain = computed(
+  () => props.variant === "danger" && props.plain === true,
+);
+</script>
+
+<template>
+  <el-button v-bind="$attrs" :type="buttonType" :text="isText" :plain="isPlain">
+    <slot />
+  </el-button>
+</template>

--- a/frontend/src/components/VtButton.vue
+++ b/frontend/src/components/VtButton.vue
@@ -1,15 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-
-export type VtButtonVariant = "primary" | "secondary" | "tertiary" | "danger";
-
-export type VtButtonProps =
-  | { variant: "primary" | "secondary" | "tertiary" }
-  | {
-      variant: "danger";
-      /** Outline when a Primary button is in the same action group. */
-      plain?: boolean;
-    };
+import type { VtButtonProps } from "./vtButtonVariants";
 
 const props = defineProps<VtButtonProps>();
 

--- a/frontend/src/components/__tests__/VtButton.spec.ts
+++ b/frontend/src/components/__tests__/VtButton.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import VtButton from "../VtButton.vue";
+
+describe("VtButton", () => {
+  it("maps primary variant to el-button--primary", () => {
+    const wrapper = mount(VtButton, {
+      props: { variant: "primary" },
+      slots: { default: "Save" },
+    });
+    expect(wrapper.find(".el-button--primary").exists()).toBe(true);
+    expect(wrapper.find(".is-text").exists()).toBe(false);
+  });
+
+  it("maps secondary variant to default filled button", () => {
+    const wrapper = mount(VtButton, {
+      props: { variant: "secondary" },
+      slots: { default: "Launch" },
+    });
+    const btn = wrapper.find(".el-button");
+    expect(btn.classes()).not.toContain("el-button--primary");
+    expect(btn.classes()).not.toContain("is-text");
+    expect(btn.classes()).not.toContain("el-button--danger");
+  });
+
+  it("maps tertiary variant to text button", () => {
+    const wrapper = mount(VtButton, {
+      props: { variant: "tertiary" },
+      slots: { default: "Reload" },
+    });
+    expect(wrapper.find(".is-text").exists()).toBe(true);
+  });
+
+  it("maps danger variant to el-button--danger", () => {
+    const wrapper = mount(VtButton, {
+      props: { variant: "danger" },
+      slots: { default: "Delete" },
+    });
+    expect(wrapper.find(".el-button--danger").exists()).toBe(true);
+    expect(wrapper.find(".is-plain").exists()).toBe(false);
+  });
+
+  it("maps danger plain when plain prop is set", () => {
+    const wrapper = mount(VtButton, {
+      props: { variant: "danger", plain: true },
+      slots: { default: "Logout" },
+    });
+    expect(wrapper.find(".el-button--danger").exists()).toBe(true);
+    expect(wrapper.find(".is-plain").exists()).toBe(true);
+  });
+
+  it("forwards attrs such as disabled and data-testid", () => {
+    const wrapper = mount(VtButton, {
+      props: { variant: "primary" },
+      attrs: {
+        disabled: true,
+        "data-testid": "save-btn",
+      },
+      slots: { default: "Save" },
+    });
+    const btn = wrapper.find(".el-button");
+    expect(btn.attributes("data-testid")).toBe("save-btn");
+    expect(btn.attributes("disabled")).toBeDefined();
+  });
+
+  it("forwards loading to el-button", () => {
+    const wrapper = mount(VtButton, {
+      props: { variant: "primary" },
+      attrs: { loading: true },
+      slots: { default: "Apply" },
+    });
+    expect(wrapper.find(".is-loading").exists()).toBe(true);
+  });
+});

--- a/frontend/src/components/__tests__/VtButton.spec.ts
+++ b/frontend/src/components/__tests__/VtButton.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
-import VtButton from "../VtButton.vue";
+import VtButton, { type VtButtonProps } from "../VtButton.vue";
 
 describe("VtButton", () => {
   it("maps primary variant to el-button--primary", () => {
@@ -42,7 +42,7 @@ describe("VtButton", () => {
 
   it("maps danger plain when plain prop is set", () => {
     const wrapper = mount(VtButton, {
-      props: { variant: "danger", plain: true },
+      props: { variant: "danger", plain: true } satisfies VtButtonProps,
       slots: { default: "Logout" },
     });
     expect(wrapper.find(".el-button--danger").exists()).toBe(true);

--- a/frontend/src/components/__tests__/VtButton.spec.ts
+++ b/frontend/src/components/__tests__/VtButton.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
-import VtButton, { type VtButtonProps } from "../VtButton.vue";
+import VtButton from "../VtButton.vue";
+import { type VtButtonProps } from "../vtButtonVariants";
 
 describe("VtButton", () => {
   it("maps primary variant to el-button--primary", () => {

--- a/frontend/src/components/vtButtonClasses.ts
+++ b/frontend/src/components/vtButtonClasses.ts
@@ -1,0 +1,13 @@
+/**
+ * ElMessageBox button classes shared with VtButton styling (ADR 0017).
+ * MessageBox cannot render VtButton; use these constants for confirm/cancel.
+ */
+
+/** Destructive confirm (Danger button in dialogs). */
+export const VT_BUTTON_DANGER_CONFIRM_CLASS = "el-button--danger";
+
+/**
+ * Cancel in destructive confirm dialogs (Secondary button).
+ * Empty — Element Plus default button matches our secondary filled style.
+ */
+export const VT_BUTTON_SECONDARY_CANCEL_CLASS = "";

--- a/frontend/src/components/vtButtonVariants.ts
+++ b/frontend/src/components/vtButtonVariants.ts
@@ -1,0 +1,16 @@
+export const VT_BUTTON_VARIANTS = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "danger",
+] as const;
+
+export type VtButtonVariant = (typeof VT_BUTTON_VARIANTS)[number];
+
+export type VtButtonProps =
+  | { variant: Exclude<VtButtonVariant, "danger"> }
+  | {
+      variant: "danger";
+      /** Outline when a Primary button is in the same action group. */
+      plain?: boolean;
+    };

--- a/frontend/src/views/AutomationView.vue
+++ b/frontend/src/views/AutomationView.vue
@@ -372,7 +372,10 @@ import {
   newAutomationId,
   type EditorState,
 } from "./automationEditorMapping";
-import { VT_BUTTON_DANGER_CONFIRM_CLASS } from "../components/vtButtonClasses";
+import {
+  VT_BUTTON_DANGER_CONFIRM_CLASS,
+  VT_BUTTON_SECONDARY_CANCEL_CLASS,
+} from "../components/vtButtonClasses";
 
 const { t } = useI18n();
 
@@ -662,6 +665,7 @@ async function confirmDelete() {
         cancelButtonText: t("common.cancel"),
         type: "warning",
         confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
+        cancelButtonClass: VT_BUTTON_SECONDARY_CANCEL_CLASS,
       },
     );
   } catch {

--- a/frontend/src/views/AutomationView.vue
+++ b/frontend/src/views/AutomationView.vue
@@ -372,6 +372,7 @@ import {
   newAutomationId,
   type EditorState,
 } from "./automationEditorMapping";
+import { VT_BUTTON_DANGER_CONFIRM_CLASS } from "../components/vtButtonClasses";
 
 const { t } = useI18n();
 
@@ -660,7 +661,7 @@ async function confirmDelete() {
         confirmButtonText: t("common.delete"),
         cancelButtonText: t("common.cancel"),
         type: "warning",
-        confirmButtonClass: "el-button--danger",
+        confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
       },
     );
   } catch {

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -354,6 +354,7 @@ import { ElMessageBox, ElMessage } from "element-plus";
 import { App } from "../wails/app";
 import type { VRChatConfigDTO } from "../wails/app";
 import { AssetCacheErr } from "../utils/assetCacheErrors";
+import { VT_BUTTON_DANGER_CONFIRM_CLASS } from "../components/vtButtonClasses";
 
 const { t } = useI18n();
 
@@ -591,7 +592,7 @@ async function deleteConfig() {
       confirmButtonText: t("common.delete"),
       cancelButtonText: t("common.cancel"),
       type: "warning",
-      confirmButtonClass: "el-button--danger",
+      confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
     });
   } catch {
     return;
@@ -669,7 +670,7 @@ async function doClearAssetCache() {
         confirmButtonText: t("common.execute"),
         cancelButtonText: t("common.cancel"),
         type: "warning",
-        confirmButtonClass: "el-button--danger",
+        confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
       },
     );
   } catch {

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -354,7 +354,10 @@ import { ElMessageBox, ElMessage } from "element-plus";
 import { App } from "../wails/app";
 import type { VRChatConfigDTO } from "../wails/app";
 import { AssetCacheErr } from "../utils/assetCacheErrors";
-import { VT_BUTTON_DANGER_CONFIRM_CLASS } from "../components/vtButtonClasses";
+import {
+  VT_BUTTON_DANGER_CONFIRM_CLASS,
+  VT_BUTTON_SECONDARY_CANCEL_CLASS,
+} from "../components/vtButtonClasses";
 
 const { t } = useI18n();
 
@@ -593,6 +596,7 @@ async function deleteConfig() {
       cancelButtonText: t("common.cancel"),
       type: "warning",
       confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
+      cancelButtonClass: VT_BUTTON_SECONDARY_CANCEL_CLASS,
     });
   } catch {
     return;
@@ -671,6 +675,7 @@ async function doClearAssetCache() {
         cancelButtonText: t("common.cancel"),
         type: "warning",
         confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
+        cancelButtonClass: VT_BUTTON_SECONDARY_CANCEL_CLASS,
       },
     );
   } catch {

--- a/frontend/src/views/LauncherView.vue
+++ b/frontend/src/views/LauncherView.vue
@@ -558,7 +558,10 @@ import {
   type ValueOptionsEnabled,
 } from "./launcher/launcherProfileEdits";
 import { formatError } from "../utils/formatError";
-import { VT_BUTTON_DANGER_CONFIRM_CLASS } from "../components/vtButtonClasses";
+import {
+  VT_BUTTON_DANGER_CONFIRM_CLASS,
+  VT_BUTTON_SECONDARY_CANCEL_CLASS,
+} from "../components/vtButtonClasses";
 
 const { t } = useI18n();
 
@@ -1020,6 +1023,7 @@ async function confirmDelete() {
         cancelButtonText: t("common.cancel"),
         type: "warning",
         confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
+        cancelButtonClass: VT_BUTTON_SECONDARY_CANCEL_CLASS,
       },
     );
   } catch {

--- a/frontend/src/views/LauncherView.vue
+++ b/frontend/src/views/LauncherView.vue
@@ -558,6 +558,7 @@ import {
   type ValueOptionsEnabled,
 } from "./launcher/launcherProfileEdits";
 import { formatError } from "../utils/formatError";
+import { VT_BUTTON_DANGER_CONFIRM_CLASS } from "../components/vtButtonClasses";
 
 const { t } = useI18n();
 
@@ -1018,7 +1019,7 @@ async function confirmDelete() {
         confirmButtonText: t("launcher.deleteOk"),
         cancelButtonText: t("common.cancel"),
         type: "warning",
-        confirmButtonClass: "el-button--danger",
+        confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
       },
     );
   } catch {


### PR DESCRIPTION
## Summary

- Add **VtButton** wrapper with required `variant` (`primary` / `secondary` / `tertiary` / `danger`) mapping to Element Plus per ADR 0017
- Document domain terms in `CONTEXT.md` and implementation contract in `docs/adr/0017-button-design-system-vtbutton.md`
- Add Storybook catalog (4 variants × disabled/loading + action-group examples), unit tests, and `.cursor/rules/button-design-system.mdc`
- Export `VT_BUTTON_DANGER_CONFIRM_CLASS` for destructive `ElMessageBox` confirms (Launcher, Automation, Config)
- Incremental adoption: Presence change retry/apply buttons migrated to VtButton; semantic presence-color buttons unchanged

## Test plan

- [x] `make fmt` / `make test` (Go + frontend Vitest)
- [x] `VtButton` + `PresenceChangeSection` unit tests
- [x] `pnpm run build-storybook` (VtButton stories)
- [ ] Storybook: visually confirm 4 variants and action-group stories
- [ ] Dashboard: Presence change retry + apply buttons
- [ ] Launcher / Automation / Config: destructive confirm dialogs still use red confirm button


Made with [Cursor](https://cursor.com)