### PR TITLE
feat(frontend): Form control design system (ADR 0021)

### DIFF
--- a/.cursor/rules/element-plus-ui.mdc
+++ b/.cursor/rules/element-plus-ui.mdc
@@ -16,6 +16,7 @@ alwaysApply: false
 
 - ボタン・フォーム・ダイアログ・テーブル・タグなどは **Element Plus コンポーネントを優先**し、素の HTML で同等物を作らない（デザインと挙動の一貫性のため）。
 - **操作ボタン**は **`VtButton`** を使う（`.cursor/rules/button-design-system.mdc`、ADR 0017）。`el-button` 直書きは移行期のみ併存可。
+- **フォーム入力**（テキスト・選択・チェック・スイッチ）は **`VtInput` / `VtSelect` / `VtCheckbox` / `VtSwitch`** を使う（`.cursor/rules/form-design-system.mdc`、ADR 0021）。
 - 仕様・props・スロットは **[Element Plus 公式ドキュメント](https://element-plus.org/)** を正とする（バージョンは `frontend/package.json` の依存に合わせる）。
 
 ## DOM とセレクタ（テスト・E2E）

--- a/.cursor/rules/form-design-system.mdc
+++ b/.cursor/rules/form-design-system.mdc
@@ -1,0 +1,72 @@
+---
+description: Form control ラッパーとレイアウト規約（ADR 0021）。新規・改修で触った画面は VtInput / VtSelect / VtCheckbox / VtSwitch を使う
+globs: "frontend/**/*.{vue,ts}"
+alwaysApply: false
+---
+
+# Form & input control design system
+
+正本: [ADR 0021](../docs/adr/0021-form-control-design-system.md)、用語: [`CONTEXT.md`](../CONTEXT.md) Design system 節。
+
+## 使うもの
+
+| 用途 | コンポーネント |
+|------|----------------|
+| テキスト入力 | **`VtInput`** |
+| 単一選択 | **`VtSelect`** + `el-option` |
+| 編集フォーム内の真偽（一括保存） | **`VtCheckbox`** |
+| 即時反映設定・一覧の有効フラグ | **`VtSwitch`** |
+
+`disabled` / `size` / `data-testid` / `placeholder` 等はそのまま渡す（透過）。
+
+## Checkbox vs switch
+
+| 文脈 | 使うもの |
+|------|----------|
+| `el-form` 内・他項目と同じ保存タイミング | **VtCheckbox** |
+| 即時 API 保存の単発設定（多くは Setting row） | **VtSwitch** |
+| 一覧カードの有効/無効即切替 | **VtSwitch**（`size="small"` 可） |
+| UI 表示モード切替（Friends Online/Offline 等） | **UI mode toggle**（既存 toggle-group。VtSwitch にしない） |
+
+**VtSwitch** の `active-text` / `inline-prompt` は使わない。ラベルは外側で付ける。
+
+## レイアウト
+
+| パターン | いつ |
+|----------|------|
+| **Form layout** | 複数項目の編集 → `el-form` + `label-position="top"` + `size="default"`。項目間 `--space-form-field` |
+| **Setting row** | カード内 1 行設定 → `.setting-row`（ラベル左・コントロール右） |
+| **Path input row** | パス入力 → `.path-input-group` + **VtInput** + 参照 **VtButton** `variant="secondary"` |
+
+編集フォーム内の入力は **`el-form-item` 内で幅 100%**（フル幅）を既定とする。
+
+## サイズ
+
+- 省略時 **default**（`el-form size="default"` で継承）
+- `small` は **List enable toggle** の VtSwitch と密集レイアウトの明示指定のみ
+- `large` は使わない
+
+## エラー
+
+| 層 | 示し方 |
+|----|--------|
+| フィールド検証 | `el-form-item` 直下、i18n 固定文 |
+| 一括保存失敗 | `ElMessage.error` |
+| 即時トグル失敗 | ブロック内 `el-alert`（Cookie linkage 型） |
+
+## 移行
+
+- 新規・改修で触ったファイルは Vt* へ。未触りの `el-input` 等直書きは一括置換しない
+- ESLint 禁止は v1 では入れない
+- パス入力: `.cursor/rules/path-input-pattern.mdc`
+
+## Storybook
+
+- `VtInput.stories.ts` / `VtSelect.stories.ts` / `VtCheckbox.stories.ts` / `VtSwitch.stories.ts`
+- `FormLayoutPatterns.stories.ts` — レイアウト例の正本
+
+## 関連
+
+- ボタン: `.cursor/rules/button-design-system.mdc`
+- Element Plus: `.cursor/rules/element-plus-ui.mdc`
+- Storybook: `.cursor/rules/storybook-wails-ui.mdc`

--- a/.cursor/rules/path-input-pattern.mdc
+++ b/.cursor/rules/path-input-pattern.mdc
@@ -28,16 +28,22 @@ alwaysApply: false
 ```vue
 <!-- フォルダ選択 -->
 <div class="path-input-group">
-  <input v-model="config.cacheDirectory" type="text" ...>
-  <button type="button" class="btn-browse" @click="browseCacheDirectory">参照</button>
+  <VtInput v-model="config.cacheDirectory" ... />
+  <VtButton variant="secondary" data-testid="cache-browse" @click="browseCacheDirectory">
+    参照
+  </VtButton>
 </div>
 
 <!-- ファイル選択 -->
 <div class="path-input-group">
-  <input v-model="pathSettings.outputLogPath" type="text" ...>
-  <button type="button" class="btn-browse" @click="browseOutputLogPath">参照</button>
+  <VtInput v-model="pathSettings.outputLogPath" ... />
+  <VtButton variant="secondary" data-testid="output-log-browse" @click="browseOutputLogPath">
+    参照
+  </VtButton>
 </div>
 ```
+
+正本: [ADR 0021](../docs/adr/0021-form-control-design-system.md)、`.cursor/rules/form-design-system.mdc`（**Path input row**）。
 
 ```ts
 // フォルダ選択

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -708,7 +708,7 @@ _Avoid_: 常時実行, バックグラウンドサービス（v1 で含意しな
 
 ## Design system
 
-ボタン様式・余白・色・タイポグラフィなどアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
+ボタン様式・余白・色・タイポグラフィ・フォーム入力部品などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。**Form control** ラッパー（VtInput / VtSelect / VtCheckbox / VtSwitch）は grill-with-docs で合意済み（[ADR 0021](docs/adr/0021-form-control-design-system.md)）。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
 
 ### Language
 
@@ -1002,6 +1002,106 @@ _Avoid_: 全面置換, rem 禁止の CI 強制（即時一括・CI 強制を含�
 **Typography Storybook catalog**:
 Typography の Storybook 一覧。**Typography scale**・**Line height scale**・**Font weight scale**・**Text style catalog** の対応表と使用例、**Element Plus typography mapping** の要点を載せ、見た目と使い方の正本とする（**Spacing Storybook catalog** / **Color Storybook catalog** と同型）。
 _Avoid_: 全画面 Storybook, デザイントークン一覧（Color・Spacing の総称）
+
+**Form control**:
+テキスト入力・選択・チェック・トグルなど、ユーザーが値を編集する単体 UI 部品。**VtButton** と同型で **VtInput** / **VtSelect** / **VtCheckbox** / **VtSwitch** ラッパーを正とし、`el-input` / `el-select` / `el-checkbox` / `el-switch` の直接利用は **Form control adoption** の移行期のみ併存可。見た目の色は既存の **Element Plus color mapping**（`--el-input-*` / `--el-switch-*`）を維持する。
+_Avoid_: フォーム（**Form layout** 全体と混同しやすいため）, 入力欄（素の `<input>` や path 専用パターンまで含意しうるため）
+
+**VtInput**:
+テキスト系入力の標準ラッパー。内部は `el-input`（`type` 透過で password 等も可）。`textarea` は v1 では別ラッパーにせず、必要時は `el-input type="textarea"` を規約で扱うか後続で **VtTextarea** を検討する。
+_Avoid_: el-input（移行完了後の直呼び）, path 入力行（**Path input row** は専用パターン）
+
+**VtSelect**:
+単一選択ドロップダウンの標準ラッパー。内部は `el-select` + `el-option`。フィルタ可能・複数選択・リモート検索は v1 スコープ外（必要になったら拡張）。
+_Avoid_: el-select, セレクトボックス（HTML `<select>` と混同しやすいため）
+
+**VtCheckbox**:
+真偽を選ぶチェックボックスの標準ラッパー。内部は `el-checkbox`。**Form layout** 内で他フィールドと**同じ保存・反映タイミング**の真偽に使う（起動オプション、ルール条件、continue on error、既定フラグなど）。複数選択は `el-checkbox-group`（v1 ではグループラッパーなし）。即時 API 保存の単発設定や一覧の有効フラグには使わない（**VtSwitch**）。
+_Avoid_: el-checkbox, トグル（**VtSwitch** と混同しやすいため）, 即時反映設定（**Immediate setting toggle** と混同しやすいため）
+
+**VtSwitch**:
+オン／オフを切り替えるトグルスイッチの標準ラッパー。内部は `el-switch`。**Immediate setting toggle**（**Setting row**）、**List enable toggle** に使う。`el-switch` の内蔵ラベル（`active-text` / `inline-prompt` 等）は v1 では使わない（ラベルは外側の **Form layout** または **Setting row** で付ける）。**Form layout** 内で他項目とまとめて保存する真偽には使わない（**VtCheckbox**）。
+_Avoid_: el-switch, チェックボックス（**VtCheckbox** と混同しやすいため）, UI モード切替（**UI mode toggle** は別パターン）
+
+**Immediate setting toggle**:
+変更と同時に（またはほぼ同時に）永続化・API 反映する単発のオン／オフ設定。**VtSwitch** + 多くは **Setting row**。例: スリープ抑制、yt-dlp 実験機能の有効化。編集フォームの「保存ボタンまで送らない」真偽（ルール条件など）とは別。
+_Avoid_: 有効フラグ（**List enable toggle** と混同しやすいため）, チェックボックス設定
+
+**List enable toggle**:
+一覧・カード行上で、その item の有効／無効を**即切替**する **VtSwitch**。編集フォームの保存タイミングとは独立。例: Automation item の `isEnabled`。`size="small"` を使ってよい。
+_Avoid_: チェックボックス, フォーム内トグル
+
+**UI mode toggle**:
+2 状態の**表示モード**を切り替える UI（設定の永続化が主目的ではない）。**VtSwitch** / **VtCheckbox** の使い分けルールの対象外。**toggle-group** + ラジオ、またはラベル付きモード表示（Friends の Online/Offline 型）を **Semantic 例外**として維持。Form control ラッパーへの統合は v1 では行わない。
+_Avoid_: VtSwitch, 設定スイッチ（**Immediate setting toggle** と混同しやすいため）, フィルタ（Gallery の絞り込みと混同しやすいため）
+
+**Form control checkbox–switch rule**:
+**VtCheckbox** と **VtSwitch** の使い分け正本。編集フォーム内の真偽（他フィールドと同じ保存・反映）→ **VtCheckbox**。即時反映の単発設定 → **VtSwitch** + **Setting row**。一覧・カードの有効フラグ即切替 → **VtSwitch**（small 可）。UI 表示モード切替 → **UI mode toggle**（Semantic 例外）。複数選択 → **VtCheckbox** + group。
+_Avoid_: トグル全般, 真偽入力（4 コントロール以外の radio 等を含意しうるため）
+
+**Form control size**:
+Form control の寸法。**省略時は常に `default`**（暗黙の `small` / `large` は持たない）。`small` は **List enable toggle** の **VtSwitch**、Launcher Advanced など密集レイアウトで**明示指定したときのみ**。`large` は v1 不使用（ラッパーでも公開しない）。編集フォームは **`el-form size="default"`** で子へ継承し、個別 Vt* に毎回 `size` を付けない。
+_Avoid_: small 既定, large ボタン（**VtButton** の size と混同しやすいため）
+
+**Form control disabled state**:
+操作できない Form control に付ける状態。ボタン様式ではなくいずれのコントロールにも重ねる。実装は標準 `disabled`（または同等）の**透過**。無効理由はラベル近くの hint・周辺文言で伝える（**Button disabled state** と同型）。`readonly` は v1 の Form control では使わず編集不可は `disabled` に統一。**VtInput** / **VtSelect** には **Button loading state** 相当の loading 様式は設けない（ロード中はフォーム全体 `disabled` または操作ボタン loading）。
+_Avoid_: Readonly 様式, Loading 入力（ボタン loading と混同しやすいため）, Disabled 様式（第 5 の見た目名）
+
+**Form field validation error**:
+保存前にクライアントで判定できる不正（空必須・数値範囲など）の示し方。**Form layout** 内では **`el-form-item` のフィールド直下**（`:error` または将来 `:rules`）に **i18n 固定文**のみ示す。Vt* ラッパー内にエラー UI は持たない。バックエンドの生エラー文字列をラベルやフィールドエラーに載せない。
+_Avoid_: ElMessage（一括保存失敗と混同しやすいため）, バリデーション（サーバー応答のマッピングまで含意しうるため）
+
+**Form save failure feedback**:
+編集フォームの一括保存 API が失敗したときの示し方。既存どおり **`ElMessage.error`**（i18n + `formatBackendError` 等）。フィールド別に原因が分からない失敗を `el-form-item` へ割り当てない。
+_Avoid_: フィールドエラー, セクション alert（即時反映失敗と混同しやすいため）
+
+**Immediate toggle failure feedback**:
+**Immediate setting toggle** または **List enable toggle** の API 失敗の示し方。**そのブロック内**の `el-alert` またはブロック直下のエラー行（Cookie linkage 型）。**i18n 分類済みの短い文**のみ。`ElMessage.error` だけに頼らない（一覧トグルと Setting row を同型にする）。失敗後はトグルを操作前の Effective 状態へ戻す（Cookie linkage draft 型）。
+_Avoid_: Form save failure feedback, 生のバックエンドエラー, Server status fetch failure（読み取り失敗と混同しやすいため）
+
+**Form fetch failure**:
+フォーム表示用データの取得失敗（ログイン済みだが self 行を読めない等）。Form control のバリデーションとは別契約。カード内メッセージ＋コントロール `disabled` または非表示（Presence change / Dashboard launch block と同型）。`ElMessage` は出さない。
+_Avoid_: Form field validation error, 空フォームでの編集
+
+**Form control error v1 scope**:
+Form control まわりのエラー表示 v1 範囲。上記 3 層（フィールド検証・一括保存・即時トグル）と **Form fetch failure** の文書化に限定。**含めない**: 全フォーム `:rules` 一括導入、`VtFormItem` ラッパー、サーバーのフィールド別エラー自動マッピング、Automation 一覧トグルの ElMessage 即時統一（触ったファイルから **Immediate toggle failure feedback** へ寄せる）。
+_Avoid_: Form control error（v1 範囲を指すときは scope とセットで書く）
+
+**Path input row**:
+ファイルまたはフォルダのパスを入力する**複合レイアウトパターン**。**Form control**（単体）・**Form layout**・**Setting row** とは別の第三の型。`.path-input-group` で **VtInput** と参照 **VtButton**（**Secondary button**）を横並べ。Settings の path-row はラベル上・入力下で、参照に加え存在確認など**複数アクション**を並べてよい。v1 では **VtPathInput** ラッパーは作らない。`path-input-pattern.mdc` の素 `<input>` 例は **VtInput** へ更新する。**Cookies file source** のパス欄も同パターン。
+_Avoid_: VtInput 単体（browse 必須の文脈）, Path input（行全体のレイアウトを含意しないため）, 解像度プリセット（**resolution-selection-ui** は別パターン）
+
+**Path input row adoption**:
+Path input row への揃え方針。新規・改修のパス欄は `.path-input-group` + **VtInput** + **VtButton**（参照は Secondary）。既存 `el-input` / `el-button` 直書きは触ったところから。**VtPathInput** 統合は v1 では行わない。
+_Avoid_: 全面 Path ラッパー化, 素 input 新規追加（`element-plus-ui` と矛盾するため）
+
+**Form control Storybook catalog**:
+Form control の Storybook 正本。**VtInput** / **VtSelect** / **VtCheckbox** / **VtSwitch** それぞれ独立の `*.stories.ts`（通常・**Form control disabled state**・代表 props）。加えて **Form layout patterns story** 1 本（**Form layout**・**Setting row**・**Path input row** の並び例）。見た目と使い方は **VtButton Storybook catalog** と同型。
+_Avoid_: 統合 catalog 1 本のみ（コンポーネント別の正本が薄れるため）, 全画面 Storybook
+
+**Form control v1 deliverables**:
+Issue／PR で最初に届ける具体物。(1) 4 ラッパー + 各単体テスト、(2) **Form control Storybook catalog**、(3) **Form layout patterns story**、(4) `.cursor/rules/form-design-system.mdc`、(5) `docs/adr/0021-form-control-design-system.md`、(6) `path-input-pattern.mdc` の Vt* 更新、(7) `CONTEXT.md` 同期。色・タイポは既存 **Element Plus color mapping** / **Element Plus typography mapping** を維持（見た目変更なし）。各 View の `el-*` 直書きは **Form control adoption** に従い触ったところだけ。
+_Avoid_: Form control v1 scope（届け物リストを指すときは deliverables とセットで書く）, 全画面置換
+
+**Form control adoption**:
+Form control ラッパーへの移行方針。新規画面・改修で触ったファイルでは **VtInput** / **VtSelect** / **VtCheckbox** / **VtSwitch** を使う。未着手の既存 `el-*` 直書きは一括置換しない（触ったところから順次）。遵守は `.cursor/rules/` で案内し、移行期は ESLint では強制しない。見た目の正本は各 **Form control Storybook catalog**。
+_Avoid_: 全面置換, el-input 禁止の CI 強制（即時一括・CI 強制を含意するため）
+
+**Form control v1 scope**:
+Form & Input Controls 策定の最初の届け範囲。4 ラッパー + Storybook + `.cursor/rules/` + ADR + `CONTEXT.md` に限定する。含める: 上記 4 種、`disabled` / `loading`（該当時）・`data-testid` の透過、**Element Plus color mapping** の維持。含めない: `el-input-number` / `el-radio` / `el-autocomplete` のラッパー、**Path input row** の統合、全 View 一括置換、ESLint 強制、バリデーション UI の全面再設計。
+_Avoid_: Form control（v1 範囲を指すときは scope とセットで書く）, 将来拡張（スコープ外リストの総称として曖昧なため）
+
+**Form layout**:
+Form control を並べるレイアウト規約。**複数項目の編集**は **`el-form` + `label-position="top"`** を正とする（Launcher・Automation・Settings ログイン等）。項目間の縦間隔は **Spacing pattern** の `--space-form-field`（12px）。`el-form-item` 内の入力・選択は**原則幅 100%**（フル幅）。ラベルは `el-form-item` の `:label`（または同等）で付け、**Body small** 相当の **Neutral text** で示す。補足文（hint）は入力の直下に `el-text` 等で置き、ラベルと入力の間には入れない。
+_Avoid_: setting-row（**Setting row** は単発設定行の別パターン）, 横ラベルフォーム（編集フォーム全体を指すとき）
+
+**Setting row**:
+`el-card` 内などで **1 行に説明とコントロールを横並べ**するレイアウトパターン。左にラベル＋任意の hint、右に **VtSwitch** や **VtInput** 等。Settings の電源スイッチ・保存期間入力が代表例。共有クラス `.setting-row` を正とし、v1 では **VtSettingRow** ラッパーは必須にしない。複数項目の編集ブロックは **Form layout**（top ラベル `el-form`）を使い、Setting row に寄せない。
+_Avoid_: フォーム行（**Form layout** 全体と混同しやすいため）, 設定行（Launcher の profile 行など別 UI と混同しやすいため）
+
+**Form layout adoption**:
+Form layout / Setting row への揃え方針。新規・改修で複数項目編集は **Form layout**、カード内単発の横並び設定は **Setting row**。既存のばらつき（`setting-row` 内 `el-input-number` 等）は一括置換しない（触ったところから）。Spacing は **Spacing token** / **Spacing pattern** を使う。
+_Avoid_: 全面レイアウト統一, el-form 強制の CI（即時一括を含意するため）
 
 ## Agent contribution
 

--- a/docs/adr/0021-form-control-design-system.md
+++ b/docs/adr/0021-form-control-design-system.md
@@ -1,0 +1,116 @@
+# ADR 0021: Form & input control design system (VtInput / VtSelect / VtCheckbox / VtSwitch)
+
+## Status
+
+Accepted（grill-with-docs で合意）
+
+## Context
+
+- 画面ごとに `el-input` / `el-select` / `el-checkbox` / `el-switch` の直書きが散在し、レイアウト（`el-form` top vs `setting-row`）、checkbox/switch の意味論、エラー表示がばらつく
+- **VtButton**（[ADR 0017](0017-button-design-system-vtbutton.md)）、**Spacing**（[ADR 0018](0018-spacing-design-system.md)）、**Color**（[ADR 0019](0019-color-design-system.md)）、**Typography**（[ADR 0020](0020-typography-design-system.md)）は整備済み。入力コントロールの色は `style.css` の `--el-input-*` / `--el-switch-*` で既にマッピング済みだが、コンポーネント規約と adoption は未定義
+- Element Plus は見た目 API を持つが、**checkbox vs switch**・**即時反映 vs 一括保存**の意味論は規定しない
+- パス入力は `.path-input-group` + `el-input` が実装主流だが、`path-input-pattern.mdc` の例は素 `<input>` のまま
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Design system** セクション（**Form control**、**Form layout**、**Form control checkbox–switch rule** 等）を正本とする。
+
+## Decision
+
+### 1. ラッパー（Vt*）
+
+| ラッパー | 内部 | 用途 |
+|----------|------|------|
+| **VtInput** | `el-input` | テキスト系（`type` 透過）。`textarea` は v1 ではラッパーなし |
+| **VtSelect** | `el-select` + `el-option` | 単一選択。filterable / multiple / remote は v1 外 |
+| **VtCheckbox** | `el-checkbox` | **Form layout** 内・他フィールドと同じ保存タイミングの真偽 |
+| **VtSwitch** | `el-switch` | **Immediate setting toggle** / **List enable toggle** |
+
+- `disabled`・`data-testid`・`size` 等は **透過**（`$attrs` / `inheritAttrs`、VtButton と同型）
+- v1 では暗黙の `variant` は不要（ボタンと異なり 4 様式ではない）
+- 新規・改修では Vt* を使う。**Form control adoption**（触ったところから順次）
+
+### 2. Element Plus マッピング
+
+- 色: 既存 `--el-input-*` / `--el-switch-*`（**Color** ADR）を維持。v1 では見た目変更なし
+- サイズ: **`el-form size="default"`** で子へ継承。Vt* に毎回 `size` は付けない
+- **Form control size**: 省略時 `default`。`small` は **List enable toggle** の VtSwitch と密集レイアウト（Launcher Advanced 等）の明示指定のみ。`large` は v1 不使用
+
+### 3. レイアウト
+
+| パターン | 正本 | 用途 |
+|----------|------|------|
+| **Form layout** | `el-form` + `label-position="top"` | 複数項目の編集フォーム。項目間 `--space-form-field` |
+| **Setting row** | `.setting-row` | カード内 1 行（ラベル＋hint 左、コントロール右） |
+| **Path input row** | `.path-input-group` + VtInput + VtButton Secondary | パス + 参照（複数アクション可）。**VtPathInput** は v1 では作らない |
+
+### 4. Checkbox vs switch（**Form control checkbox–switch rule**）
+
+| 文脈 | コントロール |
+|------|--------------|
+| 編集フォーム内の真偽（他項目と同じ保存・反映） | **VtCheckbox** |
+| 即時反映の単発設定 | **VtSwitch** + 多くは **Setting row** |
+| 一覧・カードの有効フラグ即切替 | **VtSwitch**（`small` 可） |
+| UI 表示モード切替（Friends Online/Offline 等） | **UI mode toggle**（Semantic 例外。toggle-group 等） |
+| 複数選択（曜日など） | **VtCheckbox** + `el-checkbox-group` |
+
+- **VtSwitch** の `active-text` / `inline-prompt` 等の内蔵ラベルは v1 不使用
+
+### 5. disabled / readonly
+
+- **Form control disabled state**: 標準 `disabled` 透過。理由は周辺 hint / 文言
+- `readonly` は v1 の Form control では使わない（`disabled` に統一）
+- VtInput / VtSelect に loading 様式は設けない
+
+### 6. エラー表示（3 層）
+
+| 層 | 示し方 |
+|----|--------|
+| **Form field validation error** | `el-form-item` 直下、i18n 固定文のみ |
+| **Form save failure feedback** | `ElMessage.error`（一括保存失敗） |
+| **Immediate toggle failure feedback** | ブロック内 `el-alert` 等（Cookie linkage 型）。一覧トグルも同型へ寄せる |
+| **Form fetch failure** | カード内メッセージ＋disabled / 非表示（Presence 型）。別契約 |
+
+### 7. Storybook
+
+- `VtInput.stories.ts` / `VtSelect.stories.ts` / `VtCheckbox.stories.ts` / `VtSwitch.stories.ts` — 各コントロールの通常 / disabled / 代表 props
+- `FormLayoutPatterns.stories.ts` — Form layout / Setting row / Path input row
+- 正本は **Form control Storybook catalog**（VtButton catalog と同型）
+
+### 8. Agent / 実装ルール
+
+- `.cursor/rules/form-design-system.mdc` 新設
+- `path-input-pattern.mdc` を VtInput + VtButton に更新
+- ESLint による `el-input` 等禁止は v1 では入れない
+
+## Considered options
+
+| 案 | 却下理由 |
+|----|----------|
+| 規約のみ（ラッパーなし） | adoption の強制力が弱く、checkbox/switch 誤用が再発しやすい |
+| **VtPathInput** を v1 で統合 | Settings path-row の複数アクションで props が膨らむ |
+| レイアウトを `el-form` に全面統一 | Setting row の横並び説明＋スイッチが縦に伸びる |
+| 即時トグル失敗を ElMessage のみ | 一覧トグルと Setting row で表現がずれる |
+| Storybook 統合 1 ファイルのみ | コンポーネント別の正本が薄れる |
+
+## v1 scope
+
+**含む:**
+
+- 4 ラッパー + 単体テスト + Storybook（4 + Form layout patterns）
+- `.cursor/rules/form-design-system.mdc`
+- `path-input-pattern.mdc` 更新
+- `CONTEXT.md` / 本 ADR
+
+**含まない:**
+
+- `el-input-number` / `el-radio` / `el-autocomplete` ラッパー
+- `VtPathInput` / `VtFormItem` / `VtTextarea`
+- 全 View 一括置換、ESLint 強制
+- 全フォーム `:rules` 一括導入、サーバーフィールド別エラー自動マッピング
+- `resolution-selection-ui` の変更
+- Element Plus 入力色・見た目の変更
+
+## Consequences
+
+- 新規・改修 PR では Vt* と Form layout / Setting row / Path input row の使い分けが期待される
+- 即時トグル失敗は触ったファイルからブロック内エラーへ寄せる（Automation 一覧の ElMessage は段階移行）
+- UI モード切替（Friends 等）は現行パターンを維持

--- a/frontend/src/components/FormControl.stories.css
+++ b/frontend/src/components/FormControl.stories.css
@@ -17,8 +17,7 @@
   margin-bottom: 0;
 }
 
-.vt-form-layout-story .el-form-item__content > .el-input,
-.vt-form-layout-story .el-form-item__content > .el-select {
+.vt-form-layout-story .el-form-item__content > * {
   width: 100%;
 }
 
@@ -35,7 +34,7 @@
 
 .vt-setting-row-story__hint {
   display: block;
-  margin-top: var(--space-inline-tight);
+  margin-top: var(--space-4);
   color: var(--color-text-secondary);
   font-size: var(--font-size-12);
 }
@@ -51,7 +50,7 @@
   flex-wrap: wrap;
 }
 
-.vt-path-input-group-story .el-input {
+.vt-path-input-group-story > :first-child {
   flex: 1;
   min-width: 0;
 }

--- a/frontend/src/components/FormControl.stories.css
+++ b/frontend/src/components/FormControl.stories.css
@@ -1,0 +1,57 @@
+.vt-form-story-prefix {
+  color: var(--color-text-secondary);
+}
+
+.vt-form-layout-story {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-section);
+  max-width: 28rem;
+}
+
+.vt-form-layout-story .el-form-item {
+  margin-bottom: var(--space-form-field);
+}
+
+.vt-form-layout-story .el-form-item:last-child {
+  margin-bottom: 0;
+}
+
+.vt-form-layout-story .el-form-item__content > .el-input,
+.vt-form-layout-story .el-form-item__content > .el-select {
+  width: 100%;
+}
+
+.vt-setting-row-story {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-block);
+}
+
+.vt-setting-row-story__label {
+  flex: 1;
+  min-width: 0;
+}
+
+.vt-setting-row-story__hint {
+  display: block;
+  margin-top: var(--space-inline-tight);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-12);
+}
+
+.vt-setting-row-story__control {
+  flex-shrink: 0;
+}
+
+.vt-path-input-group-story {
+  display: flex;
+  gap: var(--space-action-group);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.vt-path-input-group-story .el-input {
+  flex: 1;
+  min-width: 0;
+}

--- a/frontend/src/components/FormLayoutPatterns.stories.ts
+++ b/frontend/src/components/FormLayoutPatterns.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ElForm, ElFormItem, ElOption } from "element-plus";
 import { ref } from "vue";
 import VtInput from "./VtInput.vue";
 import VtSelect from "./VtSelect.vue";
@@ -23,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 export const FormLayoutTopLabels: Story = {
   name: "Form layout (top labels)",
   render: () => ({
-    components: { VtInput, VtSelect, VtCheckbox },
+    components: { VtInput, VtSelect, VtCheckbox, ElForm, ElFormItem, ElOption },
     setup() {
       const name = ref("Desktop");
       const lang = ref("ja");

--- a/frontend/src/components/FormLayoutPatterns.stories.ts
+++ b/frontend/src/components/FormLayoutPatterns.stories.ts
@@ -76,7 +76,7 @@ export const PathInputRow: Story = {
   render: () => ({
     components: { VtInput, VtButton },
     setup() {
-      const path = ref("C:\\\\VRChat\\\\output_log.txt");
+      const path = ref("C:\\VRChat\\output_log.txt");
       return { path };
     },
     template: `

--- a/frontend/src/components/FormLayoutPatterns.stories.ts
+++ b/frontend/src/components/FormLayoutPatterns.stories.ts
@@ -82,9 +82,9 @@ export const PathInputRow: Story = {
     },
     template: `
       <div class="vt-form-layout-story">
-        <label>Output log path</label>
+        <label for="output-log-path">Output log path</label>
         <div class="vt-path-input-group-story">
-          <VtInput v-model="path" />
+          <VtInput id="output-log-path" v-model="path" />
           <VtButton variant="secondary">Browse</VtButton>
         </div>
       </div>

--- a/frontend/src/components/FormLayoutPatterns.stories.ts
+++ b/frontend/src/components/FormLayoutPatterns.stories.ts
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ref } from "vue";
+import VtInput from "./VtInput.vue";
+import VtSelect from "./VtSelect.vue";
+import VtCheckbox from "./VtCheckbox.vue";
+import VtSwitch from "./VtSwitch.vue";
+import VtButton from "./VtButton.vue";
+import "./FormControl.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Design/Form layout patterns",
+  tags: ["autodocs"],
+  parameters: catalogParameters,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FormLayoutTopLabels: Story = {
+  name: "Form layout (top labels)",
+  render: () => ({
+    components: { VtInput, VtSelect, VtCheckbox },
+    setup() {
+      const name = ref("Desktop");
+      const lang = ref("ja");
+      const desktop = ref(true);
+      return { name, lang, desktop };
+    },
+    template: `
+      <div class="vt-form-layout-story">
+        <el-form label-position="top" size="default">
+          <el-form-item label="Profile name">
+            <VtInput v-model="name" placeholder="Name" />
+          </el-form-item>
+          <el-form-item label="Language">
+            <VtSelect v-model="lang">
+              <el-option value="ja" label="日本語" />
+              <el-option value="en" label="English" />
+            </VtSelect>
+          </el-form-item>
+          <el-form-item>
+            <VtCheckbox v-model="desktop">Desktop mode</VtCheckbox>
+          </el-form-item>
+        </el-form>
+      </div>
+    `,
+  }),
+};
+
+export const SettingRow: Story = {
+  name: "Setting row",
+  render: () => ({
+    components: { VtSwitch },
+    setup() {
+      const suppressSleep = ref(true);
+      return { suppressSleep };
+    },
+    template: `
+      <div class="vt-setting-row-story">
+        <div class="vt-setting-row-story__label">
+          <span>Suppress sleep while VRChat is running</span>
+          <span class="vt-setting-row-story__hint">Keeps the PC awake during sessions.</span>
+        </div>
+        <VtSwitch v-model="suppressSleep" class="vt-setting-row-story__control" />
+      </div>
+    `,
+  }),
+};
+
+export const PathInputRow: Story = {
+  name: "Path input row",
+  render: () => ({
+    components: { VtInput, VtButton },
+    setup() {
+      const path = ref("C:\\\\VRChat\\\\output_log.txt");
+      return { path };
+    },
+    template: `
+      <div class="vt-form-layout-story">
+        <label>Output log path</label>
+        <div class="vt-path-input-group-story">
+          <VtInput v-model="path" />
+          <VtButton variant="secondary">Browse</VtButton>
+        </div>
+      </div>
+    `,
+  }),
+};

--- a/frontend/src/components/VtCheckbox.stories.ts
+++ b/frontend/src/components/VtCheckbox.stories.ts
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ref } from "vue";
+import VtCheckbox from "./VtCheckbox.vue";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Components/VtCheckbox",
+  component: VtCheckbox,
+  tags: ["autodocs"],
+} satisfies Meta<typeof VtCheckbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { VtCheckbox },
+    setup() {
+      const checked = ref(true);
+      return { checked };
+    },
+    template: `<VtCheckbox v-model="checked">Desktop mode</VtCheckbox>`,
+  }),
+};
+
+export const Disabled: Story = {
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtCheckbox },
+    setup() {
+      const checked = ref(false);
+      return { checked };
+    },
+    template: `<VtCheckbox v-model="checked" disabled>Desktop mode</VtCheckbox>`,
+  }),
+};

--- a/frontend/src/components/VtCheckbox.stories.ts
+++ b/frontend/src/components/VtCheckbox.stories.ts
@@ -10,6 +10,7 @@ const meta = {
   title: "Components/VtCheckbox",
   component: VtCheckbox,
   tags: ["autodocs"],
+  parameters: catalogParameters,
 } satisfies Meta<typeof VtCheckbox>;
 
 export default meta;
@@ -27,7 +28,6 @@ export const Default: Story = {
 };
 
 export const Disabled: Story = {
-  parameters: catalogParameters,
   render: () => ({
     components: { VtCheckbox },
     setup() {

--- a/frontend/src/components/VtCheckbox.vue
+++ b/frontend/src/components/VtCheckbox.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+</script>
+
+<template>
+  <el-checkbox v-bind="$attrs">
+    <slot />
+  </el-checkbox>
+</template>

--- a/frontend/src/components/VtCheckbox.vue
+++ b/frontend/src/components/VtCheckbox.vue
@@ -7,7 +7,7 @@ defineOptions({
 <template>
   <el-checkbox v-bind="$attrs">
     <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
-      <slot :name="slotName" v-bind="slotProps || {}" />
+      <slot :name="slotName" v-bind="slotProps ?? {}" />
     </template>
   </el-checkbox>
 </template>

--- a/frontend/src/components/VtCheckbox.vue
+++ b/frontend/src/components/VtCheckbox.vue
@@ -6,6 +6,8 @@ defineOptions({
 
 <template>
   <el-checkbox v-bind="$attrs">
-    <slot />
+    <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
+      <slot :name="slotName" v-bind="slotProps || {}" />
+    </template>
   </el-checkbox>
 </template>

--- a/frontend/src/components/VtInput.stories.ts
+++ b/frontend/src/components/VtInput.stories.ts
@@ -10,6 +10,7 @@ const meta = {
   title: "Components/VtInput",
   component: VtInput,
   tags: ["autodocs"],
+  parameters: catalogParameters,
 } satisfies Meta<typeof VtInput>;
 
 export default meta;
@@ -23,7 +24,6 @@ export const Default: Story = {
 };
 
 export const Disabled: Story = {
-  parameters: catalogParameters,
   render: () => ({
     components: { VtInput },
     template: `<VtInput placeholder="Profile name" disabled />`,
@@ -31,7 +31,6 @@ export const Disabled: Story = {
 };
 
 export const WithPrefix: Story = {
-  parameters: catalogParameters,
   render: () => ({
     components: { VtInput },
     template: `

--- a/frontend/src/components/VtInput.stories.ts
+++ b/frontend/src/components/VtInput.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import VtInput from "./VtInput.vue";
+import "./FormControl.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Components/VtInput",
+  component: VtInput,
+  tags: ["autodocs"],
+} satisfies Meta<typeof VtInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { VtInput },
+    template: `<VtInput placeholder="Profile name" />`,
+  }),
+};
+
+export const Disabled: Story = {
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtInput },
+    template: `<VtInput placeholder="Profile name" disabled />`,
+  }),
+};
+
+export const WithPrefix: Story = {
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtInput },
+    template: `
+      <VtInput placeholder="Search display name" clearable>
+        <template #prefix><span class="vt-form-story-prefix">⌕</span></template>
+      </VtInput>
+    `,
+  }),
+};

--- a/frontend/src/components/VtInput.vue
+++ b/frontend/src/components/VtInput.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+</script>
+
+<template>
+  <el-input v-bind="$attrs">
+    <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
+      <slot :name="slotName" v-bind="slotProps || {}" />
+    </template>
+  </el-input>
+</template>

--- a/frontend/src/components/VtInput.vue
+++ b/frontend/src/components/VtInput.vue
@@ -7,7 +7,7 @@ defineOptions({
 <template>
   <el-input v-bind="$attrs">
     <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
-      <slot :name="slotName" v-bind="slotProps || {}" />
+      <slot :name="slotName" v-bind="slotProps ?? {}" />
     </template>
   </el-input>
 </template>

--- a/frontend/src/components/VtSelect.stories.ts
+++ b/frontend/src/components/VtSelect.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ElOption } from "element-plus";
 import { ref } from "vue";
 import VtSelect from "./VtSelect.vue";
 
@@ -18,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => ({
-    components: { VtSelect },
+    components: { VtSelect, ElOption },
     setup() {
       const value = ref("ja");
       return { value };
@@ -34,7 +35,7 @@ export const Default: Story = {
 
 export const Disabled: Story = {
   render: () => ({
-    components: { VtSelect },
+    components: { VtSelect, ElOption },
     setup() {
       const value = ref("ja");
       return { value };

--- a/frontend/src/components/VtSelect.stories.ts
+++ b/frontend/src/components/VtSelect.stories.ts
@@ -10,6 +10,7 @@ const meta = {
   title: "Components/VtSelect",
   component: VtSelect,
   tags: ["autodocs"],
+  parameters: catalogParameters,
 } satisfies Meta<typeof VtSelect>;
 
 export default meta;
@@ -32,7 +33,6 @@ export const Default: Story = {
 };
 
 export const Disabled: Story = {
-  parameters: catalogParameters,
   render: () => ({
     components: { VtSelect },
     setup() {

--- a/frontend/src/components/VtSelect.stories.ts
+++ b/frontend/src/components/VtSelect.stories.ts
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ref } from "vue";
+import VtSelect from "./VtSelect.vue";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Components/VtSelect",
+  component: VtSelect,
+  tags: ["autodocs"],
+} satisfies Meta<typeof VtSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { VtSelect },
+    setup() {
+      const value = ref("ja");
+      return { value };
+    },
+    template: `
+      <VtSelect v-model="value" placeholder="Language">
+        <el-option value="ja" label="日本語" />
+        <el-option value="en" label="English" />
+      </VtSelect>
+    `,
+  }),
+};
+
+export const Disabled: Story = {
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtSelect },
+    setup() {
+      const value = ref("ja");
+      return { value };
+    },
+    template: `
+      <VtSelect v-model="value" disabled placeholder="Language">
+        <el-option value="ja" label="日本語" />
+        <el-option value="en" label="English" />
+      </VtSelect>
+    `,
+  }),
+};

--- a/frontend/src/components/VtSelect.vue
+++ b/frontend/src/components/VtSelect.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+</script>
+
+<template>
+  <el-select v-bind="$attrs">
+    <slot />
+  </el-select>
+</template>

--- a/frontend/src/components/VtSelect.vue
+++ b/frontend/src/components/VtSelect.vue
@@ -6,6 +6,8 @@ defineOptions({
 
 <template>
   <el-select v-bind="$attrs">
-    <slot />
+    <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
+      <slot :name="slotName" v-bind="slotProps || {}" />
+    </template>
   </el-select>
 </template>

--- a/frontend/src/components/VtSelect.vue
+++ b/frontend/src/components/VtSelect.vue
@@ -7,7 +7,7 @@ defineOptions({
 <template>
   <el-select v-bind="$attrs">
     <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
-      <slot :name="slotName" v-bind="slotProps || {}" />
+      <slot :name="slotName" v-bind="slotProps ?? {}" />
     </template>
   </el-select>
 </template>

--- a/frontend/src/components/VtSwitch.stories.ts
+++ b/frontend/src/components/VtSwitch.stories.ts
@@ -10,6 +10,7 @@ const meta = {
   title: "Components/VtSwitch",
   component: VtSwitch,
   tags: ["autodocs"],
+  parameters: catalogParameters,
 } satisfies Meta<typeof VtSwitch>;
 
 export default meta;
@@ -22,43 +23,40 @@ export const On: Story = {
       const enabled = ref(true);
       return { enabled };
     },
-    template: `<VtSwitch v-model="enabled" />`,
+    template: `<VtSwitch v-model="enabled" aria-label="Enable feature" />`,
   }),
 };
 
 export const Off: Story = {
-  parameters: catalogParameters,
   render: () => ({
     components: { VtSwitch },
     setup() {
       const enabled = ref(false);
       return { enabled };
     },
-    template: `<VtSwitch v-model="enabled" />`,
+    template: `<VtSwitch v-model="enabled" aria-label="Enable feature" />`,
   }),
 };
 
 export const Disabled: Story = {
-  parameters: catalogParameters,
   render: () => ({
     components: { VtSwitch },
     setup() {
       const enabled = ref(true);
       return { enabled };
     },
-    template: `<VtSwitch v-model="enabled" disabled />`,
+    template: `<VtSwitch v-model="enabled" disabled aria-label="Enable feature" />`,
   }),
 };
 
 export const Small: Story = {
   name: "Small (list enable toggle)",
-  parameters: catalogParameters,
   render: () => ({
     components: { VtSwitch },
     setup() {
       const enabled = ref(true);
       return { enabled };
     },
-    template: `<VtSwitch v-model="enabled" size="small" />`,
+    template: `<VtSwitch v-model="enabled" size="small" aria-label="Enable list item" />`,
   }),
 };

--- a/frontend/src/components/VtSwitch.stories.ts
+++ b/frontend/src/components/VtSwitch.stories.ts
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ref } from "vue";
+import VtSwitch from "./VtSwitch.vue";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Components/VtSwitch",
+  component: VtSwitch,
+  tags: ["autodocs"],
+} satisfies Meta<typeof VtSwitch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const On: Story = {
+  render: () => ({
+    components: { VtSwitch },
+    setup() {
+      const enabled = ref(true);
+      return { enabled };
+    },
+    template: `<VtSwitch v-model="enabled" />`,
+  }),
+};
+
+export const Off: Story = {
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtSwitch },
+    setup() {
+      const enabled = ref(false);
+      return { enabled };
+    },
+    template: `<VtSwitch v-model="enabled" />`,
+  }),
+};
+
+export const Disabled: Story = {
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtSwitch },
+    setup() {
+      const enabled = ref(true);
+      return { enabled };
+    },
+    template: `<VtSwitch v-model="enabled" disabled />`,
+  }),
+};
+
+export const Small: Story = {
+  name: "Small (list enable toggle)",
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtSwitch },
+    setup() {
+      const enabled = ref(true);
+      return { enabled };
+    },
+    template: `<VtSwitch v-model="enabled" size="small" />`,
+  }),
+};

--- a/frontend/src/components/VtSwitch.vue
+++ b/frontend/src/components/VtSwitch.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+</script>
+
+<template>
+  <el-switch v-bind="$attrs">
+    <slot />
+  </el-switch>
+</template>

--- a/frontend/src/components/VtSwitch.vue
+++ b/frontend/src/components/VtSwitch.vue
@@ -7,7 +7,7 @@ defineOptions({
 <template>
   <el-switch v-bind="$attrs">
     <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
-      <slot :name="slotName" v-bind="slotProps || {}" />
+      <slot :name="slotName" v-bind="slotProps ?? {}" />
     </template>
   </el-switch>
 </template>

--- a/frontend/src/components/VtSwitch.vue
+++ b/frontend/src/components/VtSwitch.vue
@@ -5,7 +5,5 @@ defineOptions({
 </script>
 
 <template>
-  <el-switch v-bind="$attrs">
-    <slot />
-  </el-switch>
+  <el-switch v-bind="$attrs" />
 </template>

--- a/frontend/src/components/VtSwitch.vue
+++ b/frontend/src/components/VtSwitch.vue
@@ -5,5 +5,9 @@ defineOptions({
 </script>
 
 <template>
-  <el-switch v-bind="$attrs" />
+  <el-switch v-bind="$attrs">
+    <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
+      <slot :name="slotName" v-bind="slotProps || {}" />
+    </template>
+  </el-switch>
 </template>

--- a/frontend/src/components/__tests__/VtCheckbox.spec.ts
+++ b/frontend/src/components/__tests__/VtCheckbox.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import VtCheckbox from "../VtCheckbox.vue";
+
+describe("VtCheckbox", () => {
+  it("renders el-checkbox", () => {
+    const wrapper = mount(VtCheckbox, {
+      slots: { default: "Desktop mode" },
+    });
+    expect(wrapper.find(".el-checkbox").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Desktop mode");
+  });
+
+  it("forwards disabled and data-testid", () => {
+    const wrapper = mount(VtCheckbox, {
+      attrs: {
+        disabled: true,
+        "data-testid": "opt-desktop",
+      },
+      slots: { default: "Option" },
+    });
+    const checkbox = wrapper.find(".el-checkbox");
+    expect(checkbox.attributes("data-testid")).toBe("opt-desktop");
+    expect(checkbox.classes()).toContain("is-disabled");
+  });
+});

--- a/frontend/src/components/__tests__/VtInput.spec.ts
+++ b/frontend/src/components/__tests__/VtInput.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import VtInput from "../VtInput.vue";
+
+describe("VtInput", () => {
+  it("renders el-input", () => {
+    const wrapper = mount(VtInput, {
+      attrs: { placeholder: "Name" },
+    });
+    expect(wrapper.find(".el-input").exists()).toBe(true);
+    expect(wrapper.find("input").attributes("placeholder")).toBe("Name");
+  });
+
+  it("forwards disabled and data-testid", () => {
+    const wrapper = mount(VtInput, {
+      attrs: {
+        disabled: true,
+        "data-testid": "profile-name",
+      },
+    });
+    const input = wrapper.find("input");
+    expect(input.attributes("data-testid")).toBe("profile-name");
+    expect(input.attributes("disabled")).toBeDefined();
+  });
+
+  it("forwards prefix slot", () => {
+    const wrapper = mount(VtInput, {
+      slots: {
+        prefix: '<span class="prefix-icon">*</span>',
+      },
+    });
+    expect(wrapper.find(".prefix-icon").exists()).toBe(true);
+  });
+});

--- a/frontend/src/components/__tests__/VtInput.spec.ts
+++ b/frontend/src/components/__tests__/VtInput.spec.ts
@@ -23,6 +23,15 @@ describe("VtInput", () => {
     expect(input.attributes("disabled")).toBeDefined();
   });
 
+  it("forwards modelValue to the inner input", () => {
+    const wrapper = mount(VtInput, {
+      attrs: { modelValue: "hello" },
+    });
+    expect((wrapper.find("input").element as HTMLInputElement).value).toBe(
+      "hello",
+    );
+  });
+
   it("forwards prefix slot", () => {
     const wrapper = mount(VtInput, {
       slots: {

--- a/frontend/src/components/__tests__/VtSelect.spec.ts
+++ b/frontend/src/components/__tests__/VtSelect.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import VtSelect from "../VtSelect.vue";
+
+describe("VtSelect", () => {
+  it("renders el-select", () => {
+    const wrapper = mount(VtSelect, {
+      slots: {
+        default: '<el-option label="A" value="a" />',
+      },
+    });
+    expect(wrapper.find(".el-select").exists()).toBe(true);
+  });
+
+  it("forwards disabled and data-testid", () => {
+    const wrapper = mount(VtSelect, {
+      attrs: {
+        disabled: true,
+        "data-testid": "language-select",
+      },
+      slots: {
+        default: '<el-option label="JA" value="ja" />',
+      },
+    });
+    const select = wrapper.find(".el-select");
+    expect(select.attributes("data-testid")).toBe("language-select");
+    expect(wrapper.find(".is-disabled").exists()).toBe(true);
+  });
+});

--- a/frontend/src/components/__tests__/VtSwitch.spec.ts
+++ b/frontend/src/components/__tests__/VtSwitch.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import VtSwitch from "../VtSwitch.vue";
+
+describe("VtSwitch", () => {
+  it("renders el-switch", () => {
+    const wrapper = mount(VtSwitch, {
+      attrs: { modelValue: true },
+    });
+    expect(wrapper.find(".el-switch").exists()).toBe(true);
+    expect(wrapper.find(".is-checked").exists()).toBe(true);
+  });
+
+  it("forwards disabled and data-testid", () => {
+    const wrapper = mount(VtSwitch, {
+      attrs: {
+        disabled: true,
+        "data-testid": "item-enabled",
+      },
+    });
+    const sw = wrapper.find(".el-switch");
+    expect(sw.attributes("data-testid")).toBe("item-enabled");
+    expect(sw.classes()).toContain("is-disabled");
+  });
+
+  it("forwards size small", () => {
+    const wrapper = mount(VtSwitch, {
+      attrs: { size: "small" },
+    });
+    expect(wrapper.find(".el-switch--small").exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduce **VtInput**, **VtSelect**, **VtCheckbox**, and **VtSwitch** as thin Element Plus wrappers with attrs/slot passthrough (VtButton adoption model).
- Document form layout patterns (top-label `el-form`, Setting row, Path input row), checkbox vs switch semantics, error display layers, and size/disabled rules in ADR 0021 and `CONTEXT.md`.
- Add Storybook catalogs per control plus `FormLayoutPatterns` for layout examples; add `.cursor/rules/form-design-system.mdc` and update path-input / element-plus rules.

## Scope

v1 delivers wrappers, tests, Storybook, and docs only. No bulk migration of existing `el-input` / `el-select` usage in views (adoption on touch).

## Test plan

- [x] `cd frontend && pnpm run test` (529 tests)
- [x] `cd frontend && pnpm run build-storybook`
- [ ] Storybook: `Components/VtInput`, `VtSelect`, `VtCheckbox`, `VtSwitch`, `Design/Form layout patterns`
- [ ] Confirm no visual change intent (existing EP color mapping retained)


Made with [Cursor](https://cursor.com)