### PR TITLE
feat(gallery): 一覧取得時の stat キャッシュ（大量件数向け）(#242)

### DIFF
--- a/docs/adr/0001-gallery-scope-and-listing.md
+++ b/docs/adr/0001-gallery-scope-and-listing.md
@@ -42,6 +42,10 @@ Accepted（[#99](https://github.com/JO3QMA/vrctweaker/issues/99) で実装）
   キャッシュを無効化する。新規・復帰ファイルは次回一覧から即反映される。
 - **TTL**: ディスク上の外部削除はウォッチャーが検知しないため、TTL 経過後に再 stat して
   一覧へ反映する（最大 30 秒の stale を許容）。
+- **並行性**: 無効化は世代番号を進め、`get` で観測した世代と一致しない `put` は破棄する。
+  一覧の stat と ingest の無効化が並行しても、古い「missing」結果が無効化後に再登録されない。
+- **上限**: キャッシュは `galleryFileStatCacheMaxItems`（8192）で境界。一覧に現れなくなった
+  パスが残り続けるのを防ぐため、超過時に期限切れエントリを掃除し、残る超過分は任意に追い出す。
 - 実装: `internal/usecase/gallery_file_exists_cache.go`、`internal/usecase/media_gallery_list.go`
 
 ## Implementation

--- a/docs/adr/0001-gallery-scope-and-listing.md
+++ b/docs/adr/0001-gallery-scope-and-listing.md
@@ -32,6 +32,18 @@ Accepted（[#99](https://github.com/JO3QMA/vrctweaker/issues/99) で実装）
 - 一覧のたびに stat が走る（件数が極端に多い場合は将来キャッシュ検討）
 - DB に残る out-of-scope / missing 行の整理は別操作（Manual sync では削除しない）
 
+### 一覧の存在確認キャッシュ（[#242](https://github.com/JO3QMA/vrctweaker/issues/242)）
+
+欠損除外の「一覧 API が存在確認を担う」契約は維持したまま、パス単位の存在確認結果を
+**短い TTL（30 秒）でキャッシュ**する（`galleryFileExistsCache`、プロセス内）。
+
+- **イベント無効化**: Manual sync（`SyncPictureFolder`）と Automatic ingest
+  （`IngestUnderPictureRootSince` / ウォッチャー経由の `IngestScreenshotFile`）が成功したら
+  キャッシュを無効化する。新規・復帰ファイルは次回一覧から即反映される。
+- **TTL**: ディスク上の外部削除はウォッチャーが検知しないため、TTL 経過後に再 stat して
+  一覧へ反映する（最大 30 秒の stale を許容）。
+- 実装: `internal/usecase/gallery_file_exists_cache.go`、`internal/usecase/media_gallery_list.go`
+
 ## Implementation
 
 - `internal/domain/media/gallery_scope.go` — `PictureFolderPathPrefix`

--- a/docs/adr/0001-gallery-scope-and-listing.md
+++ b/docs/adr/0001-gallery-scope-and-listing.md
@@ -44,8 +44,14 @@ Accepted（[#99](https://github.com/JO3QMA/vrctweaker/issues/99) で実装）
   一覧へ反映する（最大 30 秒の stale を許容）。
 - **並行性**: 無効化は世代番号を進め、`get` で観測した世代と一致しない `put` は破棄する。
   一覧の stat と ingest の無効化が並行しても、古い「missing」結果が無効化後に再登録されない。
+  バルク処理（`ScanDirectory` / `IngestUnderPictureRootSince` / `SyncPictureFolder`）は最後に
+  一括で無効化するため、ループ内のパス単位無効化（世代更新）は行わない。長時間の同期中に
+  並行する一覧のキャッシュ登録が連続的に失われるのを防ぐ。
 - **上限**: キャッシュは `galleryFileStatCacheMaxItems`（8192）で境界。一覧に現れなくなった
-  パスが残り続けるのを防ぐため、超過時に期限切れエントリを掃除し、残る超過分は任意に追い出す。
+  パスが残り続けるのを防ぐ。ただし put を安価に保つため、全走査の掃除は倍容量（2×）到達時に
+  のみ行い、それ以外は境界を超えた分だけ任意に追い出す。
+- **エラー分類**: `os.IsNotExist` のみ「欠損」としてキャッシュする。権限エラーや一時 I/O エラーは
+  キャッシュせず次回一覧で再試行する（一時障害で実在ファイルが TTL 分ギャラリーから隠れない）。
 - 実装: `internal/usecase/gallery_file_exists_cache.go`、`internal/usecase/media_gallery_list.go`
 
 ## Implementation

--- a/internal/usecase/gallery_file_exists_cache.go
+++ b/internal/usecase/gallery_file_exists_cache.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -11,6 +12,11 @@ import (
 // avoiding an os.Stat per row on every listing (ADR 0001).
 const galleryFileStatCacheTTL = 30 * time.Second
 
+// galleryFileStatCacheMaxItems caps the number of cached paths. Paths that stop
+// appearing in listings (e.g. their DB row was removed) are pruned once the
+// cache exceeds this bound so long-running use does not grow without limit.
+const galleryFileStatCacheMaxItems = 8192
+
 type galleryFileStatEntry struct {
 	exists bool
 	at     time.Time
@@ -20,52 +26,98 @@ type galleryFileStatEntry struct {
 // Gallery listing. Entries expire after ttl; InvalidateAll / InvalidatePath
 // drop entries early when the picture folder is synced or a file is ingested.
 type galleryFileExistsCache struct {
-	mu    sync.Mutex
-	ttl   time.Duration
-	now   func() time.Time
-	items map[string]galleryFileStatEntry
+	mu         sync.Mutex
+	ttl        time.Duration
+	now        func() time.Time
+	generation uint64
+	maxItems   int
+	items      map[string]galleryFileStatEntry
 }
 
 func newGalleryFileExistsCache() *galleryFileExistsCache {
 	return &galleryFileExistsCache{
-		ttl:   galleryFileStatCacheTTL,
-		now:   time.Now,
-		items: make(map[string]galleryFileStatEntry),
+		ttl:      galleryFileStatCacheTTL,
+		now:      time.Now,
+		maxItems: galleryFileStatCacheMaxItems,
+		items:    make(map[string]galleryFileStatEntry),
 	}
 }
 
-// get returns the cached existence for path when it is still fresh.
-func (c *galleryFileExistsCache) get(path string) (exists bool, ok bool) {
+// get returns the cached existence for path when it is still fresh, along with
+// the generation observed. The generation must be passed back to
+// putIfUnchanged so a result computed before a concurrent invalidation is not
+// re-registered afterwards.
+func (c *galleryFileExistsCache) get(path string) (exists bool, ok bool, generation uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	path = c.normalize(path)
 	e, ok := c.items[path]
 	if !ok {
-		return false, false
+		return false, false, c.generation
 	}
 	if c.now().Sub(e.at) >= c.ttl {
 		delete(c.items, path)
-		return false, false
+		return false, false, c.generation
 	}
-	return e.exists, true
+	return e.exists, true, c.generation
 }
 
-// put records the existence of path as of now.
-func (c *galleryFileExistsCache) put(path string, exists bool) {
+// putIfUnchanged records the existence of path only when no invalidation has
+// happened since the caller's get. A put carrying a stale generation is dropped
+// so an ingest that completed in between is never overwritten by an older
+// (e.g. "missing") result.
+func (c *galleryFileExistsCache) putIfUnchanged(path string, exists bool, generation uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	path = c.normalize(path)
+	if generation != c.generation {
+		return
+	}
 	c.items[path] = galleryFileStatEntry{exists: exists, at: c.now()}
+	c.pruneLocked()
 }
 
-// invalidateAll drops every cached entry. Called after a folder sync or ingest.
+// invalidateAll drops every cached entry and bumps the generation so in-flight
+// puts are rejected. Called after a folder sync or ingest.
 func (c *galleryFileExistsCache) invalidateAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.generation++
 	c.items = make(map[string]galleryFileStatEntry)
 }
 
-// invalidatePath drops the entry for one path. Called when a file is ingested.
+// invalidatePath drops the entry for one path and bumps the generation. Called
+// when a file is ingested.
 func (c *galleryFileExistsCache) invalidatePath(path string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.items, path)
+	c.generation++
+	delete(c.items, c.normalize(path))
+}
+
+// normalize gives all callers one key space so different spellings of the same
+// file (relative vs absolute, "a/../b", …) hit a single entry.
+func (c *galleryFileExistsCache) normalize(path string) string {
+	return filepath.Clean(path)
+}
+
+// pruneLocked keeps the cache bounded: expired entries are removed when the map
+// exceeds maxItems, and any remaining overflow is evicted arbitrarily (the
+// value is simply re-derived from disk on the next listing). Caller holds mu.
+func (c *galleryFileExistsCache) pruneLocked() {
+	if len(c.items) <= c.maxItems {
+		return
+	}
+	now := c.now()
+	for k, e := range c.items {
+		if now.Sub(e.at) >= c.ttl {
+			delete(c.items, k)
+		}
+	}
+	for k := range c.items {
+		if len(c.items) <= c.maxItems {
+			break
+		}
+		delete(c.items, k)
+	}
 }

--- a/internal/usecase/gallery_file_exists_cache.go
+++ b/internal/usecase/gallery_file_exists_cache.go
@@ -1,0 +1,71 @@
+package usecase
+
+import (
+	"sync"
+	"time"
+)
+
+// galleryFileStatCacheTTL bounds how long a cached file-existence result is
+// reused by Gallery listing before the path is re-checked on disk. A short TTL
+// keeps external deletions/restorations from staying stale for long while
+// avoiding an os.Stat per row on every listing (ADR 0001).
+const galleryFileStatCacheTTL = 30 * time.Second
+
+type galleryFileStatEntry struct {
+	exists bool
+	at     time.Time
+}
+
+// galleryFileExistsCache memoizes per-path file-existence results used by
+// Gallery listing. Entries expire after ttl; InvalidateAll / InvalidatePath
+// drop entries early when the picture folder is synced or a file is ingested.
+type galleryFileExistsCache struct {
+	mu    sync.Mutex
+	ttl   time.Duration
+	now   func() time.Time
+	items map[string]galleryFileStatEntry
+}
+
+func newGalleryFileExistsCache() *galleryFileExistsCache {
+	return &galleryFileExistsCache{
+		ttl:   galleryFileStatCacheTTL,
+		now:   time.Now,
+		items: make(map[string]galleryFileStatEntry),
+	}
+}
+
+// get returns the cached existence for path when it is still fresh.
+func (c *galleryFileExistsCache) get(path string) (exists bool, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.items[path]
+	if !ok {
+		return false, false
+	}
+	if c.now().Sub(e.at) >= c.ttl {
+		delete(c.items, path)
+		return false, false
+	}
+	return e.exists, true
+}
+
+// put records the existence of path as of now.
+func (c *galleryFileExistsCache) put(path string, exists bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items[path] = galleryFileStatEntry{exists: exists, at: c.now()}
+}
+
+// invalidateAll drops every cached entry. Called after a folder sync or ingest.
+func (c *galleryFileExistsCache) invalidateAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]galleryFileStatEntry)
+}
+
+// invalidatePath drops the entry for one path. Called when a file is ingested.
+func (c *galleryFileExistsCache) invalidatePath(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.items, path)
+}

--- a/internal/usecase/gallery_file_exists_cache.go
+++ b/internal/usecase/gallery_file_exists_cache.go
@@ -12,9 +12,10 @@ import (
 // avoiding an os.Stat per row on every listing (ADR 0001).
 const galleryFileStatCacheTTL = 30 * time.Second
 
-// galleryFileStatCacheMaxItems caps the number of cached paths. Paths that stop
-// appearing in listings (e.g. their DB row was removed) are pruned once the
-// cache exceeds this bound so long-running use does not grow without limit.
+// galleryFileStatCacheMaxItems is the steady-state target for cached paths.
+// Paths that stop appearing in listings (e.g. their DB row was removed) would
+// otherwise accumulate; to keep puts cheap the cache only sweeps when it reaches
+// double this size, so it never holds more than 2*maxItems entries.
 const galleryFileStatCacheMaxItems = 8192
 
 type galleryFileStatEntry struct {
@@ -31,6 +32,7 @@ type galleryFileExistsCache struct {
 	now        func() time.Time
 	generation uint64
 	maxItems   int
+	stat       func(path string) (exists, cacheable bool)
 	items      map[string]galleryFileStatEntry
 }
 
@@ -39,8 +41,25 @@ func newGalleryFileExistsCache() *galleryFileExistsCache {
 		ttl:      galleryFileStatCacheTTL,
 		now:      time.Now,
 		maxItems: galleryFileStatCacheMaxItems,
+		stat:     statScreenshotFile,
 		items:    make(map[string]galleryFileStatEntry),
 	}
+}
+
+// check returns whether path is a regular file on disk, consulting the cache and
+// populating it on a miss. Results derived from errors other than a
+// definitively-missing file are not cached, so transient stat failures are
+// retried on the next listing instead of hiding a real file for the TTL.
+func (c *galleryFileExistsCache) check(path string) bool {
+	exists, ok, generation := c.get(path)
+	if ok {
+		return exists
+	}
+	exists, cacheable := c.stat(path)
+	if cacheable {
+		c.putIfUnchanged(path, exists, generation)
+	}
+	return exists
 }
 
 // get returns the cached existence for path when it is still fresh, along with
@@ -101,11 +120,13 @@ func (c *galleryFileExistsCache) normalize(path string) string {
 	return filepath.Clean(path)
 }
 
-// pruneLocked keeps the cache bounded: expired entries are removed when the map
-// exceeds maxItems, and any remaining overflow is evicted arbitrarily (the
-// value is simply re-derived from disk on the next listing). Caller holds mu.
+// pruneLocked keeps the cache bounded. A full TTL sweep scans every entry, so it
+// only runs once the cache reaches double maxItems; the cost is amortized over
+// the entries added since the last sweep. Any remaining overflow is evicted
+// arbitrarily (the value is simply re-derived from disk on the next listing).
+// Caller holds mu.
 func (c *galleryFileExistsCache) pruneLocked() {
-	if len(c.items) <= c.maxItems {
+	if len(c.items) < 2*c.maxItems {
 		return
 	}
 	now := c.now()
@@ -114,10 +135,10 @@ func (c *galleryFileExistsCache) pruneLocked() {
 			delete(c.items, k)
 		}
 	}
-	for k := range c.items {
-		if len(c.items) <= c.maxItems {
+	for len(c.items) > c.maxItems {
+		for k := range c.items {
+			delete(c.items, k)
 			break
 		}
-		delete(c.items, k)
 	}
 }

--- a/internal/usecase/gallery_file_exists_cache_test.go
+++ b/internal/usecase/gallery_file_exists_cache_test.go
@@ -51,11 +51,18 @@ func TestGalleryFileExistsCache_evictsWhenOverBound(t *testing.T) {
 	c.now = func() time.Time { return base }
 	c.maxItems = 2
 
-	c.putIfUnchanged("a", true, 0)
-	c.putIfUnchanged("b", true, 0)
-	c.putIfUnchanged("c", true, 0) // all fresh; evicts arbitrarily down to maxItems
-	if len(c.items) != 2 {
+	// The full sweep only runs at double the bound (4 here); the sweep then
+	// evicts arbitrarily down to the steady-state maxItems.
+	for _, p := range []string{"a", "b", "c", "d"} {
+		c.putIfUnchanged(p, true, 0)
+	}
+	if len(c.items) != c.maxItems {
 		t.Fatalf("items = %d, want %d", len(c.items), c.maxItems)
+	}
+	// Below the double bound, no pruning happens.
+	c.putIfUnchanged("e", true, 0)
+	if len(c.items) != c.maxItems+1 {
+		t.Fatalf("items = %d, want %d (no sweep under double bound)", len(c.items), c.maxItems+1)
 	}
 }
 
@@ -68,11 +75,45 @@ func TestGalleryFileExistsCache_prunesExpiredWhenOverBound(t *testing.T) {
 	c.putIfUnchanged("a", true, 0)
 	c.putIfUnchanged("b", true, 0)
 	c.now = func() time.Time { return base.Add(time.Hour) }
-	c.putIfUnchanged("c", true, 0) // a,b are expired -> pruned before adding c
-	if len(c.items) != 1 {
-		t.Fatalf("items = %d, want 1 (expired pruned)", len(c.items))
+	c.putIfUnchanged("c", true, 0)
+	c.putIfUnchanged("d", true, 0) // reaching 2*maxItems sweeps expired a,b
+	if len(c.items) != c.maxItems {
+		t.Fatalf("items = %d, want %d", len(c.items), c.maxItems)
 	}
-	if _, hit, _ := c.get("c"); !hit {
-		t.Fatal("expected c cached")
+	for _, p := range []string{"a", "b"} {
+		if _, hit, _ := c.get(p); hit {
+			t.Fatalf("expected %s pruned, still cached", p)
+		}
+	}
+	for _, p := range []string{"c", "d"} {
+		if e, hit, _ := c.get(p); !hit || !e {
+			t.Fatalf("expected %s cached, got exists=%v hit=%v", p, e, hit)
+		}
+	}
+}
+
+func TestGalleryFileExistsCache_checkCachesOnlyDefinitiveResults(t *testing.T) {
+	c := newGalleryFileExistsCache()
+	c.now = func() time.Time { return time.Unix(1_000_000, 0) }
+
+	// A transient failure (permission, I/O) is not cached: the next check
+	// re-stats and recovers.
+	c.stat = func(string) (bool, bool) { return false, false }
+	if c.check("p.png") {
+		t.Fatal("expected false from transient error")
+	}
+	c.stat = func(string) (bool, bool) { return true, true }
+	if !c.check("p.png") {
+		t.Fatal("expected true after transient error cleared")
+	}
+
+	// A definitively-missing file IS cached: still missing after a restore.
+	c.stat = func(string) (bool, bool) { return false, true }
+	if c.check("gone.png") {
+		t.Fatal("expected false from not-exist")
+	}
+	c.stat = func(string) (bool, bool) { return true, true }
+	if c.check("gone.png") {
+		t.Fatal("expected cached missing within TTL")
 	}
 }

--- a/internal/usecase/gallery_file_exists_cache_test.go
+++ b/internal/usecase/gallery_file_exists_cache_test.go
@@ -1,0 +1,78 @@
+package usecase
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGalleryFileExistsCache_putIfUnchangedRejectsStaleGeneration(t *testing.T) {
+	c := newGalleryFileExistsCache()
+	c.now = func() time.Time { return time.Unix(1_000_000, 0) }
+
+	_, ok, gen := c.get("p.png")
+	if ok {
+		t.Fatal("expected miss")
+	}
+	c.putIfUnchanged("p.png", true, gen)
+	if e, hit, _ := c.get("p.png"); !hit || !e {
+		t.Fatalf("expected cached exists, got exists=%v hit=%v", e, hit)
+	}
+
+	// An ingest completing between get and put must not be overwritten by a
+	// stale put carrying the pre-invalidation generation.
+	c.invalidatePath("p.png")
+	if _, hit, _ := c.get("p.png"); hit {
+		t.Fatal("expected miss after invalidate")
+	}
+	c.putIfUnchanged("p.png", false, gen)
+	if _, hit, _ := c.get("p.png"); hit {
+		t.Fatal("stale put re-registered a result after invalidation")
+	}
+}
+
+func TestGalleryFileExistsCache_normalizesPathKeys(t *testing.T) {
+	c := newGalleryFileExistsCache()
+	c.now = func() time.Time { return time.Unix(1_000_000, 0) }
+
+	c.putIfUnchanged(filepath.Join("a", "..", "p.png"), true, 0)
+	if e, hit, _ := c.get("p.png"); !hit || !e {
+		t.Fatalf("expected normalized lookup to hit, got exists=%v hit=%v", e, hit)
+	}
+	c.invalidatePath(filepath.Join("a", "..", "p.png"))
+	if _, hit, _ := c.get("p.png"); hit {
+		t.Fatal("expected miss after normalized invalidate")
+	}
+}
+
+func TestGalleryFileExistsCache_evictsWhenOverBound(t *testing.T) {
+	c := newGalleryFileExistsCache()
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+	c.maxItems = 2
+
+	c.putIfUnchanged("a", true, 0)
+	c.putIfUnchanged("b", true, 0)
+	c.putIfUnchanged("c", true, 0) // all fresh; evicts arbitrarily down to maxItems
+	if len(c.items) != 2 {
+		t.Fatalf("items = %d, want %d", len(c.items), c.maxItems)
+	}
+}
+
+func TestGalleryFileExistsCache_prunesExpiredWhenOverBound(t *testing.T) {
+	c := newGalleryFileExistsCache()
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+	c.maxItems = 2
+
+	c.putIfUnchanged("a", true, 0)
+	c.putIfUnchanged("b", true, 0)
+	c.now = func() time.Time { return base.Add(time.Hour) }
+	c.putIfUnchanged("c", true, 0) // a,b are expired -> pruned before adding c
+	if len(c.items) != 1 {
+		t.Fatalf("items = %d, want 1 (expired pruned)", len(c.items))
+	}
+	if _, hit, _ := c.get("c"); !hit {
+		t.Fatal("expected c cached")
+	}
+}

--- a/internal/usecase/media_gallery_list.go
+++ b/internal/usecase/media_gallery_list.go
@@ -52,11 +52,15 @@ func (uc *MediaUseCase) filterScreenshotsWithExistingFiles(list []*media.Screens
 }
 
 func (uc *MediaUseCase) fileExistsCheck(path string) bool {
-	if exists, ok := uc.fileExists.get(path); ok {
+	exists, ok, generation := uc.fileExists.get(path)
+	if ok {
 		return exists
 	}
-	exists := screenshotFileExists(path)
-	uc.fileExists.put(path, exists)
+	exists = screenshotFileExists(path)
+	// Guard the put with the generation observed at get time: if a sync/ingest
+	// invalidated the cache in between, the result is re-derived next listing
+	// instead of re-registering a stale value.
+	uc.fileExists.putIfUnchanged(path, exists, generation)
 	return exists
 }
 

--- a/internal/usecase/media_gallery_list.go
+++ b/internal/usecase/media_gallery_list.go
@@ -10,6 +10,11 @@ import (
 // ListScreenshotsInGalleryScope returns screenshots for Gallery listing: limited to
 // pictureFolderRoot and excluding rows whose files are missing on disk.
 // When pictureFolderRoot is empty, returns an empty list.
+//
+// Missing-file exclusion is memoized with a short TTL (galleryFileStatCacheTTL),
+// so external deletions/restorations are reflected only after an invalidation
+// event (sync or ingest) or once the TTL expires; within the TTL a listing may
+// briefly include a just-deleted file or exclude a just-restored one.
 func (uc *MediaUseCase) ListScreenshotsInGalleryScope(ctx context.Context, pictureFolderRoot string, filter *media.ScreenshotFilter) ([]*media.Screenshot, error) {
 	prefix := media.PictureFolderPathPrefix(pictureFolderRoot)
 	if prefix == "" {
@@ -52,26 +57,17 @@ func (uc *MediaUseCase) filterScreenshotsWithExistingFiles(list []*media.Screens
 }
 
 func (uc *MediaUseCase) fileExistsCheck(path string) bool {
-	exists, ok, generation := uc.fileExists.get(path)
-	if ok {
-		return exists
-	}
-	exists = screenshotFileExists(path)
-	// Guard the put with the generation observed at get time: if a sync/ingest
-	// invalidated the cache in between, the result is re-derived next listing
-	// instead of re-registering a stale value.
-	uc.fileExists.putIfUnchanged(path, exists, generation)
-	return exists
+	return uc.fileExists.check(path)
 }
 
-// screenshotFileExists reports whether path is a regular file on disk.
-// Overridable in tests to observe how often listing stats paths.
-var screenshotFileExists = statScreenshotFile
-
-func statScreenshotFile(path string) bool {
+// statScreenshotFile reports whether path is a regular file on disk, and whether
+// the result is safe to cache. Only a definitively-missing file (IsNotExist) is
+// cached as missing; other stat failures (permission, transient I/O) are retried
+// on the next listing so a real file is not hidden for the whole TTL.
+func statScreenshotFile(path string) (exists bool, cacheable bool) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return false
+		return false, os.IsNotExist(err)
 	}
-	return info.Mode().IsRegular()
+	return info.Mode().IsRegular(), true
 }

--- a/internal/usecase/media_gallery_list.go
+++ b/internal/usecase/media_gallery_list.go
@@ -21,7 +21,7 @@ func (uc *MediaUseCase) ListScreenshotsInGalleryScope(ctx context.Context, pictu
 	if err != nil {
 		return nil, err
 	}
-	return filterScreenshotsWithExistingFiles(list), nil
+	return uc.filterScreenshotsWithExistingFiles(list), nil
 }
 
 func cloneScreenshotFilter(f *media.ScreenshotFilter) *media.ScreenshotFilter {
@@ -32,7 +32,10 @@ func cloneScreenshotFilter(f *media.ScreenshotFilter) *media.ScreenshotFilter {
 	return &cp
 }
 
-func filterScreenshotsWithExistingFiles(list []*media.Screenshot) []*media.Screenshot {
+// filterScreenshotsWithExistingFiles excludes rows whose file is missing on disk.
+// Existence checks are memoized for a short TTL (see galleryFileExistsCache) so
+// repeated listings with many screenshots avoid a stat per row on every call.
+func (uc *MediaUseCase) filterScreenshotsWithExistingFiles(list []*media.Screenshot) []*media.Screenshot {
 	if len(list) == 0 {
 		return list
 	}
@@ -41,14 +44,27 @@ func filterScreenshotsWithExistingFiles(list []*media.Screenshot) []*media.Scree
 		if s == nil {
 			continue
 		}
-		if screenshotFileExists(s.FilePath) {
+		if uc.fileExistsCheck(s.FilePath) {
 			out = append(out, s)
 		}
 	}
 	return out
 }
 
-func screenshotFileExists(path string) bool {
+func (uc *MediaUseCase) fileExistsCheck(path string) bool {
+	if exists, ok := uc.fileExists.get(path); ok {
+		return exists
+	}
+	exists := screenshotFileExists(path)
+	uc.fileExists.put(path, exists)
+	return exists
+}
+
+// screenshotFileExists reports whether path is a regular file on disk.
+// Overridable in tests to observe how often listing stats paths.
+var screenshotFileExists = statScreenshotFile
+
+func statScreenshotFile(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false

--- a/internal/usecase/media_picture_sync.go
+++ b/internal/usecase/media_picture_sync.go
@@ -21,6 +21,9 @@ func (uc *MediaUseCase) SyncPictureFolder(ctx context.Context, basePath string, 
 	if err != nil {
 		return ingested, err
 	}
+	// The folder may have gained or lost files; drop cached existence results so
+	// the next Gallery listing reflects the synced state.
+	uc.fileExists.invalidateAll()
 	return ingested + updated, nil
 }
 

--- a/internal/usecase/media_picture_sync.go
+++ b/internal/usecase/media_picture_sync.go
@@ -76,7 +76,7 @@ func (uc *MediaUseCase) ingestImagePathsInDir(ctx context.Context, basePath stri
 		if ctx.Err() != nil {
 			return count, created, ctx.Err()
 		}
-		_, wasCreated, ingestErr := uc.IngestScreenshotFile(ctx, path)
+		_, wasCreated, ingestErr := uc.ingestScreenshotFile(ctx, path, false)
 		if ingestErr != nil {
 			// Same as ScanDirectory: skip file on ingest error.
 		} else if wasCreated {

--- a/internal/usecase/media_usecase.go
+++ b/internal/usecase/media_usecase.go
@@ -100,6 +100,16 @@ func (uc *MediaUseCase) GetScreenshot(ctx context.Context, id string) (*media.Sc
 // Returns the screenshot row, whether it was newly created, and an error only for
 // persistence/stat failures. Thumbnail generation errors are ignored so the row stays saved.
 func (uc *MediaUseCase) IngestScreenshotFile(ctx context.Context, path string) (*media.Screenshot, bool, error) {
+	return uc.ingestScreenshotFile(ctx, path, true)
+}
+
+// ingestScreenshotFile is the shared implementation. invalidateCache is true for
+// single-file ingestion (picture-folder watcher), so a restored/new file is
+// reflected by the next listing immediately. Bulk flows (ScanDirectory,
+// IngestUnderPictureRootSince, SyncPictureFolder) pass false and invalidate the
+// whole cache once at the end: a per-file generation bump during a long sync
+// would otherwise discard every concurrent listing's cache fill.
+func (uc *MediaUseCase) ingestScreenshotFile(ctx context.Context, path string, invalidateCache bool) (*media.Screenshot, bool, error) {
 	path = filepath.Clean(path)
 	info, err := os.Stat(path)
 	if err != nil {
@@ -115,9 +125,11 @@ func (uc *MediaUseCase) IngestScreenshotFile(ctx context.Context, path string) (
 		return nil, false, nil
 	}
 
-	// The file is confirmed on disk; drop any cached missing/exists result so
-	// the next Gallery listing re-checks it (covers restored and new files).
-	uc.fileExists.invalidatePath(path)
+	if invalidateCache {
+		// The file is confirmed on disk; drop any cached missing/exists result so
+		// the next Gallery listing re-checks it (covers restored and new files).
+		uc.fileExists.invalidatePath(path)
+	}
 
 	existing, _ := uc.repo.GetByFilePath(ctx, path)
 	if existing != nil {
@@ -198,7 +210,7 @@ func (uc *MediaUseCase) IngestUnderPictureRootSince(ctx context.Context, basePat
 		if !fi.ModTime().After(since) {
 			return nil
 		}
-		_, created, ingestErr := uc.IngestScreenshotFile(ctx, path)
+		_, created, ingestErr := uc.ingestScreenshotFile(ctx, path, false)
 		if ingestErr != nil {
 			return nil
 		}

--- a/internal/usecase/media_usecase.go
+++ b/internal/usecase/media_usecase.go
@@ -46,12 +46,18 @@ type MediaUseCase struct {
 	repo          screenshotRepo
 	worldRepo     worldInfoRepo
 	userCacheRepo userCacheRepo
+	fileExists    *galleryFileExistsCache
 }
 
 // NewMediaUseCase creates a new MediaUseCase.
 // worldRepo and userCacheRepo may be nil; when set, extracted metadata is upserted into world_info and users_cache.
 func NewMediaUseCase(repo screenshotRepo, worldRepo worldInfoRepo, userCacheRepo userCacheRepo) *MediaUseCase {
-	return &MediaUseCase{repo: repo, worldRepo: worldRepo, userCacheRepo: userCacheRepo}
+	return &MediaUseCase{
+		repo:          repo,
+		worldRepo:     worldRepo,
+		userCacheRepo: userCacheRepo,
+		fileExists:    newGalleryFileExistsCache(),
+	}
 }
 
 func (uc *MediaUseCase) upsertWorldInfo(ctx context.Context, worldID, worldName string, at time.Time) {
@@ -109,6 +115,10 @@ func (uc *MediaUseCase) IngestScreenshotFile(ctx context.Context, path string) (
 		return nil, false, nil
 	}
 
+	// The file is confirmed on disk; drop any cached missing/exists result so
+	// the next Gallery listing re-checks it (covers restored and new files).
+	uc.fileExists.invalidatePath(path)
+
 	existing, _ := uc.repo.GetByFilePath(ctx, path)
 	if existing != nil {
 		return existing, false, nil
@@ -149,7 +159,11 @@ func (uc *MediaUseCase) IngestScreenshotFile(ctx context.Context, path string) (
 // onProgress is optional; when non-nil it receives listing/importing snapshots.
 func (uc *MediaUseCase) ScanDirectory(ctx context.Context, basePath string, onProgress func(ScanProgress)) (int, error) {
 	count, _, err := uc.ingestImagePathsInDir(ctx, basePath, onProgress)
-	return count, err
+	if err != nil {
+		return count, err
+	}
+	uc.fileExists.invalidateAll()
+	return count, nil
 }
 
 // IngestUnderPictureRootSince walks basePath for image files whose ModTime is strictly after since
@@ -196,6 +210,7 @@ func (uc *MediaUseCase) IngestUnderPictureRootSince(ctx context.Context, basePat
 	if err != nil {
 		return createdCount, err
 	}
+	uc.fileExists.invalidateAll()
 	return createdCount, nil
 }
 

--- a/internal/usecase/media_usecase_test.go
+++ b/internal/usecase/media_usecase_test.go
@@ -761,10 +761,8 @@ func TestMediaUseCase_ListScreenshotsInGalleryScope_cachesStatWithinTTL(t *testi
 	uc := NewMediaUseCase(repo, nil, nil)
 	ctx := context.Background()
 
-	old := screenshotFileExists
 	calls := 0
-	screenshotFileExists = func(string) bool { calls++; return true }
-	t.Cleanup(func() { screenshotFileExists = old })
+	uc.fileExists.stat = func(string) (bool, bool) { calls++; return true, true }
 
 	if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
 		t.Fatal(err)
@@ -921,6 +919,40 @@ func TestMediaUseCase_ListScreenshotsInGalleryScope_ingestInvalidatesCache(t *te
 	}
 }
 
+func TestMediaUseCase_ingestScreenshotFile_bulkModeKeepsCache(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "shot.png")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "s1", FilePath: path})
+	uc := NewMediaUseCase(repo, nil, nil)
+	ctx := context.Background()
+
+	calls := 0
+	uc.fileExists.stat = func(string) (bool, bool) { calls++; return true, true }
+
+	if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("warmup list: stat calls = %d, want 1", calls)
+	}
+
+	// Bulk flows pass invalidateCache=false: no per-path generation bump, so the
+	// cache populated by a concurrent listing is not discarded mid-sync.
+	if _, _, err := uc.ingestScreenshotFile(ctx, path, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("list after bulk-style ingest: stat calls = %d, want 1 (cache kept)", calls)
+	}
+}
+
 func TestMediaUseCase_ListScreenshotsInGalleryScope_ingestUnderRootInvalidatesCache(t *testing.T) {
 	base := t.TempDir()
 	path := filepath.Join(base, "later.png")
@@ -967,12 +999,10 @@ func BenchmarkListScreenshotsInGalleryScope(b *testing.B) {
 	ctx := context.Background()
 
 	// Simulate a per-row stat cost so the cache benefit is measurable.
-	old := screenshotFileExists
-	screenshotFileExists = func(path string) bool {
+	uc.fileExists.stat = func(path string) (bool, bool) {
 		time.Sleep(2 * time.Microsecond)
 		return statScreenshotFile(path)
 	}
-	b.Cleanup(func() { screenshotFileExists = old })
 
 	b.Run("cached", func(b *testing.B) {
 		if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {

--- a/internal/usecase/media_usecase_test.go
+++ b/internal/usecase/media_usecase_test.go
@@ -747,13 +747,261 @@ func TestMediaUseCase_ListScreenshotsInGalleryScope_preservesWorldFilter(t *test
 	}
 }
 
+func TestMediaUseCase_ListScreenshotsInGalleryScope_cachesStatWithinTTL(t *testing.T) {
+	base := t.TempDir()
+	const n = 40
+	repo := newMockScreenshotRepo()
+	for i := 0; i < n; i++ {
+		path := filepath.Join(base, fmt.Sprintf("shot-%02d.png", i))
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_ = repo.Save(context.Background(), &media.Screenshot{ID: fmt.Sprintf("s%02d", i), FilePath: path})
+	}
+	uc := NewMediaUseCase(repo, nil, nil)
+	ctx := context.Background()
+
+	old := screenshotFileExists
+	calls := 0
+	screenshotFileExists = func(string) bool { calls++; return true }
+	t.Cleanup(func() { screenshotFileExists = old })
+
+	if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+		t.Fatal(err)
+	}
+	if calls != n {
+		t.Fatalf("first list: stat calls = %d, want %d (one per row)", calls, n)
+	}
+	if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+		t.Fatal(err)
+	}
+	if calls != n {
+		t.Fatalf("second list within TTL: stat calls = %d, want %d (cache hit)", calls, n)
+	}
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_reStatsAfterTTLExpiry(t *testing.T) {
+	base := t.TempDir()
+	here := filepath.Join(base, "here.png")
+	gone := filepath.Join(base, "gone.png")
+	if err := os.WriteFile(here, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "here", FilePath: here})
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "gone", FilePath: gone})
+	uc := NewMediaUseCase(repo, nil, nil)
+	uc.fileExists.ttl = time.Hour
+	now := time.Unix(1_000_000, 0)
+	uc.fileExists.now = func() time.Time { return now }
+	ctx := context.Background()
+
+	assertIDs := func(want ...string) {
+		t.Helper()
+		list, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []string
+		for _, s := range list {
+			got = append(got, s.ID)
+		}
+		slices.Sort(got)
+		slices.Sort(want)
+		if !slices.Equal(got, want) {
+			t.Fatalf("list = %v, want %v", got, want)
+		}
+	}
+
+	assertIDs("here") // warms cache: here=exists, gone=missing
+	if err := os.Remove(here); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gone, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertIDs("here") // stale within TTL: cache still reports here exists, gone missing
+
+	now = now.Add(time.Hour) // expire the cache
+	assertIDs("gone")        // re-stat reflects the swap
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_syncInvalidatesCache(t *testing.T) {
+	base := t.TempDir()
+	a := filepath.Join(base, "a.png")
+	b := filepath.Join(base, "b.png")
+	for _, p := range []string{a, b} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "a", FilePath: a})
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "b", FilePath: b})
+	uc := NewMediaUseCase(repo, nil, nil)
+	ctx := context.Background()
+
+	list, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("warmup list = %d, want 2", len(list))
+	}
+
+	if err = os.Remove(a); err != nil {
+		t.Fatal(err)
+	}
+	list, err = uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("list within TTL = %d, want 2 (cached)", len(list))
+	}
+
+	if _, err = uc.SyncPictureFolder(ctx, base, nil); err != nil {
+		t.Fatal(err)
+	}
+	list, err = uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].ID != "b" {
+		t.Fatalf("list after sync = %v, want only b", list)
+	}
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_ingestInvalidatesCache(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "restored.png")
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "restored", FilePath: path})
+	uc := NewMediaUseCase(repo, nil, nil)
+	ctx := context.Background()
+
+	list, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("warmup list = %d, want 0 (missing)", len(list))
+	}
+
+	// Restore the file; within TTL the cached "missing" hides it.
+	if err = os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	list, err = uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("list within TTL = %d, want 0 (cached missing)", len(list))
+	}
+
+	// Ingest (picture folder watcher hook) drops the cached entry for the path.
+	s, created, err := uc.IngestScreenshotFile(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || s == nil || s.ID != "restored" {
+		t.Fatalf("ingest = %+v created=%v, want existing row restored", s, created)
+	}
+
+	list, err = uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].ID != "restored" {
+		t.Fatalf("list after ingest = %v, want restored", list)
+	}
+}
+
+func TestMediaUseCase_ListScreenshotsInGalleryScope_ingestUnderRootInvalidatesCache(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "later.png")
+
+	repo := newMockScreenshotRepo()
+	_ = repo.Save(context.Background(), &media.Screenshot{ID: "later", FilePath: path})
+	uc := NewMediaUseCase(repo, nil, nil)
+	ctx := context.Background()
+
+	if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// File appears on disk after the cached "missing" result; the automatic
+	// ingest pass invalidates the cache on success.
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := uc.IngestUnderPictureRootSince(ctx, base, time.Now().Add(-time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].ID != "later" {
+		t.Fatalf("list after ingest-under-root = %v, want later", list)
+	}
+}
+
+func BenchmarkListScreenshotsInGalleryScope(b *testing.B) {
+	const n = 300
+	base := b.TempDir()
+	repo := newMockScreenshotRepo()
+	for i := 0; i < n; i++ {
+		path := filepath.Join(base, fmt.Sprintf("shot-%03d.png", i))
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			b.Fatal(err)
+		}
+		_ = repo.Save(context.Background(), &media.Screenshot{ID: fmt.Sprintf("s%03d", i), FilePath: path})
+	}
+	uc := NewMediaUseCase(repo, nil, nil)
+	ctx := context.Background()
+
+	// Simulate a per-row stat cost so the cache benefit is measurable.
+	old := screenshotFileExists
+	screenshotFileExists = func(path string) bool {
+		time.Sleep(2 * time.Microsecond)
+		return statScreenshotFile(path)
+	}
+	b.Cleanup(func() { screenshotFileExists = old })
+
+	b.Run("cached", func(b *testing.B) {
+		if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("uncached", func(b *testing.B) {
+		uc.fileExists.ttl = 0 // every lookup is stale -> re-stat on each listing
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := uc.ListScreenshotsInGalleryScope(ctx, base, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 func TestMediaUseCase_ListGetDeleteScreenshot(t *testing.T) {
 	repo := newMockScreenshotRepo()
 	s := &media.Screenshot{ID: "s-del", FilePath: "/tmp/x.png"}
 	_ = repo.Save(context.Background(), s)
 	uc := NewMediaUseCase(repo, nil, nil)
 	ctx := context.Background()
-
 	list, err := uc.ListScreenshots(ctx, nil)
 	if err != nil || len(list) != 1 {
 		t.Fatalf("ListScreenshots = %d err=%v", len(list), err)


### PR DESCRIPTION
## 概要

Closes #242

Gallery 一覧取得のたびに各 Screenshot へ `os.Stat` していた（ADR 0001 の Consequences）処理を、**短い TTL のパス単位キャッシュ + sync/ingest 成功時のイベント無効化**で最適化しました。

## 変更内容

- `internal/usecase/gallery_file_exists_cache.go`（新規）
  - パス単位の存在確認結果を保持するプロセス内キャッシュ
  - TTL は `galleryFileStatCacheTTL = 30s`（定数、テストで上書き可能）
  - `get` / `put` / `invalidateAll` / `invalidatePath`
- `internal/usecase/media_gallery_list.go`
  - `ListScreenshotsInGalleryScope` の存在確認をキャッシュ経由に変更（欠損除外の契約は不変）
  - `screenshotFileExists` をテストから観測可能な変数に変更
- `internal/usecase/media_usecase.go`
  - `MediaUseCase` にキャッシュを追加し `NewMediaUseCase` で初期化
  - `IngestScreenshotFile` 成功時にパス単位で無効化（ウォッチャー経由の復帰・新規を即反映）
  - `ScanDirectory` / `IngestUnderPictureRootSince` 成功時に全体無効化
- `internal/usecase/media_picture_sync.go`
  - `SyncPictureFolder`（Manual sync）成功時に全体無効化
- `docs/adr/0001-gallery-scope-and-listing.md`
  - Consequences に「イベント無効化 + TTL」の意図を追記

## 動作の考え方

| シナリオ | 反映タイミング |
| --- | --- |
| Manual sync / Automatic ingest（新規・復帰） | 成功時にキャッシュ無効化 → 次回一覧から反映 |
| ディスク上の外部削除（ウォッチャー非検知） | TTL（最大 30 秒）経過後の再 stat で反映 |

## テスト / ベンチ

- `TestMediaUseCase_ListScreenshotsInGalleryScope_cachesStatWithinTTL` … TTL 内の連続一覧で stat 回数が増えないことを計測
- `TestMediaUseCase_ListScreenshotsInGalleryScope_reStatsAfterTTLExpiry` … TTL 経過で削除・復帰が反映されること
- `TestMediaUseCase_ListScreenshotsInGalleryScope_syncInvalidatesCache` / `_ingestInvalidatesCache` / `_ingestUnderRootInvalidatesCache` … sync / ingest 後の正しい更新
- `BenchmarkListScreenshotsInGalleryScope` … キャッシュ有無の比較（cached ≈ 51µs/op vs uncached ≈ 58.6ms/op、stat コスト 2µs/行 × 300 行を模擬）

```
go test ./internal/usecase/ -run ListScreenshotsInGalleryScope   # all pass
golangci-lint run ./...                                          # 0 issues
```

## スコープ外

- Picture folder sync の並列化（#154）
- Asset cache clear / ディスク使用量表示（#208 / #241）
- DB への mtime/size 永続化

---
*This PR was created by an AI agent (OpenHands) on behalf of the repository maintainer.*