### PR TITLE
feat(frontend): Feedback & badges design system (ADR 0022)

### DIFF
--- a/.cursor/rules/feedback-design-system.mdc
+++ b/.cursor/rules/feedback-design-system.mdc
@@ -1,0 +1,72 @@
+---
+description: Feedback & badges デザインシステム（ADR 0022）。Section alert / Toast / Status badge / Loading のチャネル選択
+globs: "frontend/**/*.{vue,ts}"
+alwaysApply: false
+---
+
+# Feedback & badges design system
+
+正本: [ADR 0022](../docs/adr/0022-feedback-badges-design-system.md)、用語: [`CONTEXT.md`](../CONTEXT.md) Design system 節。
+
+## 使うもの
+
+| チャネル | いつ | 実装 |
+|----------|------|------|
+| **Section alert** | 解消まで残す・ブロック内状態・fetch 失敗・常時警告 | **`VtAlert`** |
+| **Toast** | ユーザー操作直後の成否 | **`showToast`**（`frontend/src/utils/showToast.ts`） |
+| **Status badge** | Semantic / Neutral / default ラベル | **`VtTag`** |
+| **Action loading** | 押したボタンの待ち | **VtButton** `:loading`（[ADR 0017](../docs/adr/0017-button-design-system-vtbutton.md)） |
+| **Section loading** | ブロック取得中 | 中立テキスト 1 行（`common.loading` 等） |
+
+## VtAlert
+
+- **`variant` は必須**: `success` | `warning` | `danger` | `info`
+- 既定: `show-icon`、`:closable="false"`
+- `title` / `description` / `data-testid` は透過
+- fetch failure・即時トグル失敗・常時 warning に使う。**Toast にしない**
+
+## showToast
+
+- `showToast.success` / `.warning` / `.error` / `.info`
+- 引数は **i18n 済み string のみ**（生バックエンドエラーは `formatError` してから渡す）
+- `ElMessage.*` 直叩きは adoption で **showToast** へ
+
+## VtTag
+
+- **`variant` は必須**: `success` | `warning` | `danger` | `info` | `neutral` | `primary`
+- `primary` は **Launch profile default label** のみ
+- **Domain badge**（VrcStatusTag / VrcUserTagChip）は VtTag にしない
+- サイズ: 一覧・ログは `size="small"` 明示可。`large` は増やさない
+
+## Form ADR との結線
+
+| Form 用語 | チャネル |
+|-----------|----------|
+| Form field validation error | `el-form-item` |
+| Form save failure feedback | **showToast.error** |
+| Immediate toggle failure feedback | **VtAlert** |
+| Form fetch failure | **VtAlert** 型（Toast 禁止） |
+
+## Loading
+
+- 操作待ち: **Button loading state** のみ（画面全体ロックしない）
+- ブロック取得: Section loading テキスト。loading 中 Toast なし。loadError と排他
+
+## v1 で使わない
+
+- `ElNotification`、OS 通知、`v-loading`、スケルトン、VtToast
+
+## 移行
+
+- 新規・改修で触ったファイルは VtAlert / VtTag / showToast へ。一括置換・ESLint 禁止は v1 では入れない
+
+## Storybook
+
+- `VtAlert.stories.ts` / `VtTag.stories.ts` が見た目の正本
+
+## 関連
+
+- 色: `.cursor/rules/color-design-system.mdc`
+- フォームエラー: `.cursor/rules/form-design-system.mdc`
+- Element Plus: `.cursor/rules/element-plus-ui.mdc`
+- Storybook: `.cursor/rules/storybook-wails-ui.mdc`

--- a/.cursor/rules/form-design-system.mdc
+++ b/.cursor/rules/form-design-system.mdc
@@ -51,8 +51,9 @@ alwaysApply: false
 | 層 | 示し方 |
 |----|--------|
 | フィールド検証 | `el-form-item` 直下、i18n 固定文 |
-| 一括保存失敗 | `ElMessage.error` |
-| 即時トグル失敗 | ブロック内 `el-alert`（Cookie linkage 型） |
+| 一括保存失敗 | **showToast.error**（[Feedback ADR](../docs/adr/0022-feedback-badges-design-system.md)） |
+| 即時トグル失敗 | **VtAlert**（ブロック内。Cookie linkage 型） |
+| フォーム取得失敗 | **VtAlert** 型またはカード内文言（Toast 禁止） |
 
 ## 移行
 
@@ -67,6 +68,7 @@ alwaysApply: false
 
 ## 関連
 
+- フィードバック: `.cursor/rules/feedback-design-system.mdc`
 - ボタン: `.cursor/rules/button-design-system.mdc`
 - Element Plus: `.cursor/rules/element-plus-ui.mdc`
 - Storybook: `.cursor/rules/storybook-wails-ui.mdc`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -708,7 +708,7 @@ _Avoid_: 常時実行, バックグラウンドサービス（v1 で含意しな
 
 ## Design system
 
-ボタン様式・余白・色・タイポグラフィ・フォーム入力部品などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。**Form control** ラッパー（VtInput / VtSelect / VtCheckbox / VtSwitch）は grill-with-docs で合意済み（[ADR 0021](docs/adr/0021-form-control-design-system.md)）。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
+ボタン様式・余白・色・タイポグラフィ・フォーム入力部品などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。**Form control** ラッパー（VtInput / VtSelect / VtCheckbox / VtSwitch）は grill-with-docs で合意済み（[ADR 0021](docs/adr/0021-form-control-design-system.md)）。**Feedback & Badges**（Alert / Toast / Badge / Loading の横断チャネル）は grill-with-docs で合意済み（[ADR 0022](docs/adr/0022-feedback-badges-design-system.md)）。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
 
 ### Language
 
@@ -1052,11 +1052,11 @@ _Avoid_: Readonly 様式, Loading 入力（ボタン loading と混同しやす�
 _Avoid_: ElMessage（一括保存失敗と混同しやすいため）, バリデーション（サーバー応答のマッピングまで含意しうるため）
 
 **Form save failure feedback**:
-編集フォームの一括保存 API が失敗したときの示し方。既存どおり **`ElMessage.error`**（i18n + `formatBackendError` 等）。フィールド別に原因が分からない失敗を `el-form-item` へ割り当てない。
+編集フォームの一括保存 API が失敗したときの示し方。既存どおり **showToast.error**（i18n + `formatBackendError` 等）。フィールド別に原因が分からない失敗を `el-form-item` へ割り当てない。
 _Avoid_: フィールドエラー, セクション alert（即時反映失敗と混同しやすいため）
 
 **Immediate toggle failure feedback**:
-**Immediate setting toggle** または **List enable toggle** の API 失敗の示し方。**そのブロック内**の `el-alert` またはブロック直下のエラー行（Cookie linkage 型）。**i18n 分類済みの短い文**のみ。`ElMessage.error` だけに頼らない（一覧トグルと Setting row を同型にする）。失敗後はトグルを操作前の Effective 状態へ戻す（Cookie linkage draft 型）。
+**Immediate setting toggle** または **List enable toggle** の API 失敗の示し方。**そのブロック内**の **VtAlert** またはブロック直下のエラー行（Cookie linkage 型）。**i18n 分類済みの短い文**のみ。**showToast** だけに頼らない（一覧トグルと Setting row を同型にする）。失敗後はトグルを操作前の Effective 状態へ戻す（Cookie linkage draft 型）。
 _Avoid_: Form save failure feedback, 生のバックエンドエラー, Server status fetch failure（読み取り失敗と混同しやすいため）
 
 **Form fetch failure**:
@@ -1102,6 +1102,94 @@ _Avoid_: フォーム行（**Form layout** 全体と混同しやすいため）,
 **Form layout adoption**:
 Form layout / Setting row への揃え方針。新規・改修で複数項目編集は **Form layout**、カード内単発の横並び設定は **Setting row**。既存のばらつき（`setting-row` 内 `el-input-number` 等）は一括置換しない（触ったところから）。Spacing は **Spacing token** / **Spacing pattern** を使う。
 _Avoid_: 全面レイアウト統一, el-form 強制の CI（即時一括を含意するため）
+
+**Feedback & Badges**:
+アプリ横断のフィードバック表示ルール。**Feedback channel**（Alert / Toast / Badge / Loading）の使い分けと配置の正本。**Form control** ADR のエラー 3 層（フィールド検証・一括保存・即時トグル・取得失敗）はフィールド文脈の契約として残し、**どのチャネルを使うか**はここで結線する（上書き・再定義はしない）。色は **Semantic color catalog**（[ADR 0019](docs/adr/0019-color-design-system.md)）を参照する。
+_Avoid_: エラー表示（Form 専用の 3 層まで含む総称）, 通知（OS 通知や `ElNotification` を含意しうるため）
+
+**Feedback channel**:
+ユーザーへ状態・結果・注意を伝える表示経路の総称。v1 で扱う 4 種: **Section alert**（インライン `el-alert`）、**Toast**（`ElMessage`）、**Status badge**（`el-tag` 等のラベル）、**Loading feedback**（**Button loading state** 以外の待機表示を含む）。チャネル選択の正本は **Feedback & Badges** ADR（予定）。
+_Avoid_: フィードバック（Form バリデーションだけを指す印象）, ElNotification（v1 では未採用の別 API）
+
+**Section alert**:
+**Feedback channel** のひとつ。画面上の特定**セクション・カード・ブロック内**に置くインラインアラート（v1 実装は **VtAlert**、内部 `el-alert`）。**条件が解消するまで**（または画面を離れるまで）残す状態・注意・ブロック内操作失敗を示す。`show-icon`・`:closable="false"` を既定とする（v1）。**Fetch failure**（Presence / Launch block / Gallery loadError / Video playback history 等）、**Immediate toggle failure feedback**、常時リスク警告（Cookie BAN 文、Launcher 未保存バナー）に使う。バックグラウンド refresh 失敗も、対象ブロックの状態としてここに示す（Toast にしない）。
+_Avoid_: Toast, トースト, ElMessage（一時通知と混同しやすいため）, モーダル（`ElMessageBox` と混同しやすいため）
+
+**VtAlert**:
+**Section alert** の標準ラッパー。内部は `el-alert`。`variant`: `success` | `warning` | `danger` | `info`（**必須**。暗黙既定なし）。**Semantic color catalog** と 1 対 1。既定で `show-icon`・`:closable="false"`。`title`・`description`・`data-testid` 等は透過。**VtAlert adoption**（触ったところから `el-alert` 直書きを置換）。
+_Avoid_: el-alert（移行完了後の直呼び）, Toast
+
+**VtAlert adoption**:
+VtAlert への移行方針。新規・改修で **Section alert** には **VtAlert** を使う。未着手の `el-alert` 直書きは一括置換しない。ESLint 強制は v1 では入れない。見た目の正本は **VtAlert Storybook catalog**。
+_Avoid_: 全面置換, el-alert 禁止の CI 強制
+
+**VtAlert Storybook catalog**:
+VtAlert の Storybook 一覧。4 `variant` それぞれ（通常・長文 `description` あり）と、常時 warning / ブロック内 error の使用例を載せる（**VtTag Storybook catalog** と同型）。
+_Avoid_: 全画面 Storybook, Section alert（配置ルールまで含む総称）
+
+**Toast**:
+**Feedback channel** のひとつ。**showToast** 経由の画面端一時通知（内部は `ElMessage`）。**ユーザーが明示操作した直後**の結果フィードバック（保存・起動・反映・削除の成否、件数付き成功メッセージ等）。数秒で自動消滅し、消えても画面の主要 UI は読める。**Fetch failure** やブロック読み取り失敗には使わない（**Section alert** またはカード内文言）。`success` / `error` / `warning` / `info` は **Semantic color catalog** と 1 対 1。
+_Avoid_: Section alert, 通知バナー（常時表示を含意するため）, ElNotification（v1 未採用 API）, ElMessage 直叩き（新規・改修の正本は **showToast**）
+
+**showToast**:
+**Toast** の薄いユーティリティ（`frontend/src/utils/showToast.ts` 等）。`showToast.success(message)` / `.error` / `.warning` / `.info` で `ElMessage` に委譲。引数は **i18n 済み string のみ**（生 `Error`・バックエンド生文字列は渡さない）。例外は呼び出し側で `formatError` / `formatBackendError` してから渡す。表示時間・`grouping` 等の既定はここに集約。**showToast adoption**（触ったところから `ElMessage.*` 直叩きを置換）。DOM ラッパー（VtToast）は v1 では作らない。
+_Avoid_: VtToast, errorFromUnknown（例外吸収の魔法 API。v1 では呼び出し側で format して明示）, ElMessage（実装 API 名だけの直呼び正本）
+
+**showToast adoption**:
+showToast への移行方針。新規・改修で **Toast** には **showToast** を使う。未着手の `ElMessage.*` 直叩きは一括置換しない。ESLint 強制は v1 では入れない。
+_Avoid_: 全面置換, ElMessage 禁止の CI 強制
+
+**Feedback channel selection**:
+Alert と Toast の切り分け正本。**主軸は持続性**（解消まで残す → Section alert、操作直後 → Toast）。**補足は文脈の近さ**（特定ブロックの状態 → Section alert、画面横断の操作結果 → Toast）。**Form save failure feedback** は Toast（**showToast.error**）。**Form fetch failure** は Section alert 型（Toast 禁止）。**Immediate toggle failure feedback** は Section alert 型。
+_Avoid_: 重要度だけで機械分岐（success は常に Toast 等。常時 warning は Section alert のため）
+
+**Status badge**:
+**Feedback channel** のひとつ。短いラベルで状態・結果・属性を示すチップ UI（主に `el-tag`）。v1 では **Semantic status badge**・**Neutral badge**・**Domain badge** の 3 分類。**VtTag** が Semantic / Neutral の標準ラッパー。**Domain badge** は専用コンポーネントのまま **VtTag adoption** 対象外。
+_Avoid_: User tag chip（**Domain badge** の VrcUserTagChip と混同しやすいため）, バッジ（通知バッジの OS/UI 俗称）
+
+**Semantic status badge**:
+操作結果・有効状態・ログイン済みなど、**良し悪し・注意度**を **Semantic color catalog**（success / warning / danger / info）で示す **Status badge**。Automation 実行ログの成否、Settings のログイン済み表示など。**VtTag** の `variant`（または EP `type`）で 4 色と 1 対 1。**Domain badge** や **Neutral badge** に Semantic 色を流用しない。
+_Avoid_: primary ラベル（Brand 寄り属性と混同しやすいため）, プレゼンス色（**Domain badge**）
+
+**Neutral badge**:
+意味論色を持たない **Status badge**。件数・カテゴリ・技術メタのラベル（Licenses 件数、Automation の kind 表示など）。**VtTag** の `variant="neutral"`（`type` 省略・EP 既定の中立灰）。**Launch profile default label** は例外（下記）。
+_Avoid_: Semantic status badge, info（補足通知色と混同しやすいため）
+
+**Launch profile default label**:
+Launcher サイドバー一覧で **Default launch profile** を示す **Status badge**。**Semantic status badge** ではない。**Neutral badge** でもなく、**Brand color** 寄りの `primary`（**VtTag** `variant="primary"` または EP `type="primary"`）を**この 1 用途だけ**許可する。成功・ログイン済み等の Semantic 表示と混同しない。
+_Avoid_: 既定タグ（Neutral への統一を含意するため）, success バッジ（状態の良し悪しと混同しやすいため）
+
+**Domain badge**:
+特定ドメインだけが持つ意味付きチップ。**Semantic color catalog** を横断フィードバックとして流用しない（**VtButton** の **Semantic button** と同型の例外）。v1: **VrcStatusTag**（プレゼンス文字列）、**VrcUserTagChip**（User tag）。専用 Storybook・色ルールは各ドメイン／**Domain color** ADR 側。**VtTag** には寄せない。
+_Avoid_: Semantic status badge, Status badge（3 分類全体と混同しやすいため）
+
+**VtTag**:
+**Semantic status badge**・**Neutral badge**・**Launch profile default label** の標準ラッパー。内部は `el-tag`。`variant`: `success` | `warning` | `danger` | `info` | `neutral` | `primary`（**必須**。暗黙既定なし）。`primary` は **Launch profile default label** のみ（**Brand color mapping**）。`size`・`data-testid` 等は透過。**VtTag adoption**（触ったところから `el-tag` 直書きを置換）。**Domain badge** は対象外。
+_Avoid_: el-tag（移行完了後の直呼び）, VrcStatusTag（**Domain badge**）
+
+**VtTag adoption**:
+VtTag への移行方針。新規・改修で Semantic / Neutral の **Status badge** には **VtTag** を使う。**Domain badge** は専用 UI のまま。未着手の `el-tag` 直書きは一括置換しない。ESLint 強制は v1 では入れない。見た目の正本は **VtTag Storybook catalog**。
+_Avoid_: 全面置換, Domain badge の VtTag 化
+
+**Loading feedback**:
+**Feedback channel** のひとつ。非同期処理の待機を示す表示。v1 は **Action loading** と **Section loading** の 2 層のみ。**Button loading state**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）を操作待ちの正本とする。`v-loading` オーバーレイ・スケルトン・画面全体ロック・進捗％は v1 スコープ外。
+_Avoid_: Button loading state（第 2 の様式名。操作ボタン待ちは ADR 0017 を正本とする）, スピナー（実装部品の総称）
+
+**Action loading**:
+ユーザーが押した**操作ボタン**に付ける待機表示。**Button loading state** と同義。VtButton / `el-button` の `:loading`。Action group 内の他ボタンまで一括無効化は原則しない。取得中は関連入力を `disabled` してよい（Gallery の `loading || scanning` と同型）。
+_Avoid_: Section loading, 画面ロック
+
+**Section loading**:
+ブロック・カード・一覧の**初回または再取得中**に、その領域内でコンテンツの代わりに示す待機表示。中立テキスト 1 行（`common.loading` またはブロック専用 i18n、**Neutral text**）。Presence change・Activity・Video 履歴が代表例。loading 中は **Toast** を出さない。**Section alert**（loadError）と排他（loading → error → content）。一覧が空でも loading 中は empty メッセージを出さない。
+_Avoid_: v-loading, スケルトン, Toast, Action loading（押下ボタンだけの待ち）
+
+**Feedback & Badges v1 scope**:
+Feedback & Badges 策定の最初の届け範囲。**VtAlert**・**VtTag**・**showToast**、各 Storybook catalog（Alert / Tag）、単体テスト、`.cursor/rules/feedback-design-system.mdc`、ADR 0022、`CONTEXT.md`、**Feedback channel selection** 参照表（Form ADR 3 層との結線）に限定する。含めないもの: `ElNotification`・OS 通知、`v-loading`・スケルトン・進捗％、VtToast、全 View 一括置換、ESLint 強制、Dashboard refresh 警告や Automation トグル失敗の v1 強制移行、**Domain badge** の変更。
+_Avoid_: Feedback & Badges（v1 範囲を指すときは scope とセットで書く）, 将来拡張（スコープ外リストの総称として曖昧なため）
+
+**Feedback & Badges v1 deliverables**:
+Issue／PR で最初に届ける具体物。(1) **VtAlert** + テスト + **VtAlert Storybook catalog**、(2) **VtTag**（semantic 4 + neutral + primary）+ テスト + **VtTag Storybook catalog**、(3) **showToast** + テスト、(4) `.cursor/rules/feedback-design-system.mdc`、(5) `docs/adr/0022-feedback-badges-design-system.md`、(6) `CONTEXT.md` 同期。移行は **VtAlert adoption** / **VtTag adoption** / **showToast adoption** のみ（触ったところから）。
+_Avoid_: Feedback & Badges v1 scope（届け物リストを指すときは deliverables とセットで書く）, 全画面置換（adoption と矛盾するため）
 
 ## Agent contribution
 

--- a/docs/adr/0022-feedback-badges-design-system.md
+++ b/docs/adr/0022-feedback-badges-design-system.md
@@ -1,0 +1,116 @@
+# ADR 0022: Feedback & badges design system (VtAlert / VtTag / showToast)
+
+## Status
+
+Accepted（grill-with-docs で合意）
+
+## Context
+
+- `el-alert` / `el-tag` / `ElMessage` の直書きが画面ごとに散在し、**Section alert**（持続）と **Toast**（操作直後）の使い分けがばらつく
+- **Color** ADR（[0019](0019-color-design-system.md)）で **Semantic color catalog** は定義済みだが、フィードバックチャネルの配置ルールとラッパーは未定義
+- **Form control** ADR（[0021](0021-form-control-design-system.md)）はフィールド文脈のエラー 3 層を持つが、Alert / Toast / Badge / Loading の横断正本は別に必要
+- `ElNotification` は未使用。`v-loading` / スケルトンも未使用
+- **Button loading state**（[ADR 0017](0017-button-design-system-vtbutton.md)）は操作待ちの正本として既にある
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Design system** 節（**Feedback & Badges**、**Section alert**、**Toast**、**Status badge**、**Loading feedback** 等）を正本とする。
+
+## Decision
+
+### 1. 責務
+
+- **Feedback & Badges** = 横断 **Feedback channel** の正本（Alert / Toast / Badge / Loading）
+- Form ADR のエラー 3 層は維持し、チャネル選択だけ本 ADR で結線する
+
+### 2. チャネル選択（Feedback channel selection）
+
+| 状況 | チャネル |
+|------|----------|
+| 解消まで残す状態・常時警告・ブロック内失敗・fetch failure | **Section alert**（**VtAlert**） |
+| ユーザー明示操作の直後（保存・起動・反映の成否） | **Toast**（**showToast**） |
+| 短い状態・結果・属性ラベル | **Status badge**（**VtTag**；**Domain badge** は例外） |
+| 操作ボタン待ち | **Button loading state**（ADR 0017） |
+| ブロック初回取得待ち | **Section loading**（中立テキスト 1 行） |
+
+**主軸**: 持続性（残す → alert、操作直後 → toast）。**補足**: 文脈の近さ（ブロック内 → alert）。
+
+#### Form ADR との結線
+
+| Form 用語 | チャネル |
+|-----------|----------|
+| Form field validation error | `el-form-item`（Feedback 外） |
+| Form save failure feedback | **Toast**（`showToast.error`） |
+| Immediate toggle failure feedback | **Section alert**（**VtAlert**） |
+| Form fetch failure | **Section alert** 型（Toast 禁止） |
+
+### 3. VtAlert
+
+- 新規: `frontend/src/components/VtAlert.vue`
+- **`variant` は必須**: `success` | `warning` | `danger` | `info`
+- `danger` → EP `type="error"`（**Semantic color catalog**）
+- 既定: `show-icon`、`:closable="false"`
+- `title` / `description` / `data-testid` 等は透過
+- **VtAlert adoption**（触ったところから `el-alert` 直書きを置換）
+
+### 4. VtTag
+
+- 新規: `frontend/src/components/VtTag.vue`
+- **`variant` は必須**: `success` | `warning` | `danger` | `info` | `neutral` | `primary`
+- `primary` は **Launch profile default label** のみ（Brand mapping）
+- **Domain badge**（VrcStatusTag / VrcUserTagChip）は対象外
+- **VtTag adoption**（触ったところから `el-tag` 直書きを置換）
+
+### 5. showToast
+
+- 新規: `frontend/src/utils/showToast.ts`
+- `showToast.success` / `.warning` / `.error` / `.info` — 引数は **i18n 済み string のみ**
+- 内部は `ElMessage` に委譲。例外は呼び出し側で `formatError` 等してから渡す
+- **VtToast**（DOM ラッパー）は v1 では作らない
+- **showToast adoption**（触ったところから `ElMessage.*` 直叩きを置換）
+
+### 6. Loading feedback（v1）
+
+- **Action loading**: ADR 0017 を正本（変更なし）
+- **Section loading**: ブロック内中立テキスト（`common.loading` 等）。`v-loading` / スケルトンは v1 外
+
+### 7. Storybook
+
+- `VtAlert.stories.ts` — 4 variant + description + ブロック error / 常時 warning 例
+- `VtTag.stories.ts` — 6 variant + semantic 行 + default label 例
+
+### 8. Agent / 実装ルール
+
+- `.cursor/rules/feedback-design-system.mdc` 新設
+- ESLint による `el-alert` / `el-tag` / `ElMessage` 禁止は v1 では入れない
+
+## Considered options
+
+| 案 | 却下理由 |
+|----|----------|
+| Form ADR に統合 | フォーム外の Gallery / Dashboard / Cookie 警告が Form 文脈に収まらない |
+| `ElNotification` 採用 | 未使用。Toast と役割が重複 |
+| `v-loading` 標準化 | 現行 UI に無く、YAGNI |
+| VtToast コンポーネント | Toast はグローバル API。薄い util で十分 |
+| showToast + errorFromUnknown | 魔法 API。呼び出し側で format して明示する方がレビューしやすい |
+| v1 で全面置換 | Button / Form と同型の adoption で十分 |
+
+## v1 scope
+
+**含む:**
+
+- VtAlert / VtTag / showToast + 単体テスト
+- VtAlert / VtTag Storybook catalog
+- `.cursor/rules/feedback-design-system.mdc`
+- 本 ADR + `CONTEXT.md`
+
+**含まない:**
+
+- `ElNotification`、OS 通知、`v-loading`、スケルトン、進捗％
+- 全 View 一括置換、ESLint 強制
+- Dashboard refresh 警告・Automation トグル失敗の v1 強制移行
+- **Domain badge** の変更
+
+## Consequences
+
+- 新規・改修 PR では VtAlert / VtTag / showToast とチャネル選択表が期待される
+- Form ADR のエラー表は Toast / VtAlert へリンク更新する（実装は触ったファイルから）
+- 既存 `el-alert` / `el-tag` / `ElMessage` は adoption まで併存可

--- a/frontend/src/components/VtAlert.stories.css
+++ b/frontend/src/components/VtAlert.stories.css
@@ -1,0 +1,6 @@
+.vt-alert-story-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-block, 16px);
+  max-width: 40rem;
+}

--- a/frontend/src/components/VtAlert.stories.ts
+++ b/frontend/src/components/VtAlert.stories.ts
@@ -27,11 +27,11 @@ type Story = StoryObj<typeof meta>;
 
 function variantStory(alertTitle: string, args: VtAlertProps): Story {
   return {
-    args,
+    args: { ...args, title: alertTitle },
     render: (storyArgs) => ({
       components: { VtAlert },
-      setup: () => ({ args: storyArgs, alertTitle }),
-      template: `<VtAlert v-bind="args" :title="alertTitle" />`,
+      setup: () => ({ args: storyArgs }),
+      template: `<VtAlert v-bind="args" />`,
     }),
   };
 }
@@ -50,15 +50,16 @@ export const Info = variantStory("Official build required for cookies", {
 });
 
 export const WithDescription: Story = {
-  render: () => ({
+  args: {
+    variant: "warning",
+    title: "Account risk",
+    description:
+      "Using cookies with a main account may risk a ban. Prefer a throwaway account.",
+  },
+  render: (storyArgs) => ({
     components: { VtAlert },
-    template: `
-      <VtAlert
-        variant="warning"
-        title="Account risk"
-        description="Using cookies with a main account may risk a ban. Prefer a throwaway account."
-      />
-    `,
+    setup: () => ({ args: storyArgs }),
+    template: `<VtAlert v-bind="args" />`,
   }),
 };
 
@@ -69,7 +70,7 @@ export const BlockErrorExample: Story = {
     components: { VtAlert },
     template: `
       <div class="vt-alert-story-stack">
-        <VtAlert variant="danger" title="Could not load gallery" data-testid="gallery-load-error" />
+        <VtAlert variant="danger" title="Could not load gallery" />
       </div>
     `,
   }),

--- a/frontend/src/components/VtAlert.stories.ts
+++ b/frontend/src/components/VtAlert.stories.ts
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import VtAlert from "./VtAlert.vue";
+import { VT_ALERT_VARIANTS, type VtAlertProps } from "./vtAlertVariants";
+import "./VtAlert.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Components/VtAlert",
+  component: VtAlert,
+  tags: ["autodocs"],
+  args: {
+    variant: "info",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [...VT_ALERT_VARIANTS],
+    },
+  },
+} satisfies Meta<typeof VtAlert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function variantStory(alertTitle: string, args: VtAlertProps): Story {
+  return {
+    args,
+    render: (storyArgs) => ({
+      components: { VtAlert },
+      setup: () => ({ args: storyArgs, alertTitle }),
+      template: `<VtAlert v-bind="args" :title="alertTitle" />`,
+    }),
+  };
+}
+
+export const Success = variantStory("Operation completed", {
+  variant: "success",
+});
+export const Warning = variantStory("Review before continuing", {
+  variant: "warning",
+});
+export const Danger = variantStory("Could not load data", {
+  variant: "danger",
+});
+export const Info = variantStory("Official build required for cookies", {
+  variant: "info",
+});
+
+export const WithDescription: Story = {
+  render: () => ({
+    components: { VtAlert },
+    template: `
+      <VtAlert
+        variant="warning"
+        title="Account risk"
+        description="Using cookies with a main account may risk a ban. Prefer a throwaway account."
+      />
+    `,
+  }),
+};
+
+export const BlockErrorExample: Story = {
+  name: "Example: block fetch failure",
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtAlert },
+    template: `
+      <div class="vt-alert-story-stack">
+        <VtAlert variant="danger" title="Could not load gallery" data-testid="gallery-load-error" />
+      </div>
+    `,
+  }),
+};
+
+export const PersistentWarningExample: Story = {
+  name: "Example: persistent section warning",
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtAlert },
+    template: `
+      <div class="vt-alert-story-stack">
+        <VtAlert variant="warning" title="Replacing the bundled yt-dlp is not officially supported." />
+      </div>
+    `,
+  }),
+};

--- a/frontend/src/components/VtAlert.vue
+++ b/frontend/src/components/VtAlert.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
-import { computed, useAttrs } from "vue";
+import { computed, useAttrs, useSlots } from "vue";
 import { type VtAlertProps, vtAlertElementType } from "./vtAlertVariants";
 
 const props = defineProps<VtAlertProps>();
 const attrs = useAttrs();
+const slots = useSlots();
 
 defineOptions({
   inheritAttrs: false,
 });
 
 const alertType = computed(() => vtAlertElementType(props.variant));
+const hasDefaultSlot = computed(() => !!slots.default);
 </script>
 
 <template>
@@ -21,6 +23,8 @@ const alertType = computed(() => vtAlertElementType(props.variant));
     :closable="false"
     show-icon
   >
-    <slot />
+    <template v-if="hasDefaultSlot" #default>
+      <slot />
+    </template>
   </el-alert>
 </template>

--- a/frontend/src/components/VtAlert.vue
+++ b/frontend/src/components/VtAlert.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { type VtAlertProps, vtAlertElementType } from "./vtAlertVariants";
+
+const props = defineProps<VtAlertProps>();
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const alertType = computed(() => vtAlertElementType(props.variant));
+</script>
+
+<template>
+  <el-alert v-bind="$attrs" :type="alertType" :closable="false" show-icon />
+</template>

--- a/frontend/src/components/VtAlert.vue
+++ b/frontend/src/components/VtAlert.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, useAttrs } from "vue";
 import { type VtAlertProps, vtAlertElementType } from "./vtAlertVariants";
 
 const props = defineProps<VtAlertProps>();
+const attrs = useAttrs();
 
 defineOptions({
   inheritAttrs: false,
@@ -12,7 +13,14 @@ const alertType = computed(() => vtAlertElementType(props.variant));
 </script>
 
 <template>
-  <el-alert v-bind="$attrs" :type="alertType" :closable="false" show-icon>
+  <el-alert
+    v-bind="attrs"
+    :type="alertType"
+    :title="title"
+    :description="description"
+    :closable="false"
+    show-icon
+  >
     <slot />
   </el-alert>
 </template>

--- a/frontend/src/components/VtAlert.vue
+++ b/frontend/src/components/VtAlert.vue
@@ -12,5 +12,7 @@ const alertType = computed(() => vtAlertElementType(props.variant));
 </script>
 
 <template>
-  <el-alert v-bind="$attrs" :type="alertType" :closable="false" show-icon />
+  <el-alert v-bind="$attrs" :type="alertType" :closable="false" show-icon>
+    <slot />
+  </el-alert>
 </template>

--- a/frontend/src/components/VtTag.stories.css
+++ b/frontend/src/components/VtTag.stories.css
@@ -1,0 +1,6 @@
+.vt-tag-story-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-action-group, 8px);
+  align-items: center;
+}

--- a/frontend/src/components/VtTag.stories.css
+++ b/frontend/src/components/VtTag.stories.css
@@ -1,6 +1,6 @@
 .vt-tag-story-row {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-action-group, 8px);
+  gap: var(--space-action-group);
   align-items: center;
 }

--- a/frontend/src/components/VtTag.stories.ts
+++ b/frontend/src/components/VtTag.stories.ts
@@ -34,8 +34,8 @@ function variantStory(label: string, args: VtTagProps): Story {
     args,
     render: (storyArgs) => ({
       components: { VtTag },
-      setup: () => ({ args: storyArgs, label }),
-      template: `<VtTag v-bind="args">{{ label }}</VtTag>`,
+      setup: () => ({ storyArgs, label }),
+      template: `<VtTag v-bind="storyArgs">{{ label }}</VtTag>`,
     }),
   };
 }
@@ -44,7 +44,7 @@ export const Success = variantStory("Success", { variant: "success" });
 export const Warning = variantStory("Warning", { variant: "warning" });
 export const Danger = variantStory("Danger", { variant: "danger" });
 export const Info = variantStory("Info", { variant: "info" });
-export const Neutral = variantStory("3 licenses", { variant: "neutral" });
+export const Neutral = variantStory("Neutral", { variant: "neutral" });
 export const Primary = variantStory("Default", { variant: "primary" });
 
 export const SemanticRow: Story = {

--- a/frontend/src/components/VtTag.stories.ts
+++ b/frontend/src/components/VtTag.stories.ts
@@ -38,7 +38,7 @@ function variantStory(label: string, args: VtTagProps): Story {
 
 export const Success = variantStory("Success", { variant: "success" });
 export const Warning = variantStory("Warning", { variant: "warning" });
-export const Danger = variantStory("Failed", { variant: "danger" });
+export const Danger = variantStory("Danger", { variant: "danger" });
 export const Info = variantStory("Info", { variant: "info" });
 export const Neutral = variantStory("3 licenses", { variant: "neutral" });
 export const Primary = variantStory("Default", { variant: "primary" });

--- a/frontend/src/components/VtTag.stories.ts
+++ b/frontend/src/components/VtTag.stories.ts
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import VtTag from "./VtTag.vue";
+import { VT_TAG_VARIANTS, type VtTagProps } from "./vtTagVariants";
+import "./VtTag.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Components/VtTag",
+  component: VtTag,
+  tags: ["autodocs"],
+  args: {
+    variant: "neutral",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [...VT_TAG_VARIANTS],
+    },
+  },
+} satisfies Meta<typeof VtTag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function variantStory(label: string, args: VtTagProps): Story {
+  return {
+    args,
+    render: (storyArgs) => ({
+      components: { VtTag },
+      setup: () => ({ args: storyArgs }),
+      template: `<VtTag v-bind="args">${label}</VtTag>`,
+    }),
+  };
+}
+
+export const Success = variantStory("Success", { variant: "success" });
+export const Warning = variantStory("Warning", { variant: "warning" });
+export const Danger = variantStory("Failed", { variant: "danger" });
+export const Info = variantStory("Info", { variant: "info" });
+export const Neutral = variantStory("3 licenses", { variant: "neutral" });
+export const Primary = variantStory("Default", { variant: "primary" });
+
+export const SemanticRow: Story = {
+  name: "Semantic status badges",
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtTag },
+    template: `
+      <div class="vt-tag-story-row">
+        <VtTag variant="success" size="small">Logged in</VtTag>
+        <VtTag variant="danger" size="small">Failed</VtTag>
+        <VtTag variant="warning" size="small">Needs review</VtTag>
+        <VtTag variant="info" size="small">Rule</VtTag>
+      </div>
+    `,
+  }),
+};
+
+export const LaunchProfileDefaultLabel: Story = {
+  name: "Example: launch profile default label",
+  parameters: catalogParameters,
+  render: () => ({
+    components: { VtTag },
+    template: `
+      <VtTag variant="primary" size="small">Default</VtTag>
+    `,
+  }),
+};

--- a/frontend/src/components/VtTag.stories.ts
+++ b/frontend/src/components/VtTag.stories.ts
@@ -19,6 +19,10 @@ const meta = {
       control: "select",
       options: [...VT_TAG_VARIANTS],
     },
+    size: {
+      control: "select",
+      options: ["large", "default", "small"],
+    },
   },
 } satisfies Meta<typeof VtTag>;
 
@@ -30,8 +34,8 @@ function variantStory(label: string, args: VtTagProps): Story {
     args,
     render: (storyArgs) => ({
       components: { VtTag },
-      setup: () => ({ args: storyArgs }),
-      template: `<VtTag v-bind="args">${label}</VtTag>`,
+      setup: () => ({ args: storyArgs, label }),
+      template: `<VtTag v-bind="args">{{ label }}</VtTag>`,
     }),
   };
 }

--- a/frontend/src/components/VtTag.vue
+++ b/frontend/src/components/VtTag.vue
@@ -13,8 +13,9 @@ const tagType = computed(() => vtTagElementType(props.variant));
 
 const tagBind = computed(() => {
   if (props.variant === "neutral") {
+    const { type: _type, ...forwardedAttrs } = attrs;
     return {
-      ...attrs,
+      ...forwardedAttrs,
       class: ["vt-tag--neutral", attrs.class],
       effect: "plain" as const,
     };

--- a/frontend/src/components/VtTag.vue
+++ b/frontend/src/components/VtTag.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { computed, useAttrs } from "vue";
-import { type VtTagProps, vtTagElementType } from "./vtTagVariants";
+import {
+  type VtTagProps,
+  omitVtTagAttr,
+  vtTagElementType,
+} from "./vtTagVariants";
 
 const props = defineProps<VtTagProps>();
 const attrs = useAttrs();
@@ -12,23 +16,24 @@ defineOptions({
 const tagType = computed(() => vtTagElementType(props.variant));
 
 const tagBind = computed(() => {
+  const rawAttrs = attrs as Record<string, unknown>;
   if (props.variant === "neutral") {
-    const { type: _type, ...forwardedAttrs } = attrs;
+    const withoutType = omitVtTagAttr(rawAttrs, "type");
     return {
-      ...forwardedAttrs,
+      ...omitVtTagAttr(withoutType, "size"),
       class: ["vt-tag--neutral", attrs.class],
       effect: "plain" as const,
     };
   }
   return {
-    ...attrs,
+    ...omitVtTagAttr(rawAttrs, "size"),
     type: tagType.value,
   };
 });
 </script>
 
 <template>
-  <el-tag v-bind="tagBind">
+  <el-tag v-bind="tagBind" :size="size">
     <slot />
   </el-tag>
 </template>

--- a/frontend/src/components/VtTag.vue
+++ b/frontend/src/components/VtTag.vue
@@ -16,13 +16,16 @@ defineOptions({
 const tagType = computed(() => vtTagElementType(props.variant));
 
 const tagBind = computed(() => {
+  // `type` is owned by vtTagElementType; strip caller attrs to avoid el-tag conflicts.
   const forwarded = omitVtTagAttr(attrs as Record<string, unknown>, "type");
   if (tagType.value === undefined) {
     return {
       ...forwarded,
       type: "info" as const,
       effect: "plain" as const,
-      class: ["vt-tag--neutral", attrs.class],
+      class: attrs.class
+        ? ["vt-tag--neutral", attrs.class]
+        : ["vt-tag--neutral"],
     };
   }
   return {

--- a/frontend/src/components/VtTag.vue
+++ b/frontend/src/components/VtTag.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed, useAttrs } from "vue";
+import { type VtTagProps, vtTagElementType } from "./vtTagVariants";
+
+const props = defineProps<VtTagProps>();
+const attrs = useAttrs();
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const tagType = computed(() => vtTagElementType(props.variant));
+
+const tagBind = computed(() => {
+  if (props.variant === "neutral") {
+    return {
+      ...attrs,
+      class: ["vt-tag--neutral", attrs.class],
+      effect: "plain" as const,
+    };
+  }
+  return {
+    ...attrs,
+    type: tagType.value,
+  };
+});
+</script>
+
+<template>
+  <el-tag v-bind="tagBind">
+    <slot />
+  </el-tag>
+</template>
+
+<style scoped>
+.vt-tag--neutral {
+  --el-tag-bg-color: var(--color-bg-muted);
+  --el-tag-border-color: var(--color-border);
+  --el-tag-text-color: var(--color-text-secondary);
+}
+</style>

--- a/frontend/src/components/VtTag.vue
+++ b/frontend/src/components/VtTag.vue
@@ -16,17 +16,17 @@ defineOptions({
 const tagType = computed(() => vtTagElementType(props.variant));
 
 const tagBind = computed(() => {
-  const rawAttrs = attrs as Record<string, unknown>;
-  if (props.variant === "neutral") {
-    const withoutType = omitVtTagAttr(rawAttrs, "type");
+  const forwarded = omitVtTagAttr(attrs as Record<string, unknown>, "type");
+  if (tagType.value === undefined) {
     return {
-      ...omitVtTagAttr(withoutType, "size"),
-      class: ["vt-tag--neutral", attrs.class],
+      ...forwarded,
+      type: "info" as const,
       effect: "plain" as const,
+      class: ["vt-tag--neutral", attrs.class],
     };
   }
   return {
-    ...omitVtTagAttr(rawAttrs, "size"),
+    ...forwarded,
     type: tagType.value,
   };
 });

--- a/frontend/src/components/VtTag.vue
+++ b/frontend/src/components/VtTag.vue
@@ -15,7 +15,7 @@ defineOptions({
 
 const tagType = computed(() => vtTagElementType(props.variant));
 
-const tagBind = computed(() => {
+function tagBind() {
   // `type` is owned by vtTagElementType; strip caller attrs to avoid el-tag conflicts.
   const forwarded = omitVtTagAttr(attrs as Record<string, unknown>, "type");
   if (tagType.value === undefined) {
@@ -32,11 +32,11 @@ const tagBind = computed(() => {
     ...forwarded,
     type: tagType.value,
   };
-});
+}
 </script>
 
 <template>
-  <el-tag v-bind="tagBind" :size="size">
+  <el-tag v-bind="tagBind()" :size="props.size">
     <slot />
   </el-tag>
 </template>

--- a/frontend/src/components/VtTag.vue
+++ b/frontend/src/components/VtTag.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import { computed, useAttrs } from "vue";
-import {
-  type VtTagProps,
-  omitVtTagAttr,
-  vtTagElementType,
-} from "./vtTagVariants";
+import { type VtTagProps, vtTagElementType } from "./vtTagVariants";
 
 const props = defineProps<VtTagProps>();
 const attrs = useAttrs();
@@ -14,29 +10,23 @@ defineOptions({
 });
 
 const tagType = computed(() => vtTagElementType(props.variant));
-
-function tagBind() {
-  // `type` is owned by vtTagElementType; strip caller attrs to avoid el-tag conflicts.
-  const forwarded = omitVtTagAttr(attrs as Record<string, unknown>, "type");
-  if (tagType.value === undefined) {
-    return {
-      ...forwarded,
-      type: "info" as const,
-      effect: "plain" as const,
-      class: attrs.class
-        ? ["vt-tag--neutral", attrs.class]
-        : ["vt-tag--neutral"],
-    };
-  }
-  return {
-    ...forwarded,
-    type: tagType.value,
-  };
-}
+const isNeutral = computed(() => tagType.value === undefined);
 </script>
 
 <template>
-  <el-tag v-bind="tagBind()" :size="props.size">
+  <el-tag
+    v-bind="attrs"
+    :type="isNeutral ? 'info' : tagType"
+    :effect="isNeutral ? 'plain' : undefined"
+    :class="
+      isNeutral
+        ? attrs.class
+          ? ['vt-tag--neutral', attrs.class]
+          : 'vt-tag--neutral'
+        : undefined
+    "
+    :size="props.size"
+  >
     <slot />
   </el-tag>
 </template>

--- a/frontend/src/components/__tests__/VtAlert.spec.ts
+++ b/frontend/src/components/__tests__/VtAlert.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import VtAlert from "../VtAlert.vue";
+
+describe("VtAlert", () => {
+  it("maps danger variant to el-alert--error", () => {
+    const wrapper = mount(VtAlert, {
+      props: { variant: "danger", title: "Failed" },
+    });
+    expect(wrapper.find(".el-alert--error").exists()).toBe(true);
+  });
+
+  it("maps success variant to el-alert--success", () => {
+    const wrapper = mount(VtAlert, {
+      props: { variant: "success", title: "OK" },
+    });
+    expect(wrapper.find(".el-alert--success").exists()).toBe(true);
+  });
+
+  it("defaults to show-icon and not closable", () => {
+    const wrapper = mount(VtAlert, {
+      props: { variant: "info", title: "Hint" },
+    });
+    expect(wrapper.find(".el-alert__icon").exists()).toBe(true);
+    expect(wrapper.find(".el-alert__close-btn").exists()).toBe(false);
+  });
+
+  it("forwards description and data-testid", () => {
+    const wrapper = mount(VtAlert, {
+      props: {
+        variant: "warning",
+        title: "Warn",
+        description: "Details",
+      },
+      attrs: { "data-testid": "block-alert" },
+    });
+    expect(wrapper.text()).toContain("Details");
+    expect(wrapper.attributes("data-testid")).toBe("block-alert");
+  });
+});

--- a/frontend/src/components/__tests__/VtAlert.spec.ts
+++ b/frontend/src/components/__tests__/VtAlert.spec.ts
@@ -45,4 +45,11 @@ describe("VtAlert", () => {
     });
     expect(wrapper.find("strong").text()).toBe("Extra");
   });
+
+  it("does not render empty description when slot is absent", () => {
+    const wrapper = mount(VtAlert, {
+      props: { variant: "danger", title: "Failed" },
+    });
+    expect(wrapper.find(".el-alert__description").exists()).toBe(false);
+  });
 });

--- a/frontend/src/components/__tests__/VtAlert.spec.ts
+++ b/frontend/src/components/__tests__/VtAlert.spec.ts
@@ -37,4 +37,12 @@ describe("VtAlert", () => {
     expect(wrapper.text()).toContain("Details");
     expect(wrapper.attributes("data-testid")).toBe("block-alert");
   });
+
+  it("forwards default slot content", () => {
+    const wrapper = mount(VtAlert, {
+      props: { variant: "info", title: "Hint" },
+      slots: { default: "<strong>Extra</strong>" },
+    });
+    expect(wrapper.find("strong").text()).toBe("Extra");
+  });
 });

--- a/frontend/src/components/__tests__/VtTag.spec.ts
+++ b/frontend/src/components/__tests__/VtTag.spec.ts
@@ -17,6 +17,7 @@ describe("VtTag", () => {
       slots: { default: "3" },
     });
     expect(wrapper.find(".vt-tag--neutral").exists()).toBe(true);
+    expect(wrapper.find(".el-tag--primary").exists()).toBe(false);
     expect(wrapper.find(".el-tag--success").exists()).toBe(false);
   });
 

--- a/frontend/src/components/__tests__/VtTag.spec.ts
+++ b/frontend/src/components/__tests__/VtTag.spec.ts
@@ -20,6 +20,16 @@ describe("VtTag", () => {
     expect(wrapper.find(".el-tag--success").exists()).toBe(false);
   });
 
+  it("strips conflicting type attr when variant is neutral", () => {
+    const wrapper = mount(VtTag, {
+      props: { variant: "neutral" },
+      attrs: { type: "danger" },
+      slots: { default: "3" },
+    });
+    expect(wrapper.find(".el-tag--danger").exists()).toBe(false);
+    expect(wrapper.find(".vt-tag--neutral").exists()).toBe(true);
+  });
+
   it("maps primary variant to el-tag--primary", () => {
     const wrapper = mount(VtTag, {
       props: { variant: "primary" },

--- a/frontend/src/components/__tests__/VtTag.spec.ts
+++ b/frontend/src/components/__tests__/VtTag.spec.ts
@@ -40,11 +40,11 @@ describe("VtTag", () => {
 
   it("forwards size and data-testid", () => {
     const wrapper = mount(VtTag, {
-      props: { variant: "success" },
-      attrs: { size: "small", "data-testid": "status-tag" },
+      props: { variant: "success", size: "small" },
+      attrs: { "data-testid": "status-tag" },
       slots: { default: "OK" },
     });
     expect(wrapper.attributes("data-testid")).toBe("status-tag");
-    expect(wrapper.find(".el-tag").exists()).toBe(true);
+    expect(wrapper.find(".el-tag--small").exists()).toBe(true);
   });
 });

--- a/frontend/src/components/__tests__/VtTag.spec.ts
+++ b/frontend/src/components/__tests__/VtTag.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import VtTag from "../VtTag.vue";
+
+describe("VtTag", () => {
+  it("maps danger variant to el-tag--danger", () => {
+    const wrapper = mount(VtTag, {
+      props: { variant: "danger" },
+      slots: { default: "Failed" },
+    });
+    expect(wrapper.find(".el-tag--danger").exists()).toBe(true);
+  });
+
+  it("maps neutral variant to neutral styling class", () => {
+    const wrapper = mount(VtTag, {
+      props: { variant: "neutral" },
+      slots: { default: "3" },
+    });
+    expect(wrapper.find(".vt-tag--neutral").exists()).toBe(true);
+    expect(wrapper.find(".el-tag--success").exists()).toBe(false);
+  });
+
+  it("maps primary variant to el-tag--primary", () => {
+    const wrapper = mount(VtTag, {
+      props: { variant: "primary" },
+      slots: { default: "Default" },
+    });
+    expect(wrapper.find(".el-tag--primary").exists()).toBe(true);
+  });
+
+  it("forwards size and data-testid", () => {
+    const wrapper = mount(VtTag, {
+      props: { variant: "success" },
+      attrs: { size: "small", "data-testid": "status-tag" },
+      slots: { default: "OK" },
+    });
+    expect(wrapper.attributes("data-testid")).toBe("status-tag");
+    expect(wrapper.find(".el-tag").exists()).toBe(true);
+  });
+});

--- a/frontend/src/components/__tests__/vtFeedbackVariants.spec.ts
+++ b/frontend/src/components/__tests__/vtFeedbackVariants.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { vtAlertElementType } from "../vtAlertVariants";
-import { omitVtTagAttr, vtTagElementType } from "../vtTagVariants";
+import { vtTagElementType } from "../vtTagVariants";
 
 describe("vtAlertElementType", () => {
   it("maps danger to error", () => {
@@ -11,13 +11,5 @@ describe("vtAlertElementType", () => {
 describe("vtTagElementType", () => {
   it("maps neutral to undefined", () => {
     expect(vtTagElementType("neutral")).toBeUndefined();
-  });
-});
-
-describe("omitVtTagAttr", () => {
-  it("removes a single attribute", () => {
-    expect(omitVtTagAttr({ type: "danger", class: "x" }, "type")).toEqual({
-      class: "x",
-    });
   });
 });

--- a/frontend/src/components/__tests__/vtFeedbackVariants.spec.ts
+++ b/frontend/src/components/__tests__/vtFeedbackVariants.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { vtAlertElementType } from "../vtAlertVariants";
-import { vtTagElementType } from "../vtTagVariants";
+import { omitVtTagAttr, vtTagElementType } from "../vtTagVariants";
 
 describe("vtAlertElementType", () => {
   it("maps danger to error", () => {
@@ -11,5 +11,13 @@ describe("vtAlertElementType", () => {
 describe("vtTagElementType", () => {
   it("maps neutral to undefined", () => {
     expect(vtTagElementType("neutral")).toBeUndefined();
+  });
+});
+
+describe("omitVtTagAttr", () => {
+  it("removes a single attribute", () => {
+    expect(omitVtTagAttr({ type: "danger", class: "x" }, "type")).toEqual({
+      class: "x",
+    });
   });
 });

--- a/frontend/src/components/__tests__/vtFeedbackVariants.spec.ts
+++ b/frontend/src/components/__tests__/vtFeedbackVariants.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { vtAlertElementType } from "../vtAlertVariants";
+import { vtTagElementType } from "../vtTagVariants";
+
+describe("vtAlertElementType", () => {
+  it("maps danger to error", () => {
+    expect(vtAlertElementType("danger")).toBe("error");
+  });
+});
+
+describe("vtTagElementType", () => {
+  it("maps neutral to undefined", () => {
+    expect(vtTagElementType("neutral")).toBeUndefined();
+  });
+});

--- a/frontend/src/components/vtAlertVariants.ts
+++ b/frontend/src/components/vtAlertVariants.ts
@@ -9,6 +9,8 @@ export type VtAlertVariant = (typeof VT_ALERT_VARIANTS)[number];
 
 export type VtAlertProps = {
   variant: VtAlertVariant;
+  title?: string;
+  description?: string;
 };
 
 /** Maps semantic danger to Element Plus alert type `error`. */

--- a/frontend/src/components/vtAlertVariants.ts
+++ b/frontend/src/components/vtAlertVariants.ts
@@ -1,0 +1,20 @@
+export const VT_ALERT_VARIANTS = [
+  "success",
+  "warning",
+  "danger",
+  "info",
+] as const;
+
+export type VtAlertVariant = (typeof VT_ALERT_VARIANTS)[number];
+
+export type VtAlertProps = {
+  variant: VtAlertVariant;
+};
+
+/** Maps semantic danger to Element Plus alert type `error`. */
+export function vtAlertElementType(
+  variant: VtAlertVariant,
+): "success" | "warning" | "error" | "info" {
+  if (variant === "danger") return "error";
+  return variant;
+}

--- a/frontend/src/components/vtTagVariants.ts
+++ b/frontend/src/components/vtTagVariants.ts
@@ -1,0 +1,22 @@
+export const VT_TAG_VARIANTS = [
+  "success",
+  "warning",
+  "danger",
+  "info",
+  "neutral",
+  "primary",
+] as const;
+
+export type VtTagVariant = (typeof VT_TAG_VARIANTS)[number];
+
+export type VtTagProps = {
+  variant: VtTagVariant;
+};
+
+/** Maps VtTag variant to Element Plus el-tag `type` (neutral omits type). */
+export function vtTagElementType(
+  variant: VtTagVariant,
+): "success" | "warning" | "danger" | "info" | "primary" | undefined {
+  if (variant === "neutral") return undefined;
+  return variant;
+}

--- a/frontend/src/components/vtTagVariants.ts
+++ b/frontend/src/components/vtTagVariants.ts
@@ -9,8 +9,11 @@ export const VT_TAG_VARIANTS = [
 
 export type VtTagVariant = (typeof VT_TAG_VARIANTS)[number];
 
+export type VtTagSize = "large" | "default" | "small";
+
 export type VtTagProps = {
   variant: VtTagVariant;
+  size?: VtTagSize;
 };
 
 /** Maps VtTag variant to Element Plus el-tag `type` (neutral omits type). */
@@ -19,4 +22,14 @@ export function vtTagElementType(
 ): "success" | "warning" | "danger" | "info" | "primary" | undefined {
   if (variant === "neutral") return undefined;
   return variant;
+}
+
+/** Omit a single attribute before forwarding to Element Plus. */
+export function omitVtTagAttr(
+  attrs: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const copy = { ...attrs };
+  delete copy[key];
+  return copy;
 }

--- a/frontend/src/components/vtTagVariants.ts
+++ b/frontend/src/components/vtTagVariants.ts
@@ -16,7 +16,7 @@ export type VtTagProps = {
   size?: VtTagSize;
 };
 
-/** Maps VtTag variant to Element Plus el-tag `type` (neutral omits type). */
+/** Maps VtTag variant to Element Plus el-tag `type` (neutral → undefined; EP binding uses info+plain). */
 export function vtTagElementType(
   variant: VtTagVariant,
 ): "success" | "warning" | "danger" | "info" | "primary" | undefined {

--- a/frontend/src/components/vtTagVariants.ts
+++ b/frontend/src/components/vtTagVariants.ts
@@ -23,13 +23,3 @@ export function vtTagElementType(
   if (variant === "neutral") return undefined;
   return variant;
 }
-
-/** Omit a single attribute before forwarding to Element Plus. */
-export function omitVtTagAttr(
-  attrs: Record<string, unknown>,
-  key: string,
-): Record<string, unknown> {
-  const copy = { ...attrs };
-  delete copy[key];
-  return copy;
-}

--- a/frontend/src/utils/showToast.spec.ts
+++ b/frontend/src/utils/showToast.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ElMessage } from "element-plus";
+import { showToast } from "./showToast";
+
+describe("showToast", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates success to ElMessage.success", () => {
+    const spy = vi.spyOn(ElMessage, "success").mockReturnValue({} as never);
+    showToast.success("Saved");
+    expect(spy).toHaveBeenCalledWith("Saved");
+  });
+
+  it("delegates error to ElMessage.error", () => {
+    const spy = vi.spyOn(ElMessage, "error").mockReturnValue({} as never);
+    showToast.error("Failed");
+    expect(spy).toHaveBeenCalledWith("Failed");
+  });
+
+  it("delegates warning to ElMessage.warning", () => {
+    const spy = vi.spyOn(ElMessage, "warning").mockReturnValue({} as never);
+    showToast.warning("Careful");
+    expect(spy).toHaveBeenCalledWith("Careful");
+  });
+
+  it("delegates info to ElMessage.info", () => {
+    const spy = vi.spyOn(ElMessage, "info").mockReturnValue({} as never);
+    showToast.info("Note");
+    expect(spy).toHaveBeenCalledWith("Note");
+  });
+});

--- a/frontend/src/utils/showToast.ts
+++ b/frontend/src/utils/showToast.ts
@@ -13,6 +13,10 @@ function show(variant: ToastVariant, message: string): MessageHandler {
       return ElMessage.error(message);
     case "info":
       return ElMessage.info(message);
+    default: {
+      const _exhaustive: never = variant;
+      throw new Error(`Unknown toast variant: ${String(_exhaustive)}`);
+    }
   }
 }
 

--- a/frontend/src/utils/showToast.ts
+++ b/frontend/src/utils/showToast.ts
@@ -1,0 +1,25 @@
+import { ElMessage } from "element-plus";
+import type { MessageHandler } from "element-plus";
+
+export type ToastVariant = "success" | "warning" | "danger" | "info";
+
+function show(variant: ToastVariant, message: string): MessageHandler {
+  switch (variant) {
+    case "success":
+      return ElMessage.success(message);
+    case "warning":
+      return ElMessage.warning(message);
+    case "danger":
+      return ElMessage.error(message);
+    case "info":
+      return ElMessage.info(message);
+  }
+}
+
+/** Toast feedback (i18n-ready string only). See ADR 0022 / showToast adoption. */
+export const showToast = {
+  success: (message: string) => show("success", message),
+  warning: (message: string) => show("warning", message),
+  error: (message: string) => show("danger", message),
+  info: (message: string) => show("info", message),
+};


### PR DESCRIPTION
## Summary

- Add **VtAlert**, **VtTag**, and **showToast** as the v1 feedback channel primitives (Alert / Toast / Badge).
- Document channel selection (persistent Section alert vs action Toast, Form ADR linkage) in ADR 0022, `CONTEXT.md`, and `.cursor/rules/feedback-design-system.mdc`.
- Storybook catalogs for VtAlert and VtTag; unit tests for wrappers and showToast.

## Test plan

- [x] `make fmt`
- [x] `make test` (Go + frontend unit tests)
- [x] Storybook: VtAlert / VtTag catalogs
- [ ] Adoption in existing views deferred (touch-on-change only)


Made with [Cursor](https://cursor.com)