### PR TITLE
feat(frontend): Typography design system (ADR 0020)

### DIFF
--- a/.cursor/rules/color-design-system.mdc
+++ b/.cursor/rules/color-design-system.mdc
@@ -51,5 +51,6 @@ border-color: var(--color-border);
 ## 関連
 
 - 余白: `.cursor/rules/spacing-design-system.mdc`
+- タイポグラフィ: `.cursor/rules/typography-design-system.mdc`
 - ボタン: `.cursor/rules/button-design-system.mdc`
 - Element Plus 一般: `.cursor/rules/element-plus-ui.mdc`

--- a/.cursor/rules/typography-design-system.mdc
+++ b/.cursor/rules/typography-design-system.mdc
@@ -1,0 +1,73 @@
+---
+description: Typography タイポグラフィデザインシステム（ADR 0020）。新規・改修で触った画面は Typography token / Text style を使う
+globs: "frontend/**/*.{vue,ts,css}"
+alwaysApply: false
+---
+
+# Typography design system
+
+正本: [ADR 0020](../docs/adr/0020-typography-design-system.md)、用語: [`CONTEXT.md`](../CONTEXT.md) Design system 節。
+
+## トークン
+
+`frontend/src/assets/style.css` の `:root` で定義。
+
+**Font size**（px）: `--font-size-10` … `--font-size-24`（10, 12, 14, 16, 18, 20, 24 のみ）
+
+**Line height**（無単位）:
+
+| 変数 | 値 | 用途 |
+|------|-----|------|
+| `--line-height-tight` | 1.25 | 見出し |
+| `--line-height-normal` | 1.5 | Body 既定 |
+| `--line-height-relaxed` | 1.75 | 長文 |
+
+**Font weight**: `--font-weight-400` … `--font-weight-700`（400, 500, 600, 700 のみ）
+
+**Font family**: `--font-family-ui`（UI サンセリフスタック）
+
+## Text style catalog
+
+共有クラス（色は含まない。`--color-text-*` は Color 側）:
+
+| クラス | 用途 |
+|--------|------|
+| `.text-h1` | Heading 1（`.page-title` は同型 alias + margin） |
+| `.text-h2` … `.text-h4` | 画面内見出し |
+| `.text-body` | 本文（`body` と同型） |
+| `.text-body-sm` | 補足・ラベル |
+| `.text-caption` | メタ情報・最小段 |
+
+## 使い方
+
+```css
+font-size: var(--font-size-14);
+line-height: var(--line-height-normal);
+font-weight: var(--font-weight-600);
+font-family: var(--font-family-ui);
+```
+
+または `<p class="text-body-sm">` のように Text style クラスを使う。
+
+- `rem` / スケール外の任意 `px` / 非標準 `font-weight` は増やさない
+- `--el-font-size-*` 直参照は EP mapping ブロックと既存 EP 利用に限定
+- EP の `13px`（`--el-font-size-small`）は derivative。画面から参照しない
+- TitleBar クローム・**Code font** は v1 スコープ外
+
+## 移行（Typography adoption）
+
+- 新規・改修で触ったファイルはトークン化する
+- 未触りの View scoped `rem` / 任意 px は一括置換しない
+- 置換時は **Typography migration rounding**（四捨五入で最寄り段階）
+- v1 deliverables では見た目を変えない（H1 は `calc(var(--font-size-14) * 1.4)`）
+- ESLint 禁止は v1 では入れない
+
+## Storybook
+
+`frontend/src/design/Typography.stories.ts` がスケール・Text style・EP mapping の正本。変更時は `typographyTokens.ts` とストーリーも更新する。
+
+## 関連
+
+- 色: `.cursor/rules/color-design-system.mdc`
+- 余白: `.cursor/rules/spacing-design-system.mdc`
+- ボタン: `.cursor/rules/button-design-system.mdc`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -708,7 +708,7 @@ _Avoid_: 常時実行, バックグラウンドサービス（v1 で含意しな
 
 ## Design system
 
-ボタン様式・余白・色などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
+ボタン様式・余白・色・タイポグラフィなどアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
 
 ### Language
 
@@ -902,6 +902,106 @@ _Avoid_: Color token（App 正本と混同するため）, 派生色カタログ
 **Color v1 visual policy**:
 Color v1 では **hex 値・見た目を変えない**。現行 `style.css`・**Server status color**・**Presence color** の色をそのまま **App color token** に移し、トークン名と参照の整理のみ行う。コントラスト改善・色相の揃え込み・Brand のリデザインは v1 スコープ外（別 PR／Issue）。
 _Avoid_: リデザイン（v1 で見た目変更を含意するため）, トークン化 PR での微調整（回帰レビューと混ぜないため）
+
+**Typography**:
+アプリ横断の文字組ルール。UI 用 **Font family**、**Typography scale**（サイズ）、**Line height**、**Font weight**、用途別 **Text style**（見出し・本文・キャプション等）を含む。**Spacing** の Sizing・**Border radius** とは別カテゴリ。**Color** の **Neutral text**（色）とは別で、サイズ・行高・太さを扱う。
+_Avoid_: フォント（ウェイト・行高を含意しない俗称）, テーマ（色・余白まで含む総称）
+
+**Typography v1 scope**:
+Typography の最初の届け範囲。**ダークテーマのみ**の **Typography token**・**Text style catalog**、**Typography adoption**、**Typography Storybook catalog**、ADR、`.cursor/rules/` に限定する。含める: アプリ作者が書くテキスト（`style.css` 共有クラス、新規・改修 View）、**Line height** の正本化（**Spacing** では除外済み）。含めない: Element Plus コンポーネント内部タイポの全面上書き、**Sizing**（アイコン・アバター寸法）、TitleBar 等ウィンドウクローム固有サイズ、**Code font**（モノスペース）カタログ、ライトテーマ・テーマ切替 UI、全 View 一括トークン化、ESLint 強制。
+_Avoid_: Typography（v1 範囲を指すときは scope とセットで書く）, 将来拡張（スコープ外リストの総称として曖昧なため）
+
+**Typography v1 deliverables**:
+Issue／PR で最初に届ける具体物。(1) `frontend/src/assets/style.css` の **Typography token** 全種、**Text style catalog** 共有クラス、`body` / `.page-title` のトークン化、**Element Plus typography mapping**、(2) `frontend/src/design/typographyTokens.ts`（Spacing の `spacingTokens.ts` 同型）+ 単体テスト、(3) **Typography Storybook catalog**、(4) `.cursor/rules/typography-design-system.mdc`、(5) `docs/adr/0020-typography-design-system.md` + `CONTEXT.md`。各 View の scoped `rem` / 任意 px は **Typography adoption** に従い触ったところだけ。
+_Avoid_: Typography v1 scope（届け物リストを指すときは deliverables とセットで書く）, 全画面置換（adoption と矛盾するため）
+
+**Typography v1 visual policy**:
+Typography v1 では **見た目を変えない**（**Color v1 visual policy** と同型）。現行の computed サイズ・行高・ウェイトをそのまま **Typography token** / **Text style** に移し、トークン名と参照の整理のみ行う。タイポグラフィのリデザイン・スケールの整理による寄せは v1 スコープ外（別 PR／Issue）。
+_Avoid_: リデザイン（v1 で見た目変更を含意するため）, Spacing 型の四捨五入寄せを v1 deliverables に含める（回帰レビューと混ぜないため）
+
+**Typography token**:
+Typography の正本となる CSS カスタムプロパティ。`frontend/src/assets/style.css` の `:root` に定義する。サイズは **px リテラル**の **Font size token**（`--font-size-*`）、行高は **Line height token**、太さは **Font weight token**、用途別まとまりは **Text style**（セマンティック・エイリアスまたは共有クラス）。`rem` / `em` でスケールを表現しない。`html { font-size: 14px }` は Typography v1 では変更しない（**Spacing** ADR と同様）。`body` の既定サイズは **Font size token** の 14px 段へ委譲する。
+_Avoid_: rem トークン（14px ルートと噛み合わないため）, font-md（数値と名前がずれるため）
+
+**Font size token**:
+**Typography scale** の各段階を表す **Typography token**。値は **px リテラル**（例: `--font-size-14: 14px`）。トークン名の数値は実 px と一致させる（`--font-size-14` は 14px）。新規・改修ではスケール外の任意 `px` / `rem` 直書きを増やさない（**Typography adoption**）。
+_Avoid_: --text-14（サイズと色の接頭辞が衝突しうるため）, 1rem（単位混在）
+
+**Typography scale**:
+Typography で使ってよいフォントサイズの段階列。許容値は **10, 12, 14, 16, 18, 20, 24**（px）のみ。新規・改修ではこの列以外の任意サイズを増やさない（**Typography adoption**）。`body` 既定は **14** 段。
+_Avoid_: 8 の倍数ルール（10 を含むため）, 連続スケール（任意の 1px 刻みすべてを許す印象）, Spacing scale との同一列（用途が別のため）
+
+**Typography migration rounding**:
+既存の `rem` や任意 px を **Font size token** へ置き換えるとき（**Typography adoption**）、スケールに無い値は **四捨五入で最寄りの段階**へ寄せる（例: 12.6px → 12 または 13 → **12**、15.4px → **16**、19.6px → **20**）。**Typography v1 deliverables** では寄せない。スケール外でも現行 computed と完全一致が必要な共有スタイルは **Text style** で `calc(var(--font-size-14) * 倍率)` 等を使い見た目を維持する。
+_Avoid_: 目視のみ（置換ごとに判断がぶれるため）, v1 deliverables での四捨五入（**Typography v1 visual policy** と矛盾）
+
+**Font family token**:
+UI 本文スタックを表す **Typography token**（`--font-family-ui`）。モノスペース（**Code font**）は v1 では含めない。Web フォントの新規読み込みは v1 スコープ外。`button` / `input` / `textarea` は `inherit` で **Font family token** に追従する。
+_Avoid_: --font-sans（Tailwind 俗称）, 日本語フォント（v1 でスタック変更を含意するため）
+
+**UI font**:
+**Font family token** が指す、本文・見出し・ラベル等に使うサンセリフスタック。v1 では現行 `body` と同型（Segoe UI → system UI → sans-serif）。**Typography v1 visual policy** に従いスタックも見た目も変えない。
+_Avoid_: 本文フォント（**Code font** を含意しうるため）, Element Plus フォント（EP 内部は v1 で全面上書きしない）
+
+**Line height token**:
+行高を表す **Typography token**。値は **無単位の比率**（`px` ではない）。フォントサイズに追従する。**Line height scale** の各段階または **Line height pattern** 名で参照する。
+_Avoid_: px 行高（テキストの拡大縮小に弱いため）, line-height-150（数値名と実値の対応が曖昧なため）
+
+**Line height scale**:
+Typography で使ってよい行高の段階列（無単位）。v1 は **1.25, 1.5, 1.75** の 3 段のみ。`body` 既定は **1.5**（`--line-height-normal`）。メニュー行高など固定 `px` の Sizing は含めない。
+_Avoid_: 1.4（スケール外の中間値）, 連続スケール（任意の小数すべてを許す印象）
+
+**Line height pattern**:
+繰り返し現れる行高に付ける意味別の名前。**Line height token** のセマンティック・エイリアスとして定義し、実体は **Line height scale** へ委譲する。v1: `--line-height-tight` → 1.25、`--line-height-normal` → 1.5、`--line-height-relaxed` → 1.75。
+_Avoid_: ユーティリティクラス（`.leading-normal` 等のクラス体系を含意するため）
+
+**Font weight token**:
+フォントウェイトを表す **Typography token**。トークン名の数値は CSS の `font-weight` 値と一致させる（例: `--font-weight-600: 600`）。**Font weight scale** 以外の任意ウェイトを新規・改修で増やさない（**Typography adoption**）。
+_Avoid_: semibold（数値と名前がずれるため）, bold トークン（`700` と 1 対 1 でない印象）
+
+**Font weight scale**:
+Typography で使ってよいフォントウェイトの段階列。v1 は **400, 500, 600, 700** の 4 段のみ。`body` 既定は **400**。非標準値（`450` / `550` 等）は **Typography adoption** で最寄り段階へ四捨五入（`450` → `500`、`550` → `600`）。**Typography v1 deliverables** では寄せない。
+_Avoid_: 300（現行 UI に無いため）, 800 以上（現行 UI に無いため）
+
+**Text style**:
+用途別の標準文字組（フォントサイズ・行高・ウェイトの組み合わせ）。**Text style catalog** で定義する。**Neutral text**（色）は **Color** の責務のため Text style には含めない。実装は `style.css` の共有クラス（`.text-h1` 等）。色が必要なときは呼び出し側または親で **Neutral text token** を指定する。
+_Avoid_: タイポグラフィ（トークン全体の総称）, テキスト色（**Color** と混同しやすいため）
+
+**Text style catalog**:
+v1 の **Text style** 公式一覧（いずれも共有クラス + Storybook 参照）。
+
+| Style | font-size | line-height | font-weight | クラス |
+|-------|-----------|-------------|-------------|--------|
+| Heading 1 | `calc(var(--font-size-14) * 1.4)` | tight | 600 | `.text-h1`（既存 `.page-title` は同型 alias） |
+| Heading 2 | `--font-size-18` | tight | 600 | `.text-h2` |
+| Heading 3 | `--font-size-16` | tight | 600 | `.text-h3` |
+| Heading 4 | `--font-size-14` | normal | 600 | `.text-h4` |
+| Body | `--font-size-14` | normal | 400 | `.text-body`（`body` 既定と同型） |
+| Body small | `--font-size-12` | normal | 400 | `.text-body-sm` |
+| Caption | `--font-size-10` | normal | 400 | `.text-caption` |
+
+**Typography v1 visual policy** に従い Heading 1 は `calc` で現行 19.6px を維持する。将来リデザインで `--font-size-20` へ寄せてよい。
+_Avoid_: h1 要素（HTML セマンティクスと 1 対 1 でない。見出しレベルは文脈で選ぶ）, 全スタイルの色込み定義
+
+**Page title style**:
+画面最上部のページ名向け **Text style**。**Heading 1** と同型。v1 では既存クラス名 `.page-title` を残し **Heading 1** の alias として扱う（リネームは v1 スコープ外）。
+_Avoid_: Heading 1（HTML の `<h1>` 限定を含意するため）, ウィンドウタイトル（TitleBar は **Typography v1 scope** 外）
+
+**Element Plus typography mapping**:
+**Font size token** から Element Plus の `--el-font-size-*` へ値を渡す層。`html.dark` 内で定義する。`el-form` / `el-table` 等の EP テーマ整合が目的。コンポーネントの独自スタイルは原則 **Typography token** または **Text style** を参照し、`--el-font-size-*` 直参照は EP 上書きブロックと既存 EP 利用箇所に限定する（**Element Plus color mapping** と同型）。
+_Avoid_: EP 正本（出所を Element Plus に置く案）, 二重カタログ（App と EP を別々に管理する案）
+
+**Element Plus typography derivative**:
+**Element Plus typography mapping** 内だけで定義する、EP コンポーネント向けのスケール外サイズ（例: `--el-font-size-small: 13px`）。**Font size token** の委譲先ではなく、**Typography scale** に無い値を v1 では mapping 内に残して見た目を維持する。画面・共有スタイルから直接参照しない。
+_Avoid_: Typography token（App 正本と混同するため）, 13px の App token 化（v1 でスケールを壊すため）
+
+**Typography adoption**:
+**Typography token** / **Text style** への移行方針。新規画面・改修で触ったファイルでは **Typography token** または **Text style catalog** を使い、`rem`・スケール外の任意 `px`・非標準 `font-weight` を増やさない。未着手の既存 View は一括置換しない（触ったところから順次）。**Typography v1 deliverables** の共有スタイルと **Element Plus typography mapping** は v1 で寄せる。置換時は **Typography migration rounding** を適用する（**Typography v1 deliverables** 自体では寄せない）。遵守は `.cursor/rules/` で案内し、移行期は ESLint では強制しない。見た目の正本は **Typography Storybook catalog**。
+_Avoid_: 全面置換, rem 禁止の CI 強制（即時一括・CI 強制を含意するため）
+
+**Typography Storybook catalog**:
+Typography の Storybook 一覧。**Typography scale**・**Line height scale**・**Font weight scale**・**Text style catalog** の対応表と使用例、**Element Plus typography mapping** の要点を載せ、見た目と使い方の正本とする（**Spacing Storybook catalog** / **Color Storybook catalog** と同型）。
+_Avoid_: 全画面 Storybook, デザイントークン一覧（Color・Spacing の総称）
 
 ## Agent contribution
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -984,8 +984,8 @@ v1 の **Text style** 公式一覧（いずれも共有クラス + Storybook 参
 _Avoid_: h1 要素（HTML セマンティクスと 1 対 1 でない。見出しレベルは文脈で選ぶ）, 全スタイルの色込み定義
 
 **Page title style**:
-画面最上部のページ名向け **Text style**。**Heading 1** と同型。v1 では既存クラス名 `.page-title` を残し **Heading 1** の alias として扱う（リネームは v1 スコープ外）。
-_Avoid_: Heading 1（HTML の `<h1>` 限定を含意するため）, ウィンドウタイトル（TitleBar は **Typography v1 scope** 外）
+画面最上部のページ名向け **Text style**。**Heading 1** と同じ font-size / font-weight（`--font-size-h1` / 600）だが、line-height は **v1 visual policy** のため body の `--line-height-normal` を継承する（`.text-h1` の tight とは意図的に異なる）。v1 では既存クラス名 `.page-title` を残す。
+_Avoid_: Heading 1（HTML の `<h1>` 限定を含意するため）, ウィンドウタイトル（TitleBar は **Typography v1 scope** 外）, `.text-h1` と完全同一（line-height が異なる）
 
 **Element Plus typography mapping**:
 **Font size token** から Element Plus の `--el-font-size-*` へ値を渡す層。`html.dark` 内で定義する。`el-form` / `el-table` 等の EP テーマ整合が目的。コンポーネントの独自スタイルは原則 **Typography token** または **Text style** を参照し、`--el-font-size-*` 直参照は EP 上書きブロックと既存 EP 利用箇所に限定する（**Element Plus color mapping** と同型）。

--- a/docs/adr/0020-typography-design-system.md
+++ b/docs/adr/0020-typography-design-system.md
@@ -28,6 +28,12 @@ Accepted（grill-with-docs で合意）
 | 20 | `--font-size-20` |
 | 24 | `--font-size-24` |
 
+**Font size derivative**（スケール外・レガシー維持）:
+
+| 用途 | CSS 変数 | 値 |
+|------|----------|-----|
+| Heading 1 / page title | `--font-size-h1` | `calc(var(--font-size-14) * 1.4)`（19.6px @ 14px root） |
+
 - 上記以外の任意サイズは新規・改修で増やさない
 - 値は **px リテラル**。`rem` / `em` は使わない
 - `html { font-size: 14px }` は Typography のために変更しない
@@ -68,7 +74,7 @@ Accepted（grill-with-docs で合意）
 
 | Style | font-size | line-height | font-weight | クラス |
 |-------|-----------|-------------|-------------|--------|
-| Heading 1 | `calc(var(--font-size-14) * 1.4)` | tight | 600 | `.text-h1`（`.page-title` は同型 alias + margin + 色） |
+| Heading 1 | `--font-size-h1` | tight | 600 | `.text-h1`（`.page-title` は同型 alias + margin + 色。line-height は継承） |
 | Heading 2 | `--font-size-18` | tight | 600 | `.text-h2` |
 | Heading 3 | `--font-size-16` | tight | 600 | `.text-h3` |
 | Heading 4 | `--font-size-14` | normal | 600 | `.text-h4` |
@@ -92,7 +98,7 @@ Accepted（grill-with-docs で合意）
 
 ### 7. Typography v1 visual policy
 
-tokenize 時は **既存の見た目を変えない**。Heading 1 は `calc(var(--font-size-14) * 1.4)` で 19.6px を維持。タイポグラフィのリデザインは v1 スコープ外。
+tokenize 時は **既存の見た目を変えない**。Heading 1 は `--font-size-h1`（19.6px）を維持。`.page-title` は line-height を継承（従来どおり 1.5）。タイポグラフィのリデザインは v1 スコープ外。
 
 ### 8. 実装正本
 

--- a/docs/adr/0020-typography-design-system.md
+++ b/docs/adr/0020-typography-design-system.md
@@ -1,0 +1,151 @@
+# ADR 0020: Typography design system
+
+## Status
+
+Accepted（grill-with-docs で合意）
+
+## Context
+
+- フォントサイズが `rem`（14px ルート）と任意 `px` で混在し、`0.9rem`・`12px`・`1.05rem` など **Typography scale に乗らない値**が散見される
+- **VtButton**（[ADR 0017](0017-button-design-system-vtbutton.md)）、**Spacing**（[ADR 0018](0018-spacing-design-system.md)）、**Color**（[ADR 0019](0019-color-design-system.md)）は整備済みだが、タイポグラフィの正本は未定義
+- `html { font-size: 14px }` のため `rem` ベースのサイズトークンはスケールと噛み合わない（Spacing ADR と同様、ルートは v1 では変更しない）
+- **Spacing** v1 では line-height を対象外とした。用途別の行高は Typography で正本化する
+- Element Plus は `--el-font-size-*` を持つが、画面作者が直接触る必要は限定的
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Design system** セクション（**Typography**、**Typography scale**、**Text style catalog** 等）を正本とする。
+
+## Decision
+
+### 1. Typography scale（font-size）
+
+| px | CSS 変数 |
+|----|----------|
+| 10 | `--font-size-10` |
+| 12 | `--font-size-12` |
+| 14 | `--font-size-14` |
+| 16 | `--font-size-16` |
+| 18 | `--font-size-18` |
+| 20 | `--font-size-20` |
+| 24 | `--font-size-24` |
+
+- 上記以外の任意サイズは新規・改修で増やさない
+- 値は **px リテラル**。`rem` / `em` は使わない
+- `html { font-size: 14px }` は Typography のために変更しない
+- `body` 既定は **14** 段
+
+### 2. Line height scale
+
+| Pattern | CSS 変数 | 値（無単位） |
+|---------|----------|--------------|
+| tight | `--line-height-tight` | 1.25 |
+| normal | `--line-height-normal` | 1.5 |
+| relaxed | `--line-height-relaxed` | 1.75 |
+
+`body` 既定は `--line-height-normal`。
+
+### 3. Font weight scale
+
+| 値 | CSS 変数 |
+|----|----------|
+| 400 | `--font-weight-400` |
+| 500 | `--font-weight-500` |
+| 600 | `--font-weight-600` |
+| 700 | `--font-weight-700` |
+
+`body` 既定は **400**。非標準値（`450` / `550` 等）は **Typography adoption** で最寄り段階へ四捨五入。
+
+### 4. Font family
+
+| CSS 変数 | 値 |
+|----------|-----|
+| `--font-family-ui` | `"Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif` |
+
+**Code font**（モノスペース）は v1 スコープ外。Web フォント追加も v1 外。
+
+### 5. Text style catalog
+
+共有クラス（`style.css`）。色は含めない（**Neutral text token** は Color 側）。
+
+| Style | font-size | line-height | font-weight | クラス |
+|-------|-----------|-------------|-------------|--------|
+| Heading 1 | `calc(var(--font-size-14) * 1.4)` | tight | 600 | `.text-h1`（`.page-title` は同型 alias + margin + 色） |
+| Heading 2 | `--font-size-18` | tight | 600 | `.text-h2` |
+| Heading 3 | `--font-size-16` | tight | 600 | `.text-h3` |
+| Heading 4 | `--font-size-14` | normal | 600 | `.text-h4` |
+| Body | `--font-size-14` | normal | 400 | `.text-body` |
+| Body small | `--font-size-12` | normal | 400 | `.text-body-sm` |
+| Caption | `--font-size-10` | normal | 400 | `.text-caption` |
+
+### 6. Element Plus typography mapping
+
+`html.dark` 内で **Font size token** へ委譲:
+
+| EP 変数 | 委譲先 |
+|---------|--------|
+| `--el-font-size-extra-large` | `var(--font-size-20)` |
+| `--el-font-size-large` | `var(--font-size-18)` |
+| `--el-font-size-medium` | `var(--font-size-16)` |
+| `--el-font-size-base` | `var(--font-size-14)` |
+| `--el-font-size-extra-small` | `var(--font-size-12)` |
+
+`--el-font-size-small: 13px` は **Element Plus typography derivative** として mapping 内に残す（Typography scale 外・見た目不変）。
+
+### 7. Typography v1 visual policy
+
+tokenize 時は **既存の見た目を変えない**。Heading 1 は `calc(var(--font-size-14) * 1.4)` で 19.6px を維持。タイポグラフィのリデザインは v1 スコープ外。
+
+### 8. 実装正本
+
+- トークン定義・Text style・EP mapping: `frontend/src/assets/style.css`
+- カタログ定数（Storybook・テスト用）: `frontend/src/design/typographyTokens.ts`
+- 見た目と使い方: **Typography Storybook catalog**（`frontend/src/design/Typography.stories.ts`）
+- Agent 規約: `.cursor/rules/typography-design-system.mdc`
+
+### 9. Typography adoption
+
+- 新規・改修で触ったファイルでは **Typography token** または **Text style catalog** を使う
+- `style.css` の共有スタイル（`body`、`.page-title`、`.section-card__toggle` 等）は v1 でトークンへ寄せる
+- 既存 View の `rem` / 任意 px は一括置換しない
+- **Typography migration rounding**: スケール外の値は四捨五入で最寄りトークンへ（v1 deliverables では寄せない）
+- TitleBar クローム・**Code font** は v1 スコープ外
+- Element Plus 内部タイポの全面上書きは v1 スコープ外
+- ESLint 強制は v1 では入れない
+
+## Considered options
+
+| 案 | 却下理由 |
+|----|----------|
+| `rem` トークン + `html` を 16px に変更 | 既存 UI 全体のタイポグラフィが変わり、Spacing ADR の前提も崩れる |
+| px スケールに 11 / 13 を含める | 段数が増え、EP derivative との境界が曖昧になる |
+| Heading 1 を `--font-size-20` 固定 | 19.6px → 20px で見た目が変わる（v1 visual policy と矛盾） |
+| Text style に色を含める | **Color** の Neutral text と二重管理になる |
+| EP `--el-font-size-small` を 12px に寄せる | EP コンポーネントの見た目が変わる |
+| 全 View 一括置換 | Spacing / Color adoption と方針が矛盾しリグレッションリスクが大きい |
+| Noto Sans JP 等の Web フォント追加 | v1 visual policy（見た目不変）と矛盾 |
+
+## v1 scope
+
+**含む:**
+
+- `style.css` へのトークン + Text style 定義、共有クラスのトークン化、EP typography mapping
+- `typographyTokens.ts` + 単体テスト
+- Typography Storybook catalog
+- `.cursor/rules/typography-design-system.mdc`
+- `CONTEXT.md` / 本 ADR
+
+**含めない:**
+
+- 全画面の一括トークン化
+- TitleBar クロームのトークン化
+- **Code font** カタログ
+- Element Plus 内部タイポの全面上書き
+- ライトテーマ・テーマ切替
+- 見た目のリデザイン（H1 を 20px 固定へ寄せる等）
+- ESLint 任意サイズ禁止
+
+## Consequences
+
+- 新規・改修 PR では `var(--font-size-*)` / **Text style** クラスが期待される
+- **Typography Storybook catalog** がタイポの正本となり、Spacing / Color / VtButton catalog と並べて参照できる
+- Heading 1 の `calc` は将来 `--font-size-20` へ寄せるリデザイン PR の入口を残す
+- v1 マージ直後の視覚差は意図しない（token 値は現行 computed と同等）

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -81,6 +81,8 @@
   --font-size-18: 18px;
   --font-size-20: 20px;
   --font-size-24: 24px;
+  /* Outside scale: preserves legacy page title (1.4rem @ 14px root = 19.6px). */
+  --font-size-h1: calc(var(--font-size-14) * 1.4);
 
   --line-height-tight: 1.25;
   --line-height-normal: 1.5;
@@ -272,7 +274,7 @@ a:hover {
 }
 
 .text-h1 {
-  font-size: calc(var(--font-size-14) * 1.4);
+  font-size: var(--font-size-h1);
   line-height: var(--line-height-tight);
   font-weight: var(--font-weight-600);
 }
@@ -316,8 +318,7 @@ a:hover {
 /* Page title shared style (Heading 1 alias) */
 .page-title {
   margin: 0 0 var(--space-block);
-  font-size: calc(var(--font-size-14) * 1.4);
-  line-height: var(--line-height-tight);
+  font-size: var(--font-size-h1);
   font-weight: var(--font-weight-600);
   color: var(--color-text-primary);
 }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -72,6 +72,26 @@
   --space-block: var(--space-16);
   --space-section: var(--space-24);
   --space-page: var(--space-32);
+
+  /* Typography scale (ADR 0020) */
+  --font-size-10: 10px;
+  --font-size-12: 12px;
+  --font-size-14: 14px;
+  --font-size-16: 16px;
+  --font-size-18: 18px;
+  --font-size-20: 20px;
+  --font-size-24: 24px;
+
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.75;
+
+  --font-weight-400: 400;
+  --font-weight-500: 500;
+  --font-weight-600: 600;
+  --font-weight-700: 700;
+
+  --font-family-ui: "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 /* ─── Element Plus dark theme CSS variable overrides ───────────── */
@@ -172,6 +192,14 @@ html.dark {
   --el-scrollbar-bg-color: var(--color-border);
   --el-scrollbar-hover-opacity: 0.8;
   --el-scrollbar-hover-bg-color: var(--color-brand);
+
+  /* Typography (ADR 0020) */
+  --el-font-size-extra-large: var(--font-size-20);
+  --el-font-size-large: var(--font-size-18);
+  --el-font-size-medium: var(--font-size-16);
+  --el-font-size-base: var(--font-size-14);
+  --el-font-size-small: 13px;
+  --el-font-size-extra-small: var(--font-size-12);
 }
 
 /* ─── Base resets ──────────────────────────────────────────────── */
@@ -187,14 +215,12 @@ html {
 
 body {
   margin: 0;
-  font-family:
-    "Segoe UI",
-    -apple-system,
-    BlinkMacSystemFont,
-    sans-serif;
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-400);
   background: var(--color-bg-base);
   color: var(--color-text-primary);
-  line-height: 1.5;
+  line-height: var(--line-height-normal);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -234,11 +260,65 @@ a:hover {
   line-height: 42px;
 }
 
-/* Page title shared style */
+/* Text style catalog (ADR 0020) */
+.text-h1,
+.text-h2,
+.text-h3,
+.text-h4,
+.text-body,
+.text-body-sm,
+.text-caption {
+  font-family: var(--font-family-ui);
+}
+
+.text-h1 {
+  font-size: calc(var(--font-size-14) * 1.4);
+  line-height: var(--line-height-tight);
+  font-weight: var(--font-weight-600);
+}
+
+.text-h2 {
+  font-size: var(--font-size-18);
+  line-height: var(--line-height-tight);
+  font-weight: var(--font-weight-600);
+}
+
+.text-h3 {
+  font-size: var(--font-size-16);
+  line-height: var(--line-height-tight);
+  font-weight: var(--font-weight-600);
+}
+
+.text-h4 {
+  font-size: var(--font-size-14);
+  line-height: var(--line-height-normal);
+  font-weight: var(--font-weight-600);
+}
+
+.text-body {
+  font-size: var(--font-size-14);
+  line-height: var(--line-height-normal);
+  font-weight: var(--font-weight-400);
+}
+
+.text-body-sm {
+  font-size: var(--font-size-12);
+  line-height: var(--line-height-normal);
+  font-weight: var(--font-weight-400);
+}
+
+.text-caption {
+  font-size: var(--font-size-10);
+  line-height: var(--line-height-normal);
+  font-weight: var(--font-weight-400);
+}
+
+/* Page title shared style (Heading 1 alias) */
 .page-title {
   margin: 0 0 var(--space-block);
-  font-size: 1.4rem;
-  font-weight: 600;
+  font-size: calc(var(--font-size-14) * 1.4);
+  line-height: var(--line-height-tight);
+  font-weight: var(--font-weight-600);
   color: var(--color-text-primary);
 }
 
@@ -262,7 +342,7 @@ a:hover {
   border: none;
   background: none;
   font: inherit;
-  font-weight: 600;
+  font-weight: var(--font-weight-600);
   color: var(--color-text-secondary);
   cursor: pointer;
   text-align: left;
@@ -274,7 +354,7 @@ a:hover {
 
 .section-card__toggle-icon {
   flex-shrink: 0;
-  font-size: 1rem;
+  font-size: var(--font-size-14);
 }
 
 .section-card.section-card--collapsed > .el-card__body {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -200,6 +200,7 @@ html.dark {
   --el-font-size-large: var(--font-size-18);
   --el-font-size-medium: var(--font-size-16);
   --el-font-size-base: var(--font-size-14);
+  /* ADR 0020: Element Plus small is intentionally outside the app scale */
   --el-font-size-small: 13px;
   --el-font-size-extra-small: var(--font-size-12);
 }
@@ -270,6 +271,7 @@ a:hover {
 .text-body,
 .text-body-sm,
 .text-caption {
+  /* Explicit UI font regardless of parent context (e.g. EP components). */
   font-family: var(--font-family-ui);
 }
 

--- a/frontend/src/design/Typography.stories.css
+++ b/frontend/src/design/Typography.stories.css
@@ -69,8 +69,20 @@
 
 .typography-story-scale-label {
   /* Storybook-only: 140px ~= legacy 10rem at 14px root for aligned scale rows */
-  flex: 0 0 calc(var(--space-64) * 2 + var(--space-12));
+  flex: 0 1 calc(var(--space-64) * 2 + var(--space-12));
+  min-width: 0;
   font-family: ui-monospace, monospace;
   font-size: var(--font-size-12);
   color: var(--color-text-secondary);
+}
+
+.typography-story-ep-samples {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-action-group);
+}
+
+.typography-story-ep-sample {
+  margin: 0;
+  color: var(--color-text-primary);
 }

--- a/frontend/src/design/Typography.stories.css
+++ b/frontend/src/design/Typography.stories.css
@@ -68,6 +68,7 @@
 }
 
 .typography-story-scale-label {
+  /* Storybook-only: 140px ~= legacy 10rem at 14px root for aligned scale rows */
   flex: 0 0 calc(var(--space-64) * 2 + var(--space-12));
   font-family: ui-monospace, monospace;
   font-size: var(--font-size-12);

--- a/frontend/src/design/Typography.stories.css
+++ b/frontend/src/design/Typography.stories.css
@@ -1,0 +1,75 @@
+.typography-story {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-14);
+}
+
+.typography-story h2 {
+  margin: 0 0 var(--space-block);
+  font-size: var(--font-size-18);
+  font-weight: var(--font-weight-600);
+  line-height: var(--line-height-tight);
+}
+
+.typography-story p {
+  margin: 0 0 var(--space-block);
+  color: var(--color-text-secondary);
+}
+
+.typography-story-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--space-section);
+}
+
+.typography-story-table th,
+.typography-story-table td {
+  padding: var(--space-12) var(--space-16);
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.typography-story-table th {
+  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-600);
+}
+
+.typography-story-table code {
+  font-family: ui-monospace, monospace;
+  font-size: var(--font-size-12);
+}
+
+.typography-story-sample {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-block);
+  margin-bottom: var(--space-section);
+}
+
+.typography-story-sample-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding-bottom: var(--space-block);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.typography-story-sample-label {
+  font-family: ui-monospace, monospace;
+  font-size: var(--font-size-12);
+  color: var(--color-text-secondary);
+}
+
+.typography-story-scale-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-block);
+  margin-bottom: var(--space-12);
+}
+
+.typography-story-scale-label {
+  flex: 0 0 10rem;
+  font-family: ui-monospace, monospace;
+  font-size: var(--font-size-12);
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/design/Typography.stories.css
+++ b/frontend/src/design/Typography.stories.css
@@ -68,7 +68,7 @@
 }
 
 .typography-story-scale-label {
-  flex: 0 0 10rem;
+  flex: 0 0 calc(var(--space-64) * 2 + var(--space-12));
   font-family: ui-monospace, monospace;
   font-size: var(--font-size-12);
   color: var(--color-text-secondary);

--- a/frontend/src/design/Typography.stories.ts
+++ b/frontend/src/design/Typography.stories.ts
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import {
   ELEMENT_PLUS_TYPOGRAPHY_DERIVATIVES,
   ELEMENT_PLUS_TYPOGRAPHY_MAPPING,
+  FONT_FAMILY_UI_VAR,
+  FONT_SIZE_DERIVATIVES,
   FONT_SIZE_SCALE_PX,
   FONT_WEIGHT_SCALE,
   LINE_HEIGHT_PATTERNS,
@@ -39,6 +41,35 @@ export const FontSizeScale: Story = {
   }),
 };
 
+export const FontSizeDerivatives: Story = {
+  name: "Font size derivatives",
+  render: () => ({
+    setup: () => ({ derivatives: FONT_SIZE_DERIVATIVES }),
+    template: `
+      <div class="typography-story">
+        <h2>Font size derivatives</h2>
+        <p>Sizes outside the numeric scale that preserve legacy computed values.</p>
+        <table class="typography-story-table">
+          <thead>
+            <tr>
+              <th>Token</th>
+              <th>Value</th>
+              <th>Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in derivatives" :key="row.varName">
+              <td><code>{{ row.varName }}</code></td>
+              <td><code>{{ row.cssValue }}</code></td>
+              <td>{{ row.note }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    `,
+  }),
+};
+
 export const LineHeightScale: Story = {
   name: "Line height scale",
   render: () => ({
@@ -61,6 +92,22 @@ export const LineHeightScale: Story = {
             </tr>
           </tbody>
         </table>
+      </div>
+    `,
+  }),
+};
+
+export const FontFamilyUi: Story = {
+  name: "UI font family",
+  render: () => ({
+    setup: () => ({ familyVar: FONT_FAMILY_UI_VAR }),
+    template: `
+      <div class="typography-story">
+        <h2>UI font family</h2>
+        <p><code>{{ familyVar }}</code> — sans-serif stack for body, headings, and labels.</p>
+        <p :style="{ fontFamily: 'var(' + familyVar + ')' }">
+          The quick brown fox jumps over the lazy dog.
+        </p>
       </div>
     `,
   }),

--- a/frontend/src/design/Typography.stories.ts
+++ b/frontend/src/design/Typography.stories.ts
@@ -1,0 +1,159 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import {
+  ELEMENT_PLUS_TYPOGRAPHY_DERIVATIVES,
+  ELEMENT_PLUS_TYPOGRAPHY_MAPPING,
+  FONT_SIZE_SCALE_PX,
+  FONT_WEIGHT_SCALE,
+  LINE_HEIGHT_PATTERNS,
+  TEXT_STYLES,
+} from "./typographyTokens";
+import "./Typography.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Design System/Typography",
+  tags: ["autodocs"],
+  parameters: catalogParameters,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FontSizeScale: Story = {
+  name: "Font size scale",
+  render: () => ({
+    setup: () => ({ scale: FONT_SIZE_SCALE_PX }),
+    template: `
+      <div class="typography-story">
+        <h2>Font size scale</h2>
+        <p>Numeric tokens (<code>--font-size-*</code>, px). Body default is 14.</p>
+        <div v-for="px in scale" :key="px" class="typography-story-scale-row">
+          <span class="typography-story-scale-label">--font-size-{{ px }} · {{ px }}px</span>
+          <span :style="{ fontSize: px + 'px' }">The quick brown fox</span>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const LineHeightScale: Story = {
+  name: "Line height scale",
+  render: () => ({
+    setup: () => ({ patterns: LINE_HEIGHT_PATTERNS }),
+    template: `
+      <div class="typography-story">
+        <h2>Line height scale</h2>
+        <p>Unitless ratios. Body default is <code>--line-height-normal</code> (1.5).</p>
+        <table class="typography-story-table">
+          <thead>
+            <tr>
+              <th>Token</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in patterns" :key="row.varName">
+              <td><code>{{ row.varName }}</code></td>
+              <td>{{ row.value }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    `,
+  }),
+};
+
+export const FontWeightScale: Story = {
+  name: "Font weight scale",
+  render: () => ({
+    setup: () => ({ weights: FONT_WEIGHT_SCALE }),
+    template: `
+      <div class="typography-story">
+        <h2>Font weight scale</h2>
+        <p>Body default is <code>--font-weight-400</code>.</p>
+        <div v-for="w in weights" :key="w" class="typography-story-scale-row">
+          <span class="typography-story-scale-label">--font-weight-{{ w }}</span>
+          <span :style="{ fontWeight: w }">Typography weight {{ w }}</span>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const TextStyleCatalog: Story = {
+  name: "Text style catalog",
+  render: () => ({
+    setup: () => ({ styles: TEXT_STYLES }),
+    template: `
+      <div class="typography-story">
+        <h2>Text style catalog</h2>
+        <p>Shared classes in <code>style.css</code>. Colors are not included (use Color tokens).</p>
+        <table class="typography-story-table">
+          <thead>
+            <tr>
+              <th>Class</th>
+              <th>font-size</th>
+              <th>line-height</th>
+              <th>font-weight</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in styles" :key="row.className">
+              <td><code>.{{ row.className }}</code></td>
+              <td><code>{{ row.fontSize }}</code></td>
+              <td><code>{{ row.lineHeightVar }}</code></td>
+              <td><code>{{ row.fontWeightVar }}</code></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="typography-story-sample">
+          <div class="typography-story-sample-row">
+            <span class="typography-story-sample-label">.page-title (Heading 1 alias)</span>
+            <h1 class="page-title">Page title sample</h1>
+          </div>
+          <div v-for="row in styles" :key="'sample-' + row.className" class="typography-story-sample-row">
+            <span class="typography-story-sample-label">.{{ row.className }}</span>
+            <p :class="row.className">The quick brown fox jumps over the lazy dog.</p>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const ElementPlusMapping: Story = {
+  name: "Element Plus typography mapping",
+  render: () => ({
+    setup: () => ({
+      mapping: ELEMENT_PLUS_TYPOGRAPHY_MAPPING,
+      derivatives: ELEMENT_PLUS_TYPOGRAPHY_DERIVATIVES,
+    }),
+    template: `
+      <div class="typography-story">
+        <h2>Element Plus typography mapping</h2>
+        <p>Defined in <code>html.dark</code>. App font-size tokens are the source of truth.</p>
+        <table class="typography-story-table">
+          <thead>
+            <tr>
+              <th>EP variable</th>
+              <th>Delegates to</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in mapping" :key="row.elVar">
+              <td><code>{{ row.elVar }}</code></td>
+              <td><code>var({{ row.appVar }})</code></td>
+            </tr>
+            <tr v-for="row in derivatives" :key="row.elVar">
+              <td><code>{{ row.elVar }}</code></td>
+              <td><code>{{ row.valuePx }}px</code> (derivative, outside scale)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    `,
+  }),
+};

--- a/frontend/src/design/Typography.stories.ts
+++ b/frontend/src/design/Typography.stories.ts
@@ -50,11 +50,12 @@ export const FontSizeDerivatives: Story = {
         <h2>Font size derivatives</h2>
         <p>Sizes outside the numeric scale that preserve legacy computed values.</p>
         <table class="typography-story-table">
+          <caption>Font size derivatives</caption>
           <thead>
             <tr>
-              <th>Token</th>
-              <th>Value</th>
-              <th>Note</th>
+              <th scope="col">Token</th>
+              <th scope="col">Value</th>
+              <th scope="col">Note</th>
             </tr>
           </thead>
           <tbody>
@@ -79,10 +80,11 @@ export const LineHeightScale: Story = {
         <h2>Line height scale</h2>
         <p>Unitless ratios. Body default is <code>--line-height-normal</code> (1.5).</p>
         <table class="typography-story-table">
+          <caption>Line height scale</caption>
           <thead>
             <tr>
-              <th>Token</th>
-              <th>Value</th>
+              <th scope="col">Token</th>
+              <th scope="col">Value</th>
             </tr>
           </thead>
           <tbody>
@@ -139,12 +141,13 @@ export const TextStyleCatalog: Story = {
         <h2>Text style catalog</h2>
         <p>Shared classes in <code>style.css</code>. Colors are not included (use Color tokens).</p>
         <table class="typography-story-table">
+          <caption>Text style catalog</caption>
           <thead>
             <tr>
-              <th>Class</th>
-              <th>font-size</th>
-              <th>line-height</th>
-              <th>font-weight</th>
+              <th scope="col">Class</th>
+              <th scope="col">font-size</th>
+              <th scope="col">line-height</th>
+              <th scope="col">font-weight</th>
             </tr>
           </thead>
           <tbody>
@@ -158,7 +161,7 @@ export const TextStyleCatalog: Story = {
         </table>
         <div class="typography-story-sample">
           <div class="typography-story-sample-row">
-            <span class="typography-story-sample-label">.page-title (Heading 1 alias)</span>
+            <span class="typography-story-sample-label">.page-title (H1 size alias; line-height inherits body)</span>
             <h1 class="page-title">Page title sample</h1>
           </div>
           <div v-for="row in styles" :key="'sample-' + row.className" class="typography-story-sample-row">
@@ -181,12 +184,16 @@ export const ElementPlusMapping: Story = {
     template: `
       <div class="typography-story">
         <h2>Element Plus typography mapping</h2>
-        <p>Defined in <code>html.dark</code>. App font-size tokens are the source of truth.</p>
+        <p>
+          Defined in <code>html.dark</code> (enabled globally in Storybook preview);
+          the samples below resolve the mapped Element Plus variables.
+        </p>
         <table class="typography-story-table">
+          <caption>Element Plus typography mapping</caption>
           <thead>
             <tr>
-              <th>EP variable</th>
-              <th>Delegates to</th>
+              <th scope="col">EP variable</th>
+              <th scope="col">Delegates to</th>
             </tr>
           </thead>
           <tbody>
@@ -200,6 +207,24 @@ export const ElementPlusMapping: Story = {
             </tr>
           </tbody>
         </table>
+        <div class="typography-story-ep-samples">
+          <p
+            v-for="row in mapping"
+            :key="'sample-' + row.elVar"
+            class="typography-story-ep-sample"
+            :style="{ fontSize: 'var(' + row.elVar + ')' }"
+          >
+            {{ row.elVar }} sample
+          </p>
+          <p
+            v-for="row in derivatives"
+            :key="'sample-' + row.elVar"
+            class="typography-story-ep-sample"
+            :style="{ fontSize: 'var(' + row.elVar + ')' }"
+          >
+            {{ row.elVar }} sample
+          </p>
+        </div>
       </div>
     `,
   }),

--- a/frontend/src/design/typographyTokens.spec.ts
+++ b/frontend/src/design/typographyTokens.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   ELEMENT_PLUS_TYPOGRAPHY_DERIVATIVES,
   ELEMENT_PLUS_TYPOGRAPHY_MAPPING,
+  FONT_FAMILY_UI_VAR,
+  FONT_SIZE_DERIVATIVES,
   FONT_SIZE_SCALE_PX,
   FONT_WEIGHT_SCALE,
   LINE_HEIGHT_PATTERNS,
@@ -28,6 +30,17 @@ describe("typographyTokens", () => {
     expect(fontWeightScaleVar(600)).toBe("--font-weight-600");
   });
 
+  it("defines font-size derivatives outside the scale", () => {
+    expect(FONT_SIZE_DERIVATIVES[0]?.varName).toBe("--font-size-h1");
+    expect(FONT_SIZE_DERIVATIVES[0]?.cssValue).toBe(
+      "calc(var(--font-size-14) * 1.4)",
+    );
+  });
+
+  it("exposes UI font family token for Storybook catalog", () => {
+    expect(FONT_FAMILY_UI_VAR).toBe("--font-family-ui");
+  });
+
   it("maps each text style to catalog tokens", () => {
     expect(TEXT_STYLES.map((s) => s.className)).toEqual([
       "text-h1",
@@ -38,7 +51,8 @@ describe("typographyTokens", () => {
       "text-body-sm",
       "text-caption",
     ]);
-    expect(TEXT_STYLES[0]?.fontSize).toBe("calc(var(--font-size-14) * 1.4)");
+    expect(TEXT_STYLES[0]?.fontSize).toBe("var(--font-size-h1)");
+    expect(TEXT_STYLES[0]?.fontWeightVar).toBe(fontWeightScaleVar(600));
   });
 
   it("maps Element Plus font sizes to app tokens", () => {

--- a/frontend/src/design/typographyTokens.spec.ts
+++ b/frontend/src/design/typographyTokens.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  ELEMENT_PLUS_TYPOGRAPHY_DERIVATIVES,
+  ELEMENT_PLUS_TYPOGRAPHY_MAPPING,
+  FONT_SIZE_SCALE_PX,
+  FONT_WEIGHT_SCALE,
+  LINE_HEIGHT_PATTERNS,
+  TEXT_STYLES,
+  fontSizeScaleVar,
+  fontWeightScaleVar,
+} from "./typographyTokens";
+
+describe("typographyTokens", () => {
+  it("defines the agreed font-size scale", () => {
+    expect([...FONT_SIZE_SCALE_PX]).toEqual([10, 12, 14, 16, 18, 20, 24]);
+  });
+
+  it("maps scale px to CSS variable names", () => {
+    expect(fontSizeScaleVar(14)).toBe("--font-size-14");
+  });
+
+  it("defines line-height patterns", () => {
+    expect(LINE_HEIGHT_PATTERNS.map((p) => p.value)).toEqual([1.25, 1.5, 1.75]);
+  });
+
+  it("defines font-weight scale", () => {
+    expect([...FONT_WEIGHT_SCALE]).toEqual([400, 500, 600, 700]);
+    expect(fontWeightScaleVar(600)).toBe("--font-weight-600");
+  });
+
+  it("maps each text style to catalog tokens", () => {
+    expect(TEXT_STYLES.map((s) => s.className)).toEqual([
+      "text-h1",
+      "text-h2",
+      "text-h3",
+      "text-h4",
+      "text-body",
+      "text-body-sm",
+      "text-caption",
+    ]);
+    expect(TEXT_STYLES[0]?.fontSize).toBe("calc(var(--font-size-14) * 1.4)");
+  });
+
+  it("maps Element Plus font sizes to app tokens", () => {
+    for (const row of ELEMENT_PLUS_TYPOGRAPHY_MAPPING) {
+      expect(row.appVar).toMatch(/^--font-size-\d+$/);
+    }
+    expect(ELEMENT_PLUS_TYPOGRAPHY_DERIVATIVES[0]?.valuePx).toBe(13);
+  });
+});

--- a/frontend/src/design/typographyTokens.ts
+++ b/frontend/src/design/typographyTokens.ts
@@ -59,13 +59,18 @@ export const FONT_SIZE_DERIVATIVES = [
   },
 ] as const satisfies readonly FontSizeDerivative[];
 
+export type FontSizeDerivativeVar = "--font-size-h1";
+
+export type FontSizeTokenRef =
+  `var(--font-size-${FontSizeScalePx})` | `var(${FontSizeDerivativeVar})`;
+
 export type TextStyleName =
   "h1" | "h2" | "h3" | "h4" | "body" | "body-sm" | "caption";
 
 export type TextStyle = {
   name: TextStyleName;
   className: `text-${TextStyleName}`;
-  fontSize: string;
+  fontSize: FontSizeTokenRef;
   lineHeightVar: LineHeightPattern["varName"];
   fontWeightVar: ReturnType<typeof fontWeightScaleVar>;
 };

--- a/frontend/src/design/typographyTokens.ts
+++ b/frontend/src/design/typographyTokens.ts
@@ -1,0 +1,128 @@
+/** Font size scale px values (ADR 0020). */
+export const FONT_SIZE_SCALE_PX = [10, 12, 14, 16, 18, 20, 24] as const;
+
+export type FontSizeScalePx = (typeof FONT_SIZE_SCALE_PX)[number];
+
+/** CSS custom property for a numeric font-size step, e.g. `--font-size-14`. */
+export function fontSizeScaleVar(
+  px: FontSizeScalePx,
+): `--font-size-${FontSizeScalePx}` {
+  return `--font-size-${px}`;
+}
+
+export type LineHeightPatternName = "tight" | "normal" | "relaxed";
+
+export type LineHeightPattern = {
+  name: LineHeightPatternName;
+  varName: `--line-height-${LineHeightPatternName}`;
+  value: number;
+};
+
+/** Line height pattern catalog (v1). Unitless ratios. */
+export const LINE_HEIGHT_PATTERNS = [
+  { name: "tight", varName: "--line-height-tight", value: 1.25 },
+  { name: "normal", varName: "--line-height-normal", value: 1.5 },
+  { name: "relaxed", varName: "--line-height-relaxed", value: 1.75 },
+] as const satisfies readonly LineHeightPattern[];
+
+/** Font weight scale values (ADR 0020). */
+export const FONT_WEIGHT_SCALE = [400, 500, 600, 700] as const;
+
+export type FontWeightScale = (typeof FONT_WEIGHT_SCALE)[number];
+
+/** CSS custom property for a font-weight step, e.g. `--font-weight-600`. */
+export function fontWeightScaleVar(
+  weight: FontWeightScale,
+): `--font-weight-${FontWeightScale}` {
+  return `--font-weight-${weight}`;
+}
+
+export const FONT_FAMILY_UI_VAR = "--font-family-ui" as const;
+
+export type TextStyleName =
+  "h1" | "h2" | "h3" | "h4" | "body" | "body-sm" | "caption";
+
+export type TextStyle = {
+  name: TextStyleName;
+  className: `text-${TextStyleName}`;
+  fontSize: string;
+  lineHeightVar: LineHeightPattern["varName"];
+  fontWeightVar: ReturnType<typeof fontWeightScaleVar>;
+};
+
+/** Text style catalog (v1). Colors are not included (see Color tokens). */
+export const TEXT_STYLES = [
+  {
+    name: "h1",
+    className: "text-h1",
+    fontSize: "calc(var(--font-size-14) * 1.4)",
+    lineHeightVar: "--line-height-tight",
+    fontWeightVar: fontWeightScaleVar(600),
+  },
+  {
+    name: "h2",
+    className: "text-h2",
+    fontSize: "var(--font-size-18)",
+    lineHeightVar: "--line-height-tight",
+    fontWeightVar: fontWeightScaleVar(600),
+  },
+  {
+    name: "h3",
+    className: "text-h3",
+    fontSize: "var(--font-size-16)",
+    lineHeightVar: "--line-height-tight",
+    fontWeightVar: fontWeightScaleVar(600),
+  },
+  {
+    name: "h4",
+    className: "text-h4",
+    fontSize: "var(--font-size-14)",
+    lineHeightVar: "--line-height-normal",
+    fontWeightVar: fontWeightScaleVar(600),
+  },
+  {
+    name: "body",
+    className: "text-body",
+    fontSize: "var(--font-size-14)",
+    lineHeightVar: "--line-height-normal",
+    fontWeightVar: fontWeightScaleVar(400),
+  },
+  {
+    name: "body-sm",
+    className: "text-body-sm",
+    fontSize: "var(--font-size-12)",
+    lineHeightVar: "--line-height-normal",
+    fontWeightVar: fontWeightScaleVar(400),
+  },
+  {
+    name: "caption",
+    className: "text-caption",
+    fontSize: "var(--font-size-10)",
+    lineHeightVar: "--line-height-normal",
+    fontWeightVar: fontWeightScaleVar(400),
+  },
+] as const satisfies readonly TextStyle[];
+
+export type ElementPlusTypographyDerivative = {
+  elVar: `--el-font-size-${string}`;
+  valuePx: number;
+};
+
+/** EP font sizes outside Typography scale (mapping block only). */
+export const ELEMENT_PLUS_TYPOGRAPHY_DERIVATIVES = [
+  { elVar: "--el-font-size-small", valuePx: 13 },
+] as const satisfies readonly ElementPlusTypographyDerivative[];
+
+export type ElementPlusTypographyMapping = {
+  elVar: `--el-font-size-${string}`;
+  appVar: `--font-size-${FontSizeScalePx}`;
+};
+
+/** Element Plus typography mapping (ADR 0020). */
+export const ELEMENT_PLUS_TYPOGRAPHY_MAPPING = [
+  { elVar: "--el-font-size-extra-large", appVar: fontSizeScaleVar(20) },
+  { elVar: "--el-font-size-large", appVar: fontSizeScaleVar(18) },
+  { elVar: "--el-font-size-medium", appVar: fontSizeScaleVar(16) },
+  { elVar: "--el-font-size-base", appVar: fontSizeScaleVar(14) },
+  { elVar: "--el-font-size-extra-small", appVar: fontSizeScaleVar(12) },
+] as const satisfies readonly ElementPlusTypographyMapping[];

--- a/frontend/src/design/typographyTokens.ts
+++ b/frontend/src/design/typographyTokens.ts
@@ -39,6 +39,26 @@ export function fontWeightScaleVar(
 
 export const FONT_FAMILY_UI_VAR = "--font-family-ui" as const;
 
+export type FontSizeDerivative = {
+  name: string;
+  varName: `--font-size-${string}`;
+  cssValue: string;
+  note: string;
+};
+
+/**
+ * Font sizes outside Typography scale (ADR 0020).
+ * Preserves legacy computed sizes without adding scale steps.
+ */
+export const FONT_SIZE_DERIVATIVES = [
+  {
+    name: "h1",
+    varName: "--font-size-h1",
+    cssValue: "calc(var(--font-size-14) * 1.4)",
+    note: "Legacy page title (19.6px at 14px root); outside scale by design",
+  },
+] as const satisfies readonly FontSizeDerivative[];
+
 export type TextStyleName =
   "h1" | "h2" | "h3" | "h4" | "body" | "body-sm" | "caption";
 
@@ -55,7 +75,7 @@ export const TEXT_STYLES = [
   {
     name: "h1",
     className: "text-h1",
-    fontSize: "calc(var(--font-size-14) * 1.4)",
+    fontSize: "var(--font-size-h1)",
     lineHeightVar: "--line-height-tight",
     fontWeightVar: fontWeightScaleVar(600),
   },


### PR DESCRIPTION
## Summary
- Add Typography design system (ADR 0020): font-size scale, line-height, font-weight, UI font family, and text-style catalog (Heading 1–4, Body, Body small, Caption).
- Tokenize shared styles in `style.css` (`body`, `.page-title`, section toggle) and map Element Plus `--el-font-size-*` from app tokens.
- Add `typographyTokens.ts`, unit tests, Storybook catalog, agent rule, and CONTEXT glossary entries.

## Test plan
- [x] `make fmt`
- [x] `make test` (Go + frontend Vitest)
- [x] `typographyTokens.spec.ts` passes
- [ ] Storybook: Design System / Typography
- [ ] Visual check: page titles and body text unchanged (v1 visual policy)


Made with [Cursor](https://cursor.com)