### PR TITLE
fix(activity): 遭遇ログ・ギャラリーの自動更新でスクロール位置を保持 (#27)

### DIFF
--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -23,7 +23,7 @@
             <el-icon><Search /></el-icon>
           </template>
         </el-input>
-        <el-button @click="refreshActivity">{{
+        <el-button @click="refreshActivity(false)">{{
           t("common.refresh")
         }}</el-button>
       </div>
@@ -246,22 +246,33 @@ function scheduleActivityRefresh(): void {
   }, ACTIVITY_ENCOUNTERS_CHANGED_DEBOUNCE_MS);
 }
 
+let encountersLoadGeneration = 0;
+let encountersForegroundGeneration = 0;
+let statsLoadGeneration = 0;
+let statsForegroundGeneration = 0;
+
 async function loadEncounters(background = false): Promise<void> {
+  const gen = ++encountersLoadGeneration;
   if (!background) {
     encountersLoading.value = true;
+    encountersForegroundGeneration = gen;
   }
   try {
-    encounters.value = await App.encounters();
+    const next = await App.encounters();
+    if (gen !== encountersLoadGeneration) return;
+    encounters.value = next;
   } finally {
-    if (!background) {
+    if (!background && gen === encountersForegroundGeneration) {
       encountersLoading.value = false;
     }
   }
 }
 
 async function loadStats(background = false): Promise<void> {
+  const gen = ++statsLoadGeneration;
   if (!background) {
     statsLoading.value = true;
+    statsForegroundGeneration = gen;
   }
   try {
     const days = playtimeChartDays.value;
@@ -271,9 +282,11 @@ async function loadStats(background = false): Promise<void> {
     const toStr = localDateISO(to);
     statsRangeFrom.value = fromStr;
     statsRangeTo.value = toStr;
-    stats.value = await App.getActivityStats(fromStr, toStr);
+    const next = await App.getActivityStats(fromStr, toStr);
+    if (gen !== statsLoadGeneration) return;
+    stats.value = next;
   } finally {
-    if (!background) {
+    if (!background && gen === statsForegroundGeneration) {
       statsLoading.value = false;
     }
   }

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -240,21 +240,29 @@ function scheduleActivityRefresh(): void {
   }
   encountersChangedDebounceTimer = setTimeout(() => {
     encountersChangedDebounceTimer = null;
-    void refreshActivity();
+    // バックグラウンド更新: loading を立てずにデータだけ差し替えることで、
+    // 遭遇ログのスクロール位置を保持する（#27）。
+    void refreshActivity(true);
   }, ACTIVITY_ENCOUNTERS_CHANGED_DEBOUNCE_MS);
 }
 
-async function loadEncounters(): Promise<void> {
-  encountersLoading.value = true;
+async function loadEncounters(background = false): Promise<void> {
+  if (!background) {
+    encountersLoading.value = true;
+  }
   try {
     encounters.value = await App.encounters();
   } finally {
-    encountersLoading.value = false;
+    if (!background) {
+      encountersLoading.value = false;
+    }
   }
 }
 
-async function loadStats(): Promise<void> {
-  statsLoading.value = true;
+async function loadStats(background = false): Promise<void> {
+  if (!background) {
+    statsLoading.value = true;
+  }
   try {
     const days = playtimeChartDays.value;
     const to = new Date();
@@ -265,12 +273,14 @@ async function loadStats(): Promise<void> {
     statsRangeTo.value = toStr;
     stats.value = await App.getActivityStats(fromStr, toStr);
   } finally {
-    statsLoading.value = false;
+    if (!background) {
+      statsLoading.value = false;
+    }
   }
 }
 
-async function refreshActivity(): Promise<void> {
-  await Promise.all([loadEncounters(), loadStats()]);
+async function refreshActivity(background = false): Promise<void> {
+  await Promise.all([loadEncounters(background), loadStats(background)]);
 }
 
 onMounted(() => {

--- a/frontend/src/views/GalleryView.vue
+++ b/frontend/src/views/GalleryView.vue
@@ -744,9 +744,11 @@ function onRefreshClick(): void {
   void load();
 }
 
-async function load(): Promise<void> {
+async function load(background = false): Promise<void> {
   loadError.value = null;
-  loading.value = true;
+  if (!background) {
+    loading.value = true;
+  }
   try {
     const filter = buildGallerySearchFilter(
       filterWorldSearch.value,
@@ -767,7 +769,9 @@ async function load(): Promise<void> {
     loadError.value = err instanceof Error ? err.message : String(err);
     list.value = [];
   } finally {
-    loading.value = false;
+    if (!background) {
+      loading.value = false;
+    }
   }
 }
 
@@ -777,7 +781,9 @@ function scheduleLoadFromPictureWatcher(): void {
   }
   screenshotsChangedDebounceTimer = setTimeout(() => {
     screenshotsChangedDebounceTimer = null;
-    void load();
+    // バックグラウンド更新: loading を立てずにグリッドを差し替えることで
+    // スクロール位置を保持する（#27）。
+    void load(true);
   }, GALLERY_SCREENSHOTS_CHANGED_DEBOUNCE_MS);
 }
 

--- a/frontend/src/views/GalleryView.vue
+++ b/frontend/src/views/GalleryView.vue
@@ -744,21 +744,29 @@ function onRefreshClick(): void {
   void load();
 }
 
+let loadGeneration = 0;
+let loadForegroundGeneration = 0;
+
 async function load(background = false): Promise<void> {
   loadError.value = null;
+  const gen = ++loadGeneration;
   if (!background) {
     loading.value = true;
+    loadForegroundGeneration = gen;
   }
   try {
     const filter = buildGallerySearchFilter(
       filterWorldSearch.value,
       filterDateRange.value,
     );
+    let next: ScreenshotDTO[];
     if (filter) {
-      list.value = await App.searchScreenshots(filter);
+      next = await App.searchScreenshots(filter);
     } else {
-      list.value = await App.screenshots("");
+      next = await App.screenshots("");
     }
+    if (gen !== loadGeneration) return;
+    list.value = next;
     if (
       selected.value &&
       !list.value.find((s) => s.id === selected.value?.id)
@@ -766,10 +774,14 @@ async function load(background = false): Promise<void> {
       selected.value = null;
     }
   } catch (err) {
+    if (gen !== loadGeneration) return;
     loadError.value = err instanceof Error ? err.message : String(err);
-    list.value = [];
-  } finally {
+    // バックグラウンド更新の失敗では表示中のグリッドを維持する（#27）
     if (!background) {
+      list.value = [];
+    }
+  } finally {
+    if (!background && gen === loadForegroundGeneration) {
       loading.value = false;
     }
   }

--- a/frontend/src/views/__tests__/ActivityView.spec.ts
+++ b/frontend/src/views/__tests__/ActivityView.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createRouter, createWebHashHistory } from "vue-router";
 import ActivityView from "../ActivityView.vue";
+import type { UserEncounterDTO } from "../../wails/app";
 
 const {
   mockEncounters,
@@ -570,6 +571,30 @@ describe("ActivityView", () => {
     mockEncounters.mockResolvedValue([]);
     const { wrapper } = await mountActivity();
     expect(wrapper.find(".empty").text()).toContain("遭遇");
+  });
+
+  it("keeps the encounter table mounted during background refresh", async () => {
+    vi.useFakeTimers();
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "u1",
+        displayName: "Alpha",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+      },
+    ]);
+    const { wrapper } = await mountActivity();
+    expect(wrapper.find(".el-table").exists()).toBe(true);
+
+    // バックグラウンド更新が保留中でも loading でテーブルを差し替えず維持する（#27）
+    mockEncounters.mockReturnValue(new Promise<UserEncounterDTO[]>(() => {}));
+    runtimeHooks.encountersChangedHandler?.();
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(wrapper.find(".encounter-log-scroll .loading").exists()).toBe(false);
+    expect(wrapper.find(".el-table").exists()).toBe(true);
+    vi.useRealTimers();
   });
 
   it("collapses encounter section when header toggle is clicked", async () => {

--- a/frontend/src/views/__tests__/ActivityView.spec.ts
+++ b/frontend/src/views/__tests__/ActivityView.spec.ts
@@ -668,6 +668,8 @@ describe("ActivityView", () => {
         displayName: "Stale",
         instanceId: "inst",
         joinedAt: "2024-01-03T12:00:00.000Z",
+        isFirstEncounter: false,
+        isListableFriend: false,
       },
     ]);
     await flushPromises();

--- a/frontend/src/views/__tests__/ActivityView.spec.ts
+++ b/frontend/src/views/__tests__/ActivityView.spec.ts
@@ -597,6 +597,86 @@ describe("ActivityView", () => {
     vi.useRealTimers();
   });
 
+  it("shows loading when the refresh button is explicitly clicked", async () => {
+    vi.useFakeTimers();
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "u1",
+        displayName: "Alpha",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+      },
+    ]);
+    const { wrapper } = await mountActivity();
+
+    // 明示的な「更新」ボタンは loading 付き更新のまま（イベントオブジェクトが
+    // background に入らないよう false を明示的に渡す）
+    mockEncounters.mockReturnValue(new Promise<UserEncounterDTO[]>(() => {}));
+    const buttons = wrapper.findAll(".filters .el-button");
+    await buttons[0]!.trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".encounter-log-scroll .loading").exists()).toBe(true);
+    expect(wrapper.find(".el-table").exists()).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("discards a stale background encounters response after a foreground load", async () => {
+    vi.useFakeTimers();
+    mockEncounters.mockResolvedValue([
+      {
+        id: "1",
+        vrcUserId: "u1",
+        displayName: "Alpha",
+        instanceId: "inst",
+        joinedAt: "2024-01-01T12:00:00.000Z",
+      },
+    ]);
+    const { wrapper } = await mountActivity();
+
+    // バックグラウンド更新を保留にし、その後に明示更新（新世代）を完了させる
+    let resolveBg!: (v: UserEncounterDTO[]) => void;
+    mockEncounters.mockReturnValue(
+      new Promise<UserEncounterDTO[]>((res) => {
+        resolveBg = res;
+      }),
+    );
+    runtimeHooks.encountersChangedHandler?.();
+    await vi.advanceTimersByTimeAsync(400);
+
+    const newer = [
+      {
+        id: "2",
+        vrcUserId: "u2",
+        displayName: "Beta",
+        instanceId: "inst",
+        joinedAt: "2024-01-02T12:00:00.000Z",
+      },
+    ];
+    mockEncounters.mockResolvedValue(newer);
+    const buttons = wrapper.findAll(".filters .el-button");
+    await buttons[0]!.trigger("click");
+    await flushPromises();
+    expect(wrapper.text()).toContain("Beta");
+
+    // 古いバックグラウンド応答が後から届いても上書きしない
+    resolveBg([
+      {
+        id: "3",
+        vrcUserId: "u3",
+        displayName: "Stale",
+        instanceId: "inst",
+        joinedAt: "2024-01-03T12:00:00.000Z",
+      },
+    ]);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Beta");
+    expect(wrapper.text()).not.toContain("Stale");
+    vi.useRealTimers();
+  });
+
   it("collapses encounter section when header toggle is clicked", async () => {
     const { wrapper } = await mountActivity();
     const encountersCard = wrapper.find(".section-card--encounters");

--- a/frontend/src/views/__tests__/GalleryView.spec.ts
+++ b/frontend/src/views/__tests__/GalleryView.spec.ts
@@ -238,6 +238,28 @@ describe("GalleryView", () => {
     expect(mockScreenshots).not.toHaveBeenCalled();
   });
 
+  it("keeps the gallery grid mounted during background refresh", async () => {
+    vi.useFakeTimers();
+    const debounceMs = 400;
+    const wrapper = mount(GalleryView, { attachTo: host });
+    await flushPromises();
+    expect(wrapper.find("[data-testid='gallery-grid-scroll']").exists()).toBe(
+      true,
+    );
+
+    // バックグラウンド更新が保留中でも loading でグリッドを差し替えず維持する（#27）
+    mockScreenshots.mockReturnValue(new Promise<ScreenshotDTO[]>(() => {}));
+    wailsEventListeners["gallery:screenshots-changed"]?.();
+    await vi.advanceTimersByTimeAsync(debounceMs);
+    await flushPromises();
+
+    expect(wrapper.find(".loading").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='gallery-grid-scroll']").exists()).toBe(
+      true,
+    );
+    vi.useRealTimers();
+  });
+
   it("fetches thumbnail data URLs via App.screenshotThumbnailDataURL", async () => {
     const wrapper = mount(GalleryView, { attachTo: host });
     await flushPromises();

--- a/frontend/src/views/__tests__/GalleryView.spec.ts
+++ b/frontend/src/views/__tests__/GalleryView.spec.ts
@@ -260,6 +260,64 @@ describe("GalleryView", () => {
     vi.useRealTimers();
   });
 
+  it("discards a stale background gallery load after a foreground load", async () => {
+    vi.useFakeTimers();
+    const debounceMs = 400;
+    const wrapper = mount(GalleryView, { attachTo: host });
+    await flushPromises();
+
+    // バックグラウンド更新を保留にし、その後にフィルタ入力（新世代）を完了させる
+    let resolveBg!: (v: ScreenshotDTO[]) => void;
+    mockScreenshots.mockReturnValue(
+      new Promise<ScreenshotDTO[]>((res) => {
+        resolveBg = res;
+      }),
+    );
+    wailsEventListeners["gallery:screenshots-changed"]?.();
+    await vi.advanceTimersByTimeAsync(debounceMs);
+
+    const newerShot: ScreenshotDTO = {
+      ...sampleShot,
+      id: "s2",
+      filePath: "C:/VRChat/2024/new.png",
+    };
+    mockSearchScreenshots.mockResolvedValue([newerShot]);
+    const filterInput = wrapper.find("[data-testid='gallery-world-filter']");
+    await filterInput.setValue("wrld_new");
+    await filterInput.trigger("keyup.enter");
+    await flushPromises();
+
+    // 古いバックグラウンド応答が後から届いても上書きしない
+    resolveBg([sampleShot]);
+    await flushPromises();
+
+    expect(wrapper.find('img[alt="new.png"]').exists()).toBe(true);
+    expect(wrapper.find('img[alt="shot.png"]').exists()).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("keeps the existing grid when a background refresh fails", async () => {
+    vi.useFakeTimers();
+    const debounceMs = 400;
+    const wrapper = mount(GalleryView, { attachTo: host });
+    await flushPromises();
+    expect(wrapper.find("[data-testid='gallery-grid-scroll']").exists()).toBe(
+      true,
+    );
+
+    mockScreenshots.mockRejectedValue(new Error("boom"));
+    wailsEventListeners["gallery:screenshots-changed"]?.();
+    await vi.advanceTimersByTimeAsync(debounceMs);
+    await flushPromises();
+
+    // バックグラウンド更新の失敗ではグリッドを維持し、エラーのみ表示する（#27）
+    expect(wrapper.find("[data-testid='gallery-grid-scroll']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find(".el-alert").exists()).toBe(true);
+    vi.useRealTimers();
+  });
+
   it("fetches thumbnail data URLs via App.screenshotThumbnailDataURL", async () => {
     const wrapper = mount(GalleryView, { attachTo: host });
     await flushPromises();


### PR DESCRIPTION
## 概要

Issue #27 の対応です。遭遇ログ（Activity 画面）とギャラリーで、ログウォッチャー／ピクチャフォルダウォッチャーによる自動更新（`activity:encounters-changed` / `gallery:screenshots-changed`）が走るたびに loading 表示に切り替わり、一番上までスクロールが戻される問題を修正します。

## 変更内容

自動更新時は `loading` フラグを立てず、データ（`encounters` / `list`）を直接差し替える**バックグラウンド更新**に変更しました。ユーザーが明示的に押す「更新」ボタンや初回読み込みは従来どおり loading を表示します。

- `frontend/src/views/ActivityView.vue`
  - `loadEncounters` / `loadStats` / `refreshActivity` に `background` 引数を追加
  - `scheduleActivityRefresh`（`activity:encounters-changed` のデバウンス）から `refreshActivity(true)` を呼ぶように変更
  - 明示的な「更新」ボタンは `@click="refreshActivity(false)"` で loading 付き更新のまま
- `frontend/src/views/GalleryView.vue`
  - `load` に `background` 引数を追加
  - `scheduleLoadFromPictureWatcher`（`gallery:screenshots-changed` のデバウンス）から `load(true)` を呼ぶように変更

これにより、遭遇ログ更新時もグリッド／テーブルがアンマウントされず、スクロール位置が維持されます。遭遇ログは新しいレコードが上に追加される順序（`joined_at DESC`）なので、表示中の行の位置は自然に保たれます。

## レビュー指摘への対応（レビュー時点のフィードバック反映）

- **明示更新ボタンへのイベントオブジェクト混入**: `@click="refreshActivity(false)"` に変更し、ネイティブイベントが `background` に入らないように修正
- **並行読み込みの順序保証**: `load` に世代カウンタ（`loadGeneration` / `loadForegroundGeneration`）を導入し、古い応答を破棄。既存の `thumbnailFetchGeneration` パターンと同様
- **バックグラウンド失敗時のグリッド維持**: バックグラウンド更新の失敗では表示中の `list` を保持し、`loadError` のみ設定

## テスト

- `ActivityView.spec.ts`: バックグラウンド更新中のテーブル維持、明示更新ボタンでの loading 表示、古い応答の破棄を確認するテストを追加
- `GalleryView.spec.ts`: バックグラウンド更新中のグリッド維持、古い応答の破棄、バックグラウンド失敗時のグリッド維持を確認するテストを追加

全 frontend テスト（52 files / 525 tests）がパスしています。

---
このプルリクエストは AI エージェント (OpenHands) が作成しました。