### PR TITLE
feat(frontend): Color design system (ADR 0019)

### DIFF
--- a/.cursor/rules/color-design-system.mdc
+++ b/.cursor/rules/color-design-system.mdc
@@ -1,0 +1,55 @@
+---
+description: Color カラーデザインシステム（ADR 0019）。新規・改修で触った画面は App color token を使う
+globs: "frontend/**/*.{vue,ts,css}"
+alwaysApply: false
+---
+
+# Color design system
+
+正本: [ADR 0019](../docs/adr/0019-color-design-system.md)、用語: [`CONTEXT.md`](../CONTEXT.md) Design system 節。
+
+## トークン
+
+`frontend/src/assets/style.css` の `:root` で定義（**App color token** が正本）。
+
+| カテゴリ | 変数例 |
+|----------|--------|
+| Brand | `--color-brand`, `--color-brand-hover` |
+| Neutral 表面 | `--color-bg-base`, `--color-bg-elevated`, `--color-bg-muted` |
+| Neutral 文字 | `--color-text-primary`, `--color-text-secondary`, `--color-text-muted` |
+| Neutral 枠 | `--color-border` |
+| Semantic | `--color-danger`, `--color-success`, `--color-warning`, `--color-info` |
+| Server status | `--color-status-operational` … `--color-status-unknown` |
+| Presence | `--color-presence-join-me` + `-border` 等 |
+
+「Primary color」は使わない（**Primary button** と混同）。**Semantic color** と **Semantic button**（Presence 等）も別カテゴリ。
+
+## 使い方
+
+```css
+color: var(--color-text-secondary);
+background: var(--color-bg-elevated);
+border-color: var(--color-border);
+```
+
+- hex 直書きや新規レガシー名（`--accent` 等）は増やさない
+- `--el-color-*` 直参照は EP テーマ上書きと既存 EP 利用に限定。独自スタイルは `--color-*` を優先
+- EP の `light-*` / `dark-*` は mapping 内のみ（画面から参照しない）
+
+## 移行（Color adoption）
+
+- 新規・改修で触ったファイルはトークン化する
+- 未触りの View scoped hex は一括置換しない
+- レガシー alias（`--bg-primary` → `--color-bg-base` 等）は移行期のみ。新規コードでは `--color-*` を使う
+- v1 では見た目（hex 値）を変えない
+- ESLint 禁止は v1 では入れない
+
+## Storybook
+
+`frontend/src/design/Color.stories.ts` がスウォッチとマッピング表の正本。変更時は `colorTokens.ts` とストーリーも更新する。
+
+## 関連
+
+- 余白: `.cursor/rules/spacing-design-system.mdc`
+- ボタン: `.cursor/rules/button-design-system.mdc`
+- Element Plus 一般: `.cursor/rules/element-plus-ui.mdc`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -692,7 +692,7 @@ _Avoid_: 常時実行, バックグラウンドサービス（v1 で含意しな
 
 ## Design system
 
-ボタン様式・余白などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。実装契約は各 ADR を正本とする。色コード・個別 props など実装詳細はここに書かない。
+ボタン様式・余白・色などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
 
 ### Language
 
@@ -791,6 +791,101 @@ _Avoid_: 目視のみ（置換ごとに判断がぶれるため）, 切り上げ
 **Border radius**:
 角丸の半径。既存の `--radius` トークンで扱う。**Spacing** スケールとは別カテゴリ。v1 では Spacing 策定と同時に値や命名を変えない。
 _Avoid_: Spacing（余白と混同しやすいため）, 角丸ルール（Border radius 用語と重複）
+
+**Color**:
+アプリ横断の色ルール。**Brand color**、**Neutral color**、**Semantic color** などのカテゴリ、**Color token**、**Element Plus color mapping** を含む。**Spacing**・**Border radius** とは別カテゴリ。
+_Avoid_: パレット（具体的な色一覧だけを指す印象）, テーマ（タイポ・余白まで含む総称）
+
+**Color token**:
+Color の正本となる CSS カスタムプロパティ（`--color-*` 接頭辞）。`frontend/src/assets/style.css` の `:root` に定義する。**App color token** が唯一の色の出所であり、Element Plus の `--el-color-*` 等は **Element Plus color mapping** でここから委譲する（Spacing の **Spacing token** が正本で pattern が委譲するのと同型）。新規・改修では hex 直書きやレガシー名（`--accent` 等）を増やさない（**Color adoption**）。
+_Avoid_: --el-color-primary（EP 変数を正本にしない）, accent（レガシー俗称）
+
+**App color token**:
+**Color token** のうち、アプリ UI の意味論（Brand / Neutral / Semantic 等）に沿って名前付けされたもの。画面・共有スタイルはこれを参照し、同じ意味の色を二重に hex 定義しない。
+_Avoid_: デザイントークン（Sizing・Spacing と混同しやすいため）, ブランドカラー（英語以外の俗称だけ）
+
+**Element Plus color mapping**:
+**App color token** から Element Plus の `--el-*` 色変数へ値を渡す層。`html.dark` ブロック内で定義する。`el-button` 等の EP テーマ整合が目的。コンポーネントの独自スタイルは原則 **App color token** を参照し、`--el-*` 直参照は EP 上書きブロックと既存 EP 利用箇所に限定する。
+_Avoid_: EP 正本（出所を Element Plus に置く案）, 二重カタログ（App と EP を別々に hex 管理する案）
+
+**Color v1 scope**:
+Color の最初の届け範囲。**ダークテーマのみ**の **App color token** 定義、**Element Plus color mapping**、**Color adoption**、**Color Storybook catalog**、ADR、`.cursor/rules/` に限定する。含めないもの: ライトテーマ用トークン、`prefers-color-scheme` 切替、テーマ切替 UI、全 View の hex 一括置換、Element Plus 内部色の全面再設計、Neutral border の多段トークン化、ESLint 強制。
+
+**Color v1 deliverables**:
+Issue／PR で最初に届ける具体物。(1) `frontend/src/assets/style.css` の全カテゴリ **App color token** と **Element Plus color mapping**、レガシー **Color alias**、(2) `frontend/src/design/colorTokens.ts`（Spacing の `spacingTokens.ts` 同型）、(3) **Server status color**・**Presence color** の既知 2 コンポーネントをトークン参照へ、(4) 共有スタイル（`.page-title`、`.section-card` 等）の Neutral 置換、(5) **Color Storybook catalog**、ADR。各 View の scoped hex は **Color adoption** に従い触ったところだけ。
+_Avoid_: Color v1 scope（届け物リストを指すときは deliverables とセットで書く）, 全画面置換（adoption と矛盾するため）
+
+**Color adoption**:
+**App color token** への移行方針。新規画面・改修で触ったファイルでは **Color token** を使い、hex 直書きやレガシー名を増やさない。未着手の既存 View・scoped style は一括置換しない。**Color v1 deliverables** の共有スタイルと既知 Domain コンポーネントは v1 で寄せる。遵守は `.cursor/rules/` で案内し、移行期は ESLint では強制しない。見た目の正本は **Color Storybook catalog**。
+_Avoid_: 全面置換, hex 禁止の CI 強制（即時一括・CI 強制を含意するため）
+
+**Color alias**:
+移行期に残す、旧 CSS 変数名から新 **App color token** へのエイリアス（例: `--accent` → `--color-brand`、`--bg-primary` → `--color-bg-base`）。v1 では **Color adoption** の破壊を避けるため `:root` に置く。削除時期は別判断（v1 では削除しない）。
+_Avoid_: 永久互換の約束（削除時期を v1 で固定しないため）, 二重 hex（エイリアスは委譲のみ。別値を持たない）
+
+**Color Storybook catalog**:
+Color の Storybook 一覧。**Brand color**、**Neutral color token** 各段、**Semantic color catalog**、**Server status color**、**Presence color** のスウォッチとトークン名対応表、**Element Plus color mapping** の要点を載せ、見た目と使い方の正本とする（**Spacing Storybook catalog** と同型）。
+_Avoid_: 全画面 Storybook, デザイントークン一覧（Sizing・Spacing の総称）
+
+**Brand color**:
+アプリのメインアクセント色（リンク、フォーカスリング、**Primary button** の塗り、サイドバーアクティブ項目など）。**Color** カテゴリのひとつ。**Primary button**（操作優先度の様式名）とは別概念。「Primary color」「アクセント色」としてパレット用語にしない。
+_Avoid_: Primary color（**Primary button** と混同するため）, accent（レガシー `--accent` の俗称）, メインカラー（様式と色の区別が曖昧なため）
+
+**Brand color token**:
+**Brand color** を表す **App color token**（例: 本体・hover のペア）。**Element Plus color mapping** では `--el-color-primary` 系へ委譲する。レガシーの `--accent` / `--accent-hover` は v1 で **Brand color token** へ寄せ、移行期はエイリアス可。
+_Avoid_: --color-primary（Primary button 用語と接頭辞が衝突するため）, --el-color-primary（正本ではなく mapping 先）
+
+**Semantic color**:
+UI の状態・結果を伝える **Color** カテゴリ。**Danger color**、**Success color**、**Warning color**、**Info color** の 4 種（**Semantic color catalog**）。`el-tag`・`ElMessage`・フォーム検証・**Danger button** の警告色など横断フィードバックに使う。**Semantic button**（Presence 色ボタン等のドメイン UI）とは別カテゴリ。
+_Avoid_: Semantic button（ボタン分類の用語と混同するため）, 状態色（Server status のドメイン色と混同しやすいため）
+
+**Semantic color catalog**:
+v1 の **Semantic color** 公式一覧: danger（危険・エラー・破壊）、success（成功・正常）、warning（注意・要確認）、info（中立通知・補足）。Element Plus の `danger` / `success` / `warning` / `info` と 1 対 1 で **Element Plus color mapping** する。`error` は danger と同値でよい（EP 互換）。
+_Avoid_: 3 色のみ（info を落とすと EP `type="info"` とずれる）, Server status 5 色（**Domain color** 側）
+
+**Domain color**:
+特定画面・ドメインだけが持つ意味付きの色。**Semantic color** とは別カタログ。全体のフィードバック色として流用しない。v1 では **Server status color** と **Presence color** を扱う。他ドメインは必要になったらカタログ追加。
+_Avoid_: Semantic color（横断フィードバックと混同するため）, テーマカラー（**Brand color** と混同しやすいため）
+
+**Server status color**:
+**Server status presentation** 向けの **Domain color**。status.vrchat.com に近い 5 段（operational / degraded / partial / major / maintenance）＋ unknown。**Semantic color** の success / warning / danger とは別トークン（メンテナンス青・partial 橙などを無理に Semantic に畳まない）。
+_Avoid_: Semantic color, プレゼンス色
+
+**Presence color**:
+**Presence change section** の **Semantic button**（Join Me / Active / Ask Me / Busy）向けの **Domain color**。VRChat クライアントに近い 4 色。**Semantic color catalog** や **Brand color** の流用はしない。
+_Avoid_: Semantic color, クイックステータス色（旧称）
+
+**Neutral color**:
+背景・テキスト・枠線など、意味を持たない骨格色の **Color** カテゴリ。**Neutral surface**、**Neutral text**、**Neutral border** に分ける。**Brand color** や **Semantic color** の代替ではない。
+_Avoid_: グレー（色相の指定を含意しないため）, テーマ色（**Brand color** と混同しやすいため）
+
+**Neutral surface**:
+画面の層（奥行き）を表す **Neutral color**。v1 は 3 段: **base**（ページ地）、**elevated**（カード・パネル）、**muted**（入力欄・ホバー・第 3 層）。**Neutral surface token** で表す。
+_Avoid_: bg-primary（レガシー名）, 背景色（段数が分からないため）
+
+**Neutral text**:
+本文・ラベル・補足の **Neutral color**。v1 は 3 段: **primary**（本文）、**secondary**（ラベル・補足）、**muted**（プレースホルダ・無効表示）。**Neutral text token** で表す。`placeholder` / `disabled` は **Element Plus color mapping** で **muted** へ委譲してよい。
+_Avoid_: text-secondary だけ（段数が足りないため）, プレースホルダ色（単独トークンにせず muted に含める）
+
+**Neutral border**:
+区切り線・カード枠の **Neutral color**。v1 は 1 段（既定の枠線色）。細い階層（light / lighter）は v1 では **Element Plus color mapping** 内の導出のみとし、Neutral カタログには載せない。
+_Avoid_: ボーダー色（段数が分からないため）, EP border-light 列の全面トークン化（v1 スコープ外）
+
+**Neutral color token**:
+**Neutral surface** / **Neutral text** / **Neutral border** を表す **App color token**（`--color-bg-*`、`--color-text-*`、`--color-border`）。レガシーの `--bg-primary` / `--text-secondary` / `--border` は移行期エイリアス可。
+_Avoid_: --el-bg-color（正本ではなく mapping 先）, 数値段階名のみ（base 等の役割名と対応が分からないため）
+
+**Semantic color token**:
+**Semantic color catalog** の各色 1 つずつの **App color token**（`--color-danger` 等）。hover や EP の `light-*` / `dark-*` 派生は **App color token** に含めない（**Element Plus color derivative** として mapping 内のみ）。
+_Avoid_: --color-semantic-danger（category 接頭辞の重複）, light-3（EP 派生段階を App 正本にしない）
+
+**Element Plus color derivative**:
+**Element Plus color mapping** 内だけで定義する、EP コンポーネント向けの濃淡（`--el-color-primary-light-3`、`--el-color-danger-light-5` 等）。**App color token** の委譲先であり、画面・共有スタイルから直接参照しない。v1 では tokenize 時に **既存 hex を維持**し、見た目を変えない。
+_Avoid_: Color token（App 正本と混同するため）, 派生色カタログ（v1 で App 側に持たない）
+
+**Color v1 visual policy**:
+Color v1 では **hex 値・見た目を変えない**。現行 `style.css`・**Server status color**・**Presence color** の色をそのまま **App color token** に移し、トークン名と参照の整理のみ行う。コントラスト改善・色相の揃え込み・Brand のリデザインは v1 スコープ外（別 PR／Issue）。
+_Avoid_: リデザイン（v1 で見た目変更を含意するため）, トークン化 PR での微調整（回帰レビューと混ぜないため）
 
 ## Agent contribution
 

--- a/docs/adr/0019-color-design-system.md
+++ b/docs/adr/0019-color-design-system.md
@@ -1,0 +1,159 @@
+# ADR 0019: Color design system
+
+## Status
+
+Accepted（grill-with-docs で合意）
+
+## Context
+
+- 色が `--accent` / `--bg-primary` / `--el-color-primary` / コンポーネント内 hex 直書きに分散し、同じ意味の色が二重定義されている
+- **VtButton**（[ADR 0017](0017-button-design-system-vtbutton.md)）と **Spacing**（[ADR 0018](0018-spacing-design-system.md)）は整備済みだが、カラーパレットの正本は未定義
+- **Primary button**（操作様式）と「メインカラー」の俗称が衝突しやすい
+- **Semantic color**（`el-tag` / `ElMessage` のフィードバック）と **Semantic button**（Presence 色ボタン）、**Server status color**（5 段＋メンテ青）が「状態色」として混同されやすい
+- アプリは **ダークテーマのみ**（`html.dark`）。ライトモード切替はない
+- Element Plus は `--el-color-*-light-*` 等の派生色を多数持つが、画面作者が直接触る必要はない
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Design system** セクション（**Color**、**Brand color**、**Neutral color**、**Semantic color**、**Domain color** 等）を正本とする。
+
+## Decision
+
+### 1. 正本と委譲
+
+- **App color token**（`:root` の `--color-*`）が唯一の色の出所
+- **Element Plus color mapping**（`html.dark` 内）で `--el-color-*` 等へ委譲する
+- 画面・共有スタイルは原則 **App color token** を参照する。`--el-*` 直参照は EP 上書きブロックと既存 EP 利用箇所に限定する
+- EP の `light-*` / `dark-*` は **Element Plus color derivative** として mapping 内のみ定義し、**App color token** には含めない
+
+### 2. カテゴリとトークン（v1・ダークのみ）
+
+#### Brand color
+
+| 役割 | CSS 変数 | 備考 |
+|------|----------|------|
+| 本体 | `--color-brand` | リンク、フォーカス、**Primary button** 塗り等 |
+| hover | `--color-brand-hover` | |
+
+「Primary color」は使わない（**Primary button** と混同するため）。
+
+#### Neutral color
+
+| 役割 | CSS 変数 | レガシー alias（移行期） |
+|------|----------|--------------------------|
+| 表面 base | `--color-bg-base` | `--bg-primary` |
+| 表面 elevated | `--color-bg-elevated` | `--bg-secondary` |
+| 表面 muted | `--color-bg-muted` | `--bg-tertiary` |
+| 本文 | `--color-text-primary` | `--text-primary` |
+| 補足 | `--color-text-secondary` | `--text-secondary` |
+| プレースホルダ・無効 | `--color-text-muted` | （新設。EP `placeholder` / `disabled` へ mapping） |
+| 枠線 | `--color-border` | `--border` |
+
+Neutral border の多段（`border-light` 等）は v1 では **App color token** に載せず、mapping 内導出のみ。
+
+#### Semantic color
+
+| 意味 | CSS 変数 | レガシー alias |
+|------|----------|----------------|
+| danger | `--color-danger` | `--danger` |
+| success | `--color-success` | `--success` |
+| warning | `--color-warning` | （新設。現行 `--el-color-warning` と同値） |
+| info | `--color-info` | （新設。現行 `--el-color-info` と同値） |
+
+`--el-color-error` は `--color-danger` と同値でよい（EP 互換）。hover や `light-*` は **Semantic color token** に含めない。
+
+#### Domain color
+
+**Server status color**（`ServerStatusSection.vue`）:
+
+| 状態 | CSS 変数 |
+|------|----------|
+| operational | `--color-status-operational` |
+| degraded | `--color-status-degraded` |
+| partial | `--color-status-partial` |
+| major | `--color-status-major` |
+| maintenance | `--color-status-maintenance` |
+| unknown | `--color-status-unknown` |
+
+**Presence color**（`PresenceChangeSection.vue`）:
+
+| プレゼンス | 背景 | 枠（現行どおり 2 トークン） |
+|------------|------|------------------------------|
+| Join Me | `--color-presence-join-me` | `--color-presence-join-me-border` |
+| Active | `--color-presence-active` | `--color-presence-active-border` |
+| Ask Me | `--color-presence-ask-me` | `--color-presence-ask-me-border` |
+| Busy | `--color-presence-busy` | `--color-presence-busy-border` |
+
+**Domain color** を **Semantic color** へ流用しない（メンテナンス青・partial 橙のため）。
+
+#### その他レガシー alias
+
+| 旧 | 新 |
+|----|-----|
+| `--accent` | `--color-brand` |
+| `--accent-hover` | `--color-brand-hover` |
+
+**Color alias** は委譲のみ（別 hex を持たない）。v1 では削除しない。
+
+### 3. Color v1 visual policy
+
+- tokenize 時は **既存 hex をそのまま移す**。見た目・コントラスト・色相の調整は v1 スコープ外
+- パレット改善はトークン整備後の別 PR / Issue とする
+
+### 4. 実装正本
+
+- トークン定義・EP mapping・alias: `frontend/src/assets/style.css`
+- カタログ定数（Storybook・テスト用）: `frontend/src/design/colorTokens.ts`
+- 見た目と使い方: **Color Storybook catalog**（`frontend/src/design/Color.stories.ts`）
+- Agent 規約: `.cursor/rules/color-design-system.mdc`（実装 PR で追加）
+
+### 5. Color adoption
+
+- 新規・改修で触ったファイルでは **App color token** を使い、hex 直書きやレガシー名を増やさない
+- **Color v1 deliverables** で寄せる対象:
+  - `style.css` の全カテゴリトークンと共有クラス（`.page-title`、`.section-card` 等）
+  - **Server status color**・**Presence color** の既知 2 コンポーネント
+- 既存 View の scoped hex は一括置換しない
+- Element Plus 内部色の全面再設計は v1 スコープ外
+- ESLint 強制は v1 では入れない
+
+## Considered options
+
+| 案 | 却下理由 |
+|----|----------|
+| Element Plus `--el-color-*` を正本 | Server status / Presence 等のドメイン色と二重管理が続く |
+| App と EP の二重カタログ（別 hex） | 同期ずれとメンテ負荷 |
+| 「Primary color」でメイン色を命名 | **Primary button**（ADR 0017）と用語衝突 |
+| Semantic 3 色のみ（info なし） | EP `type="info"` とずれる |
+| Server status を Semantic color に畳む | メンテナンス青・partial 橙が壊れる（[CONTEXT Server status presentation](../../CONTEXT.md) と矛盾） |
+| ライト＋ダーク両方を v1 で定義 | 現行 UI にライトモードがなく YAGNI |
+| v1 で hex 値も調整 | リネーム PR と視覚回帰レビューが混ざり、影響範囲が大きい |
+| EP 派生色をすべて App token 化 | カタログ肥大。画面から直接参照する需要がない |
+| 全 View 一括置換 | Spacing / VtButton adoption と方針が矛盾しリグレッションリスクが大きい |
+
+## v1 scope
+
+**含む:**
+
+- `style.css` への **App color token**、**Element Plus color mapping**、**Color alias**
+- `colorTokens.ts` + 単体テスト
+- **Color Storybook catalog**（Brand / Neutral / Semantic / Server status / Presence）
+- `ServerStatusSection.vue` / `PresenceChangeSection.vue` のトークン参照化
+- 共有スタイルの Neutral 置換
+- `.cursor/rules/color-design-system.mdc`
+- `CONTEXT.md` / 本 ADR
+
+**含まない:**
+
+- ライトテーマ用トークン、`prefers-color-scheme`、テーマ切替 UI
+- hex 値・コントラストのリデザイン
+- 全 View の scoped hex 一括置換
+- Neutral border 多段の App token 化
+- EP 派生色の App token 化
+- ESLint hex 直書き禁止
+
+## Consequences
+
+- 新規・改修 PR では `var(--color-*)` が期待される（レガシー alias は移行期のみ）
+- **Color Storybook catalog** が色の正本となり、Spacing / VtButton catalog と並べて参照できる
+- Server status と Presence は **Domain color** として独立したトークン名を持ち、Semantic フィードバック色と混同しにくくなる
+- 見た目不変のため v1 マージ直後の視覚差は意図しない（alias 経由の参照先同一）
+- パレット調整はトークン名が安定した後に、Storybook 上で差分比較しやすくなる

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -1,17 +1,56 @@
 /* VRChat Tweaker - Dark theme base + Element Plus dark mode overrides */
 
-/* ─── App color tokens ─────────────────────────────────────────── */
+/* ─── App color tokens (ADR 0019) ──────────────────────────────── */
 :root {
-  --bg-primary: #1b2636;
-  --bg-secondary: #243447;
-  --bg-tertiary: #2d3f54;
-  --text-primary: #e8eaed;
-  --text-secondary: #9aa0a6;
-  --accent: #5c9ce6;
-  --accent-hover: #7ab3f0;
-  --danger: #e57373;
-  --success: #81c784;
-  --border: #3d4f66;
+  /* Brand */
+  --color-brand: #5c9ce6;
+  --color-brand-hover: #7ab3f0;
+
+  /* Neutral */
+  --color-bg-base: #1b2636;
+  --color-bg-elevated: #243447;
+  --color-bg-muted: #2d3f54;
+  --color-text-primary: #e8eaed;
+  --color-text-secondary: #9aa0a6;
+  --color-text-muted: #6b7280;
+  --color-border: #3d4f66;
+
+  /* Semantic */
+  --color-danger: #e57373;
+  --color-success: #81c784;
+  --color-warning: #ffb74d;
+  --color-info: #9aa0a6;
+
+  /* Server status (domain) */
+  --color-status-operational: #2e9f4a;
+  --color-status-degraded: #d4a017;
+  --color-status-partial: #e8943c;
+  --color-status-major: #d94a4a;
+  --color-status-maintenance: #2b7fd9;
+  --color-status-unknown: var(--color-text-secondary);
+
+  /* Presence (domain) */
+  --color-presence-join-me: #2b7fd9;
+  --color-presence-join-me-border: #256bb8;
+  --color-presence-active: #2e9f4a;
+  --color-presence-active-border: #267d3c;
+  --color-presence-ask-me: #e8943c;
+  --color-presence-ask-me-border: #c97d2e;
+  --color-presence-busy: #d94a4a;
+  --color-presence-busy-border: #b83c3c;
+
+  /* Legacy aliases (Color adoption; delegate only) */
+  --bg-primary: var(--color-bg-base);
+  --bg-secondary: var(--color-bg-elevated);
+  --bg-tertiary: var(--color-bg-muted);
+  --text-primary: var(--color-text-primary);
+  --text-secondary: var(--color-text-secondary);
+  --accent: var(--color-brand);
+  --accent-hover: var(--color-brand-hover);
+  --danger: var(--color-danger);
+  --success: var(--color-success);
+  --border: var(--color-border);
+
   --radius: 8px;
   --sidebar-width: 220px;
 
@@ -36,44 +75,44 @@
 
 /* ─── Element Plus dark theme CSS variable overrides ───────────── */
 html.dark {
-  --el-bg-color-page: #1b2636;
-  --el-bg-color: #243447;
-  --el-bg-color-overlay: #2d3f54;
+  --el-bg-color-page: var(--color-bg-base);
+  --el-bg-color: var(--color-bg-elevated);
+  --el-bg-color-overlay: var(--color-bg-muted);
 
-  --el-color-primary: #5c9ce6;
-  --el-color-primary-light-3: #7ab3f0;
+  --el-color-primary: var(--color-brand);
+  --el-color-primary-light-3: var(--color-brand-hover);
   --el-color-primary-light-5: #8ec4f5;
   --el-color-primary-light-7: #a8d3f7;
   --el-color-primary-light-8: #b8dcf9;
   --el-color-primary-light-9: #d0eafc;
   --el-color-primary-dark-2: #4a88d0;
 
-  --el-color-success: #81c784;
-  --el-color-warning: #ffb74d;
-  --el-color-danger: #e57373;
-  --el-color-error: #e57373;
-  --el-color-info: #9aa0a6;
+  --el-color-success: var(--color-success);
+  --el-color-warning: var(--color-warning);
+  --el-color-danger: var(--color-danger);
+  --el-color-error: var(--color-danger);
+  --el-color-info: var(--color-info);
 
-  --el-text-color-primary: #e8eaed;
+  --el-text-color-primary: var(--color-text-primary);
   --el-text-color-regular: #c8cbd0;
-  --el-text-color-secondary: #9aa0a6;
-  --el-text-color-placeholder: #6b7280;
+  --el-text-color-secondary: var(--color-text-secondary);
+  --el-text-color-placeholder: var(--color-text-muted);
   --el-text-color-disabled: #4b5563;
 
-  --el-border-color: #3d4f66;
+  --el-border-color: var(--color-border);
   --el-border-color-light: #334155;
-  --el-border-color-lighter: #2d3f54;
-  --el-border-color-extra-light: #243447;
+  --el-border-color-lighter: var(--color-bg-muted);
+  --el-border-color-extra-light: var(--color-bg-elevated);
   --el-border-color-dark: #4a5f7a;
   --el-border-color-darker: #5a7090;
 
-  --el-fill-color: #2d3f54;
-  --el-fill-color-light: #243447;
+  --el-fill-color: var(--color-bg-muted);
+  --el-fill-color-light: var(--color-bg-elevated);
   --el-fill-color-lighter: #1f2e40;
-  --el-fill-color-extra-light: #1b2636;
+  --el-fill-color-extra-light: var(--color-bg-base);
   --el-fill-color-dark: #374d66;
   --el-fill-color-darker: #3f5573;
-  --el-fill-color-blank: #243447;
+  --el-fill-color-blank: var(--color-bg-elevated);
 
   --el-mask-color: rgba(0, 0, 0, 0.6);
   --el-mask-color-extra-light: rgba(0, 0, 0, 0.3);
@@ -84,54 +123,54 @@ html.dark {
   --el-box-shadow-dark: 0 4px 16px rgba(0, 0, 0, 0.5);
 
   /* Menu */
-  --el-menu-bg-color: #243447;
-  --el-menu-hover-bg-color: #2d3f54;
-  --el-menu-text-color: #9aa0a6;
-  --el-menu-active-color: #5c9ce6;
-  --el-menu-border-color: #3d4f66;
+  --el-menu-bg-color: var(--color-bg-elevated);
+  --el-menu-hover-bg-color: var(--color-bg-muted);
+  --el-menu-text-color: var(--color-text-secondary);
+  --el-menu-active-color: var(--color-brand);
+  --el-menu-border-color: var(--color-border);
 
   /* Table */
-  --el-table-bg-color: #243447;
-  --el-table-tr-bg-color: #243447;
+  --el-table-bg-color: var(--color-bg-elevated);
+  --el-table-tr-bg-color: var(--color-bg-elevated);
   --el-table-header-bg-color: #1f2e40;
-  --el-table-header-text-color: #9aa0a6;
-  --el-table-text-color: #e8eaed;
-  --el-table-row-hover-bg-color: #2d3f54;
-  --el-table-border-color: #3d4f66;
+  --el-table-header-text-color: var(--color-text-secondary);
+  --el-table-text-color: var(--color-text-primary);
+  --el-table-row-hover-bg-color: var(--color-bg-muted);
+  --el-table-border-color: var(--color-border);
   --el-table-fixed-box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
 
   /* Input */
-  --el-input-bg-color: #2d3f54;
-  --el-input-text-color: #e8eaed;
-  --el-input-placeholder-color: #6b7280;
-  --el-input-hover-border-color: #5c9ce6;
-  --el-input-focus-border-color: #5c9ce6;
-  --el-input-border-color: #3d4f66;
+  --el-input-bg-color: var(--color-bg-muted);
+  --el-input-text-color: var(--color-text-primary);
+  --el-input-placeholder-color: var(--color-text-muted);
+  --el-input-hover-border-color: var(--color-brand);
+  --el-input-focus-border-color: var(--color-brand);
+  --el-input-border-color: var(--color-border);
 
   /* Button */
-  --el-button-bg-color: #2d3f54;
-  --el-button-text-color: #e8eaed;
-  --el-button-hover-text-color: #e8eaed;
+  --el-button-bg-color: var(--color-bg-muted);
+  --el-button-text-color: var(--color-text-primary);
+  --el-button-hover-text-color: var(--color-text-primary);
   --el-button-hover-bg-color: #374d66;
-  --el-button-hover-border-color: #5c9ce6;
-  --el-button-active-text-color: #e8eaed;
+  --el-button-hover-border-color: var(--color-brand);
+  --el-button-active-text-color: var(--color-text-primary);
   --el-button-disabled-text-color: #4b5563;
   --el-button-disabled-bg-color: #1f2e40;
-  --el-button-disabled-border-color: #2d3f54;
+  --el-button-disabled-border-color: var(--color-bg-muted);
 
   /* Switch */
-  --el-switch-off-color: #3d4f66;
-  --el-switch-on-color: #5c9ce6;
+  --el-switch-off-color: var(--color-border);
+  --el-switch-on-color: var(--color-brand);
 
   /* Dropdown */
-  --el-dropdown-menuItem-hover-fill: #2d3f54;
-  --el-dropdown-menuItem-hover-color: #e8eaed;
+  --el-dropdown-menuItem-hover-fill: var(--color-bg-muted);
+  --el-dropdown-menuItem-hover-color: var(--color-text-primary);
 
   /* Scrollbar */
   --el-scrollbar-opacity: 0.5;
-  --el-scrollbar-bg-color: #3d4f66;
+  --el-scrollbar-bg-color: var(--color-border);
   --el-scrollbar-hover-opacity: 0.8;
-  --el-scrollbar-hover-bg-color: #5c9ce6;
+  --el-scrollbar-hover-bg-color: var(--color-brand);
 }
 
 /* ─── Base resets ──────────────────────────────────────────────── */
@@ -152,8 +191,8 @@ body {
     -apple-system,
     BlinkMacSystemFont,
     sans-serif;
-  background: var(--bg-primary);
-  color: var(--text-primary);
+  background: var(--color-bg-base);
+  color: var(--color-text-primary);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
@@ -174,12 +213,12 @@ textarea {
 }
 
 a {
-  color: var(--accent);
+  color: var(--color-brand);
   text-decoration: none;
 }
 
 a:hover {
-  color: var(--accent-hover);
+  color: var(--color-brand-hover);
 }
 
 /* ─── Element Plus component tweaks ───────────────────────────── */
@@ -199,13 +238,13 @@ a:hover {
   margin: 0 0 var(--space-block);
   font-size: 1.4rem;
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 /* Shared section card */
 .section-card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
   padding: 0;
   margin-bottom: var(--space-section);
@@ -223,13 +262,13 @@ a:hover {
   background: none;
   font: inherit;
   font-weight: 600;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   cursor: pointer;
   text-align: left;
 }
 
 .section-card__toggle:hover {
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .section-card__toggle-icon {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -13,6 +13,7 @@
   --color-text-primary: #e8eaed;
   --color-text-secondary: #9aa0a6;
   --color-text-muted: #6b7280;
+  --color-text-inverse: #ffffff;
   --color-border: #3d4f66;
 
   /* Semantic */

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -40,7 +40,7 @@
   --color-presence-busy: #d94a4a;
   --color-presence-busy-border: #b83c3c;
 
-  /* Legacy aliases (Color adoption; delegate only) */
+  /* Legacy aliases (Color adoption; deprecated — for backward compatibility only) */
   --bg-primary: var(--color-bg-base);
   --bg-secondary: var(--color-bg-elevated);
   --bg-tertiary: var(--color-bg-muted);

--- a/frontend/src/components/PresenceChangeSection.vue
+++ b/frontend/src/components/PresenceChangeSection.vue
@@ -410,28 +410,28 @@ onUnmounted(() => {
 }
 
 .presence-color-btn--selected {
-  outline: 2px solid var(--text-primary);
+  outline: 2px solid var(--color-text-primary);
   outline-offset: 2px;
 }
 
 .presence-color-btn--join-me {
-  background: #2b7fd9 !important;
-  border-color: #256bb8 !important;
+  background: var(--color-presence-join-me) !important;
+  border-color: var(--color-presence-join-me-border) !important;
 }
 
 .presence-color-btn--active {
-  background: #2e9f4a !important;
-  border-color: #267d3c !important;
+  background: var(--color-presence-active) !important;
+  border-color: var(--color-presence-active-border) !important;
 }
 
 .presence-color-btn--ask-me {
-  background: #e8943c !important;
-  border-color: #c97d2e !important;
+  background: var(--color-presence-ask-me) !important;
+  border-color: var(--color-presence-ask-me-border) !important;
 }
 
 .presence-color-btn--busy {
-  background: #d94a4a !important;
-  border-color: #b83c3c !important;
+  background: var(--color-presence-busy) !important;
+  border-color: var(--color-presence-busy-border) !important;
 }
 
 .presence-description-row {

--- a/frontend/src/components/PresenceChangeSection.vue
+++ b/frontend/src/components/PresenceChangeSection.vue
@@ -399,14 +399,14 @@ onUnmounted(() => {
 
 .presence-color-btn {
   border: 1px solid transparent;
-  color: #fff !important;
+  color: var(--color-text-inverse) !important;
   flex: 0 0 auto;
 }
 
 .presence-color-btn:hover,
 .presence-color-btn:focus {
   filter: brightness(1.08);
-  color: #fff !important;
+  color: var(--color-text-inverse) !important;
 }
 
 .presence-color-btn--selected {

--- a/frontend/src/components/ServerStatusSection.vue
+++ b/frontend/src/components/ServerStatusSection.vue
@@ -245,30 +245,30 @@ onUnmounted(() => {
 
 .server-status-link {
   font-size: 0.85rem;
-  color: var(--el-color-primary);
+  color: var(--color-brand);
 }
 
 .server-status--operational {
-  color: #2e9f4a;
+  color: var(--color-status-operational);
 }
 
 .server-status--degraded {
-  color: #d4a017;
+  color: var(--color-status-degraded);
 }
 
 .server-status--partial {
-  color: #e8943c;
+  color: var(--color-status-partial);
 }
 
 .server-status--major {
-  color: #d94a4a;
+  color: var(--color-status-major);
 }
 
 .server-status--maintenance {
-  color: #2b7fd9;
+  color: var(--color-status-maintenance);
 }
 
 .server-status--unknown {
-  color: var(--text-secondary);
+  color: var(--color-status-unknown);
 }
 </style>

--- a/frontend/src/design/Color.stories.css
+++ b/frontend/src/design/Color.stories.css
@@ -1,0 +1,81 @@
+.color-story {
+  color: var(--color-text-primary);
+  font-size: 14px;
+}
+
+.color-story h2 {
+  margin: 0 0 var(--space-block);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.color-story p {
+  margin: 0 0 var(--space-block);
+  color: var(--color-text-secondary);
+}
+
+.color-story-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  gap: var(--space-block);
+  margin-bottom: var(--space-section);
+}
+
+.color-story-swatch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-action-group);
+}
+
+.color-story-swatch-chip {
+  height: 3rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+}
+
+.color-story-swatch-chip--text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-elevated);
+  font-weight: 600;
+}
+
+.color-story-swatch-label {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  word-break: break-all;
+}
+
+.color-story-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--space-section);
+}
+
+.color-story-table th,
+.color-story-table td {
+  padding: var(--space-12) var(--space-16);
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.color-story-table th {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.color-story-presence-row {
+  display: flex;
+  gap: var(--space-action-group);
+  flex-wrap: wrap;
+}
+
+.color-story-presence-chip {
+  padding: var(--space-8) var(--space-12);
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  color: #fff;
+  font-size: 0.85rem;
+}

--- a/frontend/src/design/Color.stories.css
+++ b/frontend/src/design/Color.stories.css
@@ -45,7 +45,7 @@
   font-family: ui-monospace, monospace;
   font-size: 0.8rem;
   color: var(--color-text-secondary);
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .color-story-table {

--- a/frontend/src/design/Color.stories.css
+++ b/frontend/src/design/Color.stories.css
@@ -76,6 +76,6 @@
   padding: var(--space-8) var(--space-12);
   border-radius: var(--radius);
   border: 1px solid transparent;
-  color: #fff;
+  color: var(--color-text-inverse);
   font-size: 0.85rem;
 }

--- a/frontend/src/design/Color.stories.ts
+++ b/frontend/src/design/Color.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import type { SimpleColorToken } from "./colorTokens";
 import {
   BRAND_COLOR_TOKENS,
   NEUTRAL_COLOR_TOKENS,
@@ -24,7 +25,7 @@ type Story = StoryObj<typeof meta>;
 function swatchStory(
   title: string,
   description: string,
-  rows: ReadonlyArray<{ label: string; varName: string }>,
+  rows: ReadonlyArray<Pick<SimpleColorToken, "varName">>,
 ): Story {
   return {
     name: title,
@@ -52,7 +53,7 @@ function swatchStory(
 export const Brand: Story = swatchStory(
   "Brand color",
   "Main accent. Primary button fill and links use --color-brand.",
-  BRAND_COLOR_TOKENS.map((t) => ({ label: t.name, varName: t.varName })),
+  BRAND_COLOR_TOKENS,
 );
 
 export const Neutral: Story = {
@@ -66,12 +67,12 @@ export const Neutral: Story = {
         <div class="color-story-grid">
           <div v-for="row in rows" :key="row.varName" class="color-story-swatch">
             <div
-              v-if="row.role.startsWith('text-')"
+              v-if="row.name.startsWith('text-')"
               class="color-story-swatch-chip color-story-swatch-chip--text"
               :style="{ color: 'var(' + row.varName + ')' }"
             >Aa</div>
             <div
-              v-else-if="row.role === 'border'"
+              v-else-if="row.name === 'border'"
               class="color-story-swatch-chip"
               :style="{ background: 'var(--color-bg-base)', border: '3px solid var(' + row.varName + ')' }"
             />
@@ -92,16 +93,13 @@ export const Neutral: Story = {
 export const Semantic: Story = swatchStory(
   "Semantic color catalog",
   "Feedback for tags, messages, and validation. Not for Server status or Presence.",
-  SEMANTIC_COLOR_TOKENS.map((t) => ({ label: t.name, varName: t.varName })),
+  SEMANTIC_COLOR_TOKENS,
 );
 
 export const ServerStatus: Story = swatchStory(
   "Server status color",
   "Domain colors for Dashboard Server status. Do not reuse as Semantic feedback.",
-  SERVER_STATUS_COLOR_TOKENS.map((t) => ({
-    label: t.key,
-    varName: t.varName,
-  })),
+  SERVER_STATUS_COLOR_TOKENS,
 );
 
 export const Presence: Story = {
@@ -115,21 +113,21 @@ export const Presence: Story = {
         <div class="color-story-presence-row">
           <div
             v-for="row in rows"
-            :key="row.key"
+            :key="row.name"
             class="color-story-presence-chip"
             :style="{
               background: 'var(' + row.bgVar + ')',
               borderColor: 'var(' + row.borderVar + ')',
             }"
-          >{{ row.key }}</div>
+          >{{ row.name }}</div>
         </div>
         <table class="color-story-table">
           <thead>
-            <tr><th>Key</th><th>Background</th><th>Border</th></tr>
+            <tr><th>Name</th><th>Background</th><th>Border</th></tr>
           </thead>
           <tbody>
-            <tr v-for="row in rows" :key="row.key">
-              <td>{{ row.key }}</td>
+            <tr v-for="row in rows" :key="row.name">
+              <td>{{ row.name }}</td>
               <td><code>{{ row.bgVar }}</code></td>
               <td><code>{{ row.borderVar }}</code></td>
             </tr>

--- a/frontend/src/design/Color.stories.ts
+++ b/frontend/src/design/Color.stories.ts
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import {
+  BRAND_COLOR_TOKENS,
+  NEUTRAL_COLOR_TOKENS,
+  PRESENCE_COLOR_TOKENS,
+  SEMANTIC_COLOR_TOKENS,
+  SERVER_STATUS_COLOR_TOKENS,
+} from "./colorTokens";
+import "./Color.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Design System/Color",
+  tags: ["autodocs"],
+  parameters: catalogParameters,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function swatchStory(
+  title: string,
+  description: string,
+  rows: ReadonlyArray<{ label: string; varName: string }>,
+): Story {
+  return {
+    name: title,
+    render: () => ({
+      setup: () => ({ title, description, rows }),
+      template: `
+        <div class="color-story">
+          <h2>{{ title }}</h2>
+          <p>{{ description }}</p>
+          <div class="color-story-grid">
+            <div v-for="row in rows" :key="row.varName" class="color-story-swatch">
+              <div
+                class="color-story-swatch-chip"
+                :style="{ background: 'var(' + row.varName + ')' }"
+              />
+              <span class="color-story-swatch-label">{{ row.varName }}</span>
+            </div>
+          </div>
+        </div>
+      `,
+    }),
+  };
+}
+
+export const Brand: Story = swatchStory(
+  "Brand color",
+  "Main accent. Primary button fill and links use --color-brand.",
+  BRAND_COLOR_TOKENS.map((t) => ({ label: t.name, varName: t.varName })),
+);
+
+export const Neutral: Story = {
+  name: "Neutral color",
+  render: () => ({
+    setup: () => ({ rows: NEUTRAL_COLOR_TOKENS }),
+    template: `
+      <div class="color-story">
+        <h2>Neutral color</h2>
+        <p>Surfaces, text, and border. Prefer these over legacy --bg-* / --text-* aliases.</p>
+        <div class="color-story-grid">
+          <div v-for="row in rows" :key="row.varName" class="color-story-swatch">
+            <div
+              v-if="row.role.startsWith('text-')"
+              class="color-story-swatch-chip color-story-swatch-chip--text"
+              :style="{ color: 'var(' + row.varName + ')' }"
+            >Aa</div>
+            <div
+              v-else-if="row.role === 'border'"
+              class="color-story-swatch-chip"
+              :style="{ background: 'var(--color-bg-base)', border: '3px solid var(' + row.varName + ')' }"
+            />
+            <div
+              v-else
+              class="color-story-swatch-chip"
+              :style="{ background: 'var(' + row.varName + ')' }"
+            />
+            <span class="color-story-swatch-label">{{ row.varName }}</span>
+            <span v-if="row.legacyAlias" class="color-story-swatch-label">alias: {{ row.legacyAlias }}</span>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const Semantic: Story = swatchStory(
+  "Semantic color catalog",
+  "Feedback for tags, messages, and validation. Not for Server status or Presence.",
+  SEMANTIC_COLOR_TOKENS.map((t) => ({ label: t.name, varName: t.varName })),
+);
+
+export const ServerStatus: Story = swatchStory(
+  "Server status color",
+  "Domain colors for Dashboard Server status. Do not reuse as Semantic feedback.",
+  SERVER_STATUS_COLOR_TOKENS.map((t) => ({
+    label: t.key,
+    varName: t.varName,
+  })),
+);
+
+export const Presence: Story = {
+  name: "Presence color",
+  render: () => ({
+    setup: () => ({ rows: PRESENCE_COLOR_TOKENS }),
+    template: `
+      <div class="color-story">
+        <h2>Presence color</h2>
+        <p>Domain colors for Presence change Semantic buttons.</p>
+        <div class="color-story-presence-row">
+          <div
+            v-for="row in rows"
+            :key="row.key"
+            class="color-story-presence-chip"
+            :style="{
+              background: 'var(' + row.bgVar + ')',
+              borderColor: 'var(' + row.borderVar + ')',
+            }"
+          >{{ row.key }}</div>
+        </div>
+        <table class="color-story-table">
+          <thead>
+            <tr><th>Key</th><th>Background</th><th>Border</th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in rows" :key="row.key">
+              <td>{{ row.key }}</td>
+              <td><code>{{ row.bgVar }}</code></td>
+              <td><code>{{ row.borderVar }}</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    `,
+  }),
+};
+
+export const ElementPlusMapping: Story = {
+  name: "Element Plus mapping",
+  render: () => ({
+    template: `
+      <div class="color-story">
+        <h2>Element Plus color mapping</h2>
+        <p>
+          App tokens in <code>:root</code> are canonical.
+          <code>html.dark</code> maps <code>--el-color-*</code> and neutrals from them.
+          <code>light-*</code> / <code>dark-*</code> derivatives stay in the mapping block only.
+        </p>
+        <table class="color-story-table">
+          <thead>
+            <tr><th>App token</th><th>Element Plus (examples)</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>--color-brand</code></td><td><code>--el-color-primary</code></td></tr>
+            <tr><td><code>--color-brand-hover</code></td><td><code>--el-color-primary-light-3</code></td></tr>
+            <tr><td><code>--color-danger</code></td><td><code>--el-color-danger</code>, <code>--el-color-error</code></td></tr>
+            <tr><td><code>--color-success</code></td><td><code>--el-color-success</code></td></tr>
+            <tr><td><code>--color-warning</code></td><td><code>--el-color-warning</code></td></tr>
+            <tr><td><code>--color-info</code></td><td><code>--el-color-info</code></td></tr>
+            <tr><td><code>--color-bg-base</code></td><td><code>--el-bg-color-page</code></td></tr>
+            <tr><td><code>--color-text-muted</code></td><td><code>--el-text-color-placeholder</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+    `,
+  }),
+};

--- a/frontend/src/design/Color.stories.ts
+++ b/frontend/src/design/Color.stories.ts
@@ -110,6 +110,11 @@ export const Presence: Story = {
       <div class="color-story">
         <h2>Presence color</h2>
         <p>Domain colors for Presence change Semantic buttons.</p>
+        <p>
+          Chips use <code>--color-text-inverse</code> on every state, matching the production
+          Presence change section (ADR 0019 v1 visual policy). Ask-me contrast is below WCAG AA;
+          per-state text colors are a follow-up, not this tokenize PR.
+        </p>
         <div class="color-story-presence-row">
           <div
             v-for="row in rows"

--- a/frontend/src/design/Spacing.stories.css
+++ b/frontend/src/design/Spacing.stories.css
@@ -1,5 +1,5 @@
 .spacing-story {
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   font-size: 14px;
 }
 
@@ -13,7 +13,7 @@
   margin: var(--space-24) 0 var(--space-12);
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .spacing-story-table {
@@ -25,12 +25,12 @@
 .spacing-story-table th,
 .spacing-story-table td {
   padding: var(--space-12) var(--space-16);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border);
   text-align: left;
 }
 
 .spacing-story-table th {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-weight: 600;
 }
 
@@ -44,12 +44,12 @@
 .spacing-story-scale-bar {
   flex-shrink: 0;
   height: var(--space-8);
-  background: var(--accent);
+  background: var(--color-brand);
   border-radius: 2px;
 }
 
 .spacing-story-scale-label {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-family: ui-monospace, monospace;
   font-size: 0.85rem;
 }
@@ -59,14 +59,14 @@
   flex-direction: column;
   gap: var(--space-section);
   padding: var(--space-page);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
 }
 
 .spacing-story-layout-block {
   padding: var(--space-block);
-  background: var(--bg-tertiary);
+  background: var(--color-bg-muted);
   border-radius: var(--radius);
 }
 
@@ -89,8 +89,8 @@
 
 .spacing-story-action-chip {
   padding: var(--space-4) var(--space-8);
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
+  background: var(--color-bg-base);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
   font-size: 0.85rem;
 }

--- a/frontend/src/design/colorTokens.spec.ts
+++ b/frontend/src/design/colorTokens.spec.ts
@@ -16,6 +16,18 @@ describe("colorTokens", () => {
     ]);
   });
 
+  it("uses name for all simple token rows", () => {
+    for (const row of [
+      ...BRAND_COLOR_TOKENS,
+      ...NEUTRAL_COLOR_TOKENS,
+      ...SEMANTIC_COLOR_TOKENS,
+      ...SERVER_STATUS_COLOR_TOKENS,
+    ]) {
+      expect(row.name.length).toBeGreaterThan(0);
+      expect(row.varName.startsWith("--color-")).toBe(true);
+    }
+  });
+
   it("defines neutral surface and text tokens", () => {
     const names = NEUTRAL_COLOR_TOKENS.map((t) => t.varName);
     expect(names).toContain("--color-bg-base");
@@ -32,8 +44,8 @@ describe("colorTokens", () => {
     ]);
   });
 
-  it("defines server status domain keys", () => {
-    expect(SERVER_STATUS_COLOR_TOKENS.map((t) => t.key)).toEqual([
+  it("defines server status domain names", () => {
+    expect(SERVER_STATUS_COLOR_TOKENS.map((t) => t.name)).toEqual([
       "operational",
       "degraded",
       "partial",
@@ -45,6 +57,7 @@ describe("colorTokens", () => {
 
   it("defines presence domain bg and border pairs", () => {
     for (const row of PRESENCE_COLOR_TOKENS) {
+      expect(row.name.length).toBeGreaterThan(0);
       expect(row.borderVar).toBe(`${row.bgVar}-border`);
     }
   });

--- a/frontend/src/design/colorTokens.spec.ts
+++ b/frontend/src/design/colorTokens.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  BRAND_COLOR_TOKENS,
+  COLOR_LEGACY_ALIASES,
+  NEUTRAL_COLOR_TOKENS,
+  PRESENCE_COLOR_TOKENS,
+  SEMANTIC_COLOR_TOKENS,
+  SERVER_STATUS_COLOR_TOKENS,
+} from "./colorTokens";
+
+describe("colorTokens", () => {
+  it("defines brand tokens with --color- prefix", () => {
+    expect(BRAND_COLOR_TOKENS.map((t) => t.varName)).toEqual([
+      "--color-brand",
+      "--color-brand-hover",
+    ]);
+  });
+
+  it("defines neutral surface and text tokens", () => {
+    const names = NEUTRAL_COLOR_TOKENS.map((t) => t.varName);
+    expect(names).toContain("--color-bg-base");
+    expect(names).toContain("--color-text-muted");
+    expect(names).toContain("--color-border");
+  });
+
+  it("defines semantic catalog danger through info", () => {
+    expect(SEMANTIC_COLOR_TOKENS.map((t) => t.name)).toEqual([
+      "danger",
+      "success",
+      "warning",
+      "info",
+    ]);
+  });
+
+  it("defines server status domain keys", () => {
+    expect(SERVER_STATUS_COLOR_TOKENS.map((t) => t.key)).toEqual([
+      "operational",
+      "degraded",
+      "partial",
+      "major",
+      "maintenance",
+      "unknown",
+    ]);
+  });
+
+  it("defines presence domain bg and border pairs", () => {
+    for (const row of PRESENCE_COLOR_TOKENS) {
+      expect(row.borderVar).toBe(`${row.bgVar}-border`);
+    }
+  });
+
+  it("maps legacy aliases to canonical tokens only", () => {
+    for (const { legacy, target } of COLOR_LEGACY_ALIASES) {
+      expect(legacy.startsWith("--")).toBe(true);
+      expect(target.startsWith("--color-")).toBe(true);
+    }
+  });
+});

--- a/frontend/src/design/colorTokens.spec.ts
+++ b/frontend/src/design/colorTokens.spec.ts
@@ -32,6 +32,7 @@ describe("colorTokens", () => {
     const names = NEUTRAL_COLOR_TOKENS.map((t) => t.varName);
     expect(names).toContain("--color-bg-base");
     expect(names).toContain("--color-text-muted");
+    expect(names).toContain("--color-text-inverse");
     expect(names).toContain("--color-border");
   });
 
@@ -67,5 +68,19 @@ describe("colorTokens", () => {
       expect(legacy.startsWith("--")).toBe(true);
       expect(target.startsWith("--color-")).toBe(true);
     }
+  });
+
+  it("derives COLOR_LEGACY_ALIASES from token legacyAlias fields", () => {
+    const expected = [
+      ...BRAND_COLOR_TOKENS,
+      ...NEUTRAL_COLOR_TOKENS,
+      ...SEMANTIC_COLOR_TOKENS,
+    ]
+      .filter((token) => token.legacyAlias != null)
+      .map((token) => ({
+        legacy: token.legacyAlias,
+        target: token.varName,
+      }));
+    expect(COLOR_LEGACY_ALIASES).toEqual(expected);
   });
 });

--- a/frontend/src/design/colorTokens.spec.ts
+++ b/frontend/src/design/colorTokens.spec.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   BRAND_COLOR_TOKENS,
   COLOR_LEGACY_ALIASES,
+  hasLegacyAlias,
   NEUTRAL_COLOR_TOKENS,
   PRESENCE_COLOR_TOKENS,
   SEMANTIC_COLOR_TOKENS,
   SERVER_STATUS_COLOR_TOKENS,
+  type SimpleColorToken,
 } from "./colorTokens";
 
 describe("colorTokens", () => {
@@ -71,16 +73,15 @@ describe("colorTokens", () => {
   });
 
   it("derives COLOR_LEGACY_ALIASES from token legacyAlias fields", () => {
-    const expected = [
+    const tokens: SimpleColorToken[] = [
       ...BRAND_COLOR_TOKENS,
       ...NEUTRAL_COLOR_TOKENS,
       ...SEMANTIC_COLOR_TOKENS,
-    ]
-      .filter((token) => token.legacyAlias != null)
-      .map((token) => ({
-        legacy: token.legacyAlias,
-        target: token.varName,
-      }));
+    ];
+    const expected = tokens.filter(hasLegacyAlias).map((token) => ({
+      legacy: token.legacyAlias,
+      target: token.varName,
+    }));
     expect(COLOR_LEGACY_ALIASES).toEqual(expected);
   });
 });

--- a/frontend/src/design/colorTokens.ts
+++ b/frontend/src/design/colorTokens.ts
@@ -11,14 +11,19 @@ export type ColorLegacyAlias = {
   target: ColorVarName;
 };
 
+export function hasLegacyAlias(
+  token: SimpleColorToken,
+): token is SimpleColorToken & { legacyAlias: string } {
+  return token.legacyAlias != null;
+}
+
 function legacyAliasesFrom(
   tokens: ReadonlyArray<SimpleColorToken>,
 ): ColorLegacyAlias[] {
-  return tokens.flatMap((token) =>
-    token.legacyAlias
-      ? [{ legacy: token.legacyAlias, target: token.varName }]
-      : [],
-  );
+  return tokens.filter(hasLegacyAlias).map((token) => ({
+    legacy: token.legacyAlias,
+    target: token.varName,
+  }));
 }
 
 /** Brand color tokens (ADR 0019). */

--- a/frontend/src/design/colorTokens.ts
+++ b/frontend/src/design/colorTokens.ts
@@ -1,35 +1,43 @@
+export type ColorVarName = `--color-${string}`;
+
+export type SimpleColorToken = {
+  name: string;
+  varName: ColorVarName;
+  legacyAlias?: string;
+};
+
 /** Brand color tokens (ADR 0019). */
 export const BRAND_COLOR_TOKENS = [
   { name: "brand", varName: "--color-brand" },
   { name: "brand-hover", varName: "--color-brand-hover" },
-] as const;
+] as const satisfies ReadonlyArray<SimpleColorToken>;
 
 /** Neutral color tokens (ADR 0019). */
 export const NEUTRAL_COLOR_TOKENS = [
-  { role: "bg-base", varName: "--color-bg-base", legacyAlias: "--bg-primary" },
+  { name: "bg-base", varName: "--color-bg-base", legacyAlias: "--bg-primary" },
   {
-    role: "bg-elevated",
+    name: "bg-elevated",
     varName: "--color-bg-elevated",
     legacyAlias: "--bg-secondary",
   },
   {
-    role: "bg-muted",
+    name: "bg-muted",
     varName: "--color-bg-muted",
     legacyAlias: "--bg-tertiary",
   },
   {
-    role: "text-primary",
+    name: "text-primary",
     varName: "--color-text-primary",
     legacyAlias: "--text-primary",
   },
   {
-    role: "text-secondary",
+    name: "text-secondary",
     varName: "--color-text-secondary",
     legacyAlias: "--text-secondary",
   },
-  { role: "text-muted", varName: "--color-text-muted" },
-  { role: "border", varName: "--color-border", legacyAlias: "--border" },
-] as const;
+  { name: "text-muted", varName: "--color-text-muted" },
+  { name: "border", varName: "--color-border", legacyAlias: "--border" },
+] as const satisfies ReadonlyArray<SimpleColorToken>;
 
 /** Semantic color catalog (ADR 0019). */
 export const SEMANTIC_COLOR_TOKENS = [
@@ -37,53 +45,57 @@ export const SEMANTIC_COLOR_TOKENS = [
   { name: "success", varName: "--color-success", legacyAlias: "--success" },
   { name: "warning", varName: "--color-warning" },
   { name: "info", varName: "--color-info" },
-] as const;
+] as const satisfies ReadonlyArray<SimpleColorToken>;
 
-export type ServerStatusColorKey =
+export type ServerStatusColorName =
   "operational" | "degraded" | "partial" | "major" | "maintenance" | "unknown";
+
+export type ServerStatusColorToken = {
+  name: ServerStatusColorName;
+  varName: `--color-status-${string}`;
+};
 
 /** Server status domain colors (ADR 0019). */
 export const SERVER_STATUS_COLOR_TOKENS = [
-  { key: "operational", varName: "--color-status-operational" },
-  { key: "degraded", varName: "--color-status-degraded" },
-  { key: "partial", varName: "--color-status-partial" },
-  { key: "major", varName: "--color-status-major" },
-  { key: "maintenance", varName: "--color-status-maintenance" },
-  { key: "unknown", varName: "--color-status-unknown" },
-] as const satisfies ReadonlyArray<{
-  key: ServerStatusColorKey;
-  varName: `--color-status-${string}`;
-}>;
+  { name: "operational", varName: "--color-status-operational" },
+  { name: "degraded", varName: "--color-status-degraded" },
+  { name: "partial", varName: "--color-status-partial" },
+  { name: "major", varName: "--color-status-major" },
+  { name: "maintenance", varName: "--color-status-maintenance" },
+  { name: "unknown", varName: "--color-status-unknown" },
+] as const satisfies ReadonlyArray<ServerStatusColorToken>;
 
-export type PresenceColorKey = "join-me" | "active" | "ask-me" | "busy";
+export type PresenceColorName = "join-me" | "active" | "ask-me" | "busy";
+
+export type PresenceColorToken = {
+  name: PresenceColorName;
+  bgVar: `--color-presence-${string}`;
+  borderVar: `--color-presence-${string}-border`;
+};
 
 /** Presence domain colors (ADR 0019). */
 export const PRESENCE_COLOR_TOKENS = [
   {
-    key: "join-me",
+    name: "join-me",
     bgVar: "--color-presence-join-me",
     borderVar: "--color-presence-join-me-border",
   },
   {
-    key: "active",
+    name: "active",
     bgVar: "--color-presence-active",
     borderVar: "--color-presence-active-border",
   },
   {
-    key: "ask-me",
+    name: "ask-me",
     bgVar: "--color-presence-ask-me",
     borderVar: "--color-presence-ask-me-border",
   },
   {
-    key: "busy",
+    name: "busy",
     bgVar: "--color-presence-busy",
     borderVar: "--color-presence-busy-border",
   },
-] as const satisfies ReadonlyArray<{
-  key: PresenceColorKey;
-  bgVar: `--color-presence-${string}`;
-  borderVar: `--color-presence-${string}-border`;
-}>;
+] as const satisfies ReadonlyArray<PresenceColorToken>;
 
 /** Legacy aliases that delegate to App color tokens (migration). */
 export const COLOR_LEGACY_ALIASES = [
@@ -97,4 +109,7 @@ export const COLOR_LEGACY_ALIASES = [
   { legacy: "--border", target: "--color-border" },
   { legacy: "--danger", target: "--color-danger" },
   { legacy: "--success", target: "--color-success" },
-] as const;
+] as const satisfies ReadonlyArray<{
+  legacy: string;
+  target: ColorVarName;
+}>;

--- a/frontend/src/design/colorTokens.ts
+++ b/frontend/src/design/colorTokens.ts
@@ -1,0 +1,100 @@
+/** Brand color tokens (ADR 0019). */
+export const BRAND_COLOR_TOKENS = [
+  { name: "brand", varName: "--color-brand" },
+  { name: "brand-hover", varName: "--color-brand-hover" },
+] as const;
+
+/** Neutral color tokens (ADR 0019). */
+export const NEUTRAL_COLOR_TOKENS = [
+  { role: "bg-base", varName: "--color-bg-base", legacyAlias: "--bg-primary" },
+  {
+    role: "bg-elevated",
+    varName: "--color-bg-elevated",
+    legacyAlias: "--bg-secondary",
+  },
+  {
+    role: "bg-muted",
+    varName: "--color-bg-muted",
+    legacyAlias: "--bg-tertiary",
+  },
+  {
+    role: "text-primary",
+    varName: "--color-text-primary",
+    legacyAlias: "--text-primary",
+  },
+  {
+    role: "text-secondary",
+    varName: "--color-text-secondary",
+    legacyAlias: "--text-secondary",
+  },
+  { role: "text-muted", varName: "--color-text-muted" },
+  { role: "border", varName: "--color-border", legacyAlias: "--border" },
+] as const;
+
+/** Semantic color catalog (ADR 0019). */
+export const SEMANTIC_COLOR_TOKENS = [
+  { name: "danger", varName: "--color-danger", legacyAlias: "--danger" },
+  { name: "success", varName: "--color-success", legacyAlias: "--success" },
+  { name: "warning", varName: "--color-warning" },
+  { name: "info", varName: "--color-info" },
+] as const;
+
+export type ServerStatusColorKey =
+  "operational" | "degraded" | "partial" | "major" | "maintenance" | "unknown";
+
+/** Server status domain colors (ADR 0019). */
+export const SERVER_STATUS_COLOR_TOKENS = [
+  { key: "operational", varName: "--color-status-operational" },
+  { key: "degraded", varName: "--color-status-degraded" },
+  { key: "partial", varName: "--color-status-partial" },
+  { key: "major", varName: "--color-status-major" },
+  { key: "maintenance", varName: "--color-status-maintenance" },
+  { key: "unknown", varName: "--color-status-unknown" },
+] as const satisfies ReadonlyArray<{
+  key: ServerStatusColorKey;
+  varName: `--color-status-${string}`;
+}>;
+
+export type PresenceColorKey = "join-me" | "active" | "ask-me" | "busy";
+
+/** Presence domain colors (ADR 0019). */
+export const PRESENCE_COLOR_TOKENS = [
+  {
+    key: "join-me",
+    bgVar: "--color-presence-join-me",
+    borderVar: "--color-presence-join-me-border",
+  },
+  {
+    key: "active",
+    bgVar: "--color-presence-active",
+    borderVar: "--color-presence-active-border",
+  },
+  {
+    key: "ask-me",
+    bgVar: "--color-presence-ask-me",
+    borderVar: "--color-presence-ask-me-border",
+  },
+  {
+    key: "busy",
+    bgVar: "--color-presence-busy",
+    borderVar: "--color-presence-busy-border",
+  },
+] as const satisfies ReadonlyArray<{
+  key: PresenceColorKey;
+  bgVar: `--color-presence-${string}`;
+  borderVar: `--color-presence-${string}-border`;
+}>;
+
+/** Legacy aliases that delegate to App color tokens (migration). */
+export const COLOR_LEGACY_ALIASES = [
+  { legacy: "--accent", target: "--color-brand" },
+  { legacy: "--accent-hover", target: "--color-brand-hover" },
+  { legacy: "--bg-primary", target: "--color-bg-base" },
+  { legacy: "--bg-secondary", target: "--color-bg-elevated" },
+  { legacy: "--bg-tertiary", target: "--color-bg-muted" },
+  { legacy: "--text-primary", target: "--color-text-primary" },
+  { legacy: "--text-secondary", target: "--color-text-secondary" },
+  { legacy: "--border", target: "--color-border" },
+  { legacy: "--danger", target: "--color-danger" },
+  { legacy: "--success", target: "--color-success" },
+] as const;

--- a/frontend/src/design/colorTokens.ts
+++ b/frontend/src/design/colorTokens.ts
@@ -6,10 +6,29 @@ export type SimpleColorToken = {
   legacyAlias?: string;
 };
 
+export type ColorLegacyAlias = {
+  legacy: string;
+  target: ColorVarName;
+};
+
+function legacyAliasesFrom(
+  tokens: ReadonlyArray<SimpleColorToken>,
+): ColorLegacyAlias[] {
+  return tokens.flatMap((token) =>
+    token.legacyAlias
+      ? [{ legacy: token.legacyAlias, target: token.varName }]
+      : [],
+  );
+}
+
 /** Brand color tokens (ADR 0019). */
 export const BRAND_COLOR_TOKENS = [
-  { name: "brand", varName: "--color-brand" },
-  { name: "brand-hover", varName: "--color-brand-hover" },
+  { name: "brand", varName: "--color-brand", legacyAlias: "--accent" },
+  {
+    name: "brand-hover",
+    varName: "--color-brand-hover",
+    legacyAlias: "--accent-hover",
+  },
 ] as const satisfies ReadonlyArray<SimpleColorToken>;
 
 /** Neutral color tokens (ADR 0019). */
@@ -36,6 +55,7 @@ export const NEUTRAL_COLOR_TOKENS = [
     legacyAlias: "--text-secondary",
   },
   { name: "text-muted", varName: "--color-text-muted" },
+  { name: "text-inverse", varName: "--color-text-inverse" },
   { name: "border", varName: "--color-border", legacyAlias: "--border" },
 ] as const satisfies ReadonlyArray<SimpleColorToken>;
 
@@ -97,19 +117,9 @@ export const PRESENCE_COLOR_TOKENS = [
   },
 ] as const satisfies ReadonlyArray<PresenceColorToken>;
 
-/** Legacy aliases that delegate to App color tokens (migration). */
-export const COLOR_LEGACY_ALIASES = [
-  { legacy: "--accent", target: "--color-brand" },
-  { legacy: "--accent-hover", target: "--color-brand-hover" },
-  { legacy: "--bg-primary", target: "--color-bg-base" },
-  { legacy: "--bg-secondary", target: "--color-bg-elevated" },
-  { legacy: "--bg-tertiary", target: "--color-bg-muted" },
-  { legacy: "--text-primary", target: "--color-text-primary" },
-  { legacy: "--text-secondary", target: "--color-text-secondary" },
-  { legacy: "--border", target: "--color-border" },
-  { legacy: "--danger", target: "--color-danger" },
-  { legacy: "--success", target: "--color-success" },
-] as const satisfies ReadonlyArray<{
-  legacy: string;
-  target: ColorVarName;
-}>;
+/** Legacy aliases derived from token `legacyAlias` fields (single source of truth). */
+export const COLOR_LEGACY_ALIASES = legacyAliasesFrom([
+  ...BRAND_COLOR_TOKENS,
+  ...NEUTRAL_COLOR_TOKENS,
+  ...SEMANTIC_COLOR_TOKENS,
+]);


### PR DESCRIPTION
## Summary

- Add **App color tokens** (`--color-*`) as the single source of truth in `style.css`, with **Element Plus color mapping** and legacy aliases (`--accent`, `--bg-primary`, etc.) for gradual adoption
- Document the palette in **ADR 0019**, **CONTEXT.md** (Design system glossary), and **Color Storybook catalog** (`colorTokens.ts` + stories)
- Tokenize **Server status** and **Presence** domain colors; update shared styles to use canonical tokens (visual appearance unchanged per v1 policy)

## Test plan

- [x] `make fmt`
- [x] `make test` (Go + frontend Vitest, including `colorTokens.spec.ts`)
- [x] `pnpm run lint` (frontend)
- [ ] Storybook: **Design System / Color** — swatches for Brand, Neutral, Semantic, Server status, Presence, EP mapping table
- [ ] Smoke: Dashboard Server status colors and Presence change color buttons look unchanged
- [ ] Confirm legacy views still render (aliases for `--bg-*`, `--accent`, etc.)


Made with [Cursor](https://cursor.com)