### PR TITLE
feat(frontend): Iconography design system (ADR 0023)

### DIFF
--- a/.cursor/rules/iconography-design-system.mdc
+++ b/.cursor/rules/iconography-design-system.mdc
@@ -1,0 +1,72 @@
+---
+description: Iconography デザインシステム（ADR 0023）。UI icon / Navigation glyph / Domain icon のサイズ・色・VtIcon
+globs: "frontend/**/*.{vue,ts,css}"
+alwaysApply: false
+---
+
+# Iconography design system
+
+正本: [ADR 0023](../docs/adr/0023-iconography-design-system.md)、用語: [`CONTEXT.md`](../CONTEXT.md) Design system 節。
+
+## スコープ
+
+| 含む | 含まない |
+|------|----------|
+| **UI icon**（`@element-plus/icons-vue` + **VtIcon**） | アバター・サムネ |
+| **Navigation glyph**（絵文字。v1 はサイズのみ） | Server status ドット |
+| **Domain icon**（friend mark 等） | Presence 色ボタン |
+| **Custom icon**（`frontend/src/icons/*.vue`） | EP 全件グローバル登録 |
+
+## Icon size scale
+
+`frontend/src/assets/style.css` の `:root`:
+
+| px | 変数 | VtIcon `size` |
+|----|------|----------------|
+| 12 | `--icon-size-12` / `--icon-size-compact` | `compact` |
+| 16 | `--icon-size-16` / `--icon-size-default` | `default` |
+| 20 | `--icon-size-20` / `--icon-size-emphasis` | `emphasis` |
+| 24 | `--icon-size-24` / `--icon-size-large` | `large` |
+
+Legacy（v1 見た目不変）: `--icon-size-legacy-toggle` → `--font-size-14`（adoption 先: `--icon-size-default`）
+
+**Navigation glyph** 絵文字: `.nav-glyph-size-compact` / `.nav-glyph-size-default` / `.nav-glyph-size-legacy`（14px 現行サイドバー）等（`VtIcon` で包まない）
+
+## Icon color rule
+
+- SVG / EP: **`currentColor`**。親は **Neutral text token**
+- 装飾単体: `--color-text-secondary`
+- 絵文字: サイズのみ（色は固有）
+- **Semantic / Domain color** を汎用 UI icon に直付けしない
+
+## VtIcon
+
+```vue
+<VtIcon size="default"><Search /></VtIcon>
+<VtIcon size="compact"><SampleIcon /></VtIcon>
+```
+
+- `size` **必須**（暗黙既定なし）
+- `decorative` 既定 `true` → `aria-hidden="true"`
+- 意味あり **Domain icon** は `role="img"` + `aria-label`（VtIcon 外でも可）
+
+## Custom icon
+
+1. `frontend/src/icons/FooIcon.vue` — 単一 `<svg>`、`viewBox` 必須、`currentColor`
+2. `<VtIcon size="…"><FooIcon /></VtIcon>`
+
+## 移行（Iconography adoption）
+
+- 新規・改修は **VtIcon** + icon トークン
+- 未触りの `<el-icon>` / 絵文字直書きは一括置換しない
+- スケール外寸法は **四捨五入で最寄り**（14→16）。v1 deliverables では寄せない
+- ESLint 禁止は v1 では入れない
+
+## Storybook
+
+`frontend/src/design/Iconography.stories.ts` が正本。変更時はストーリーも更新する。
+
+## 関連
+
+- 色: `.cursor/rules/color-design-system.mdc`
+- Element Plus: `.cursor/skills/element-plus-frontend/SKILL.md`（ファイル単位 import）

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -708,7 +708,7 @@ _Avoid_: 常時実行, バックグラウンドサービス（v1 で含意しな
 
 ## Design system
 
-ボタン様式・余白・色・タイポグラフィ・フォーム入力部品などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。**Form control** ラッパー（VtInput / VtSelect / VtCheckbox / VtSwitch）は grill-with-docs で合意済み（[ADR 0021](docs/adr/0021-form-control-design-system.md)）。**Feedback & Badges**（Alert / Toast / Badge / Loading の横断チャネル）は grill-with-docs で合意済み（[ADR 0022](docs/adr/0022-feedback-badges-design-system.md)）。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
+ボタン様式・余白・色・タイポグラフィ・アイコン・フォーム入力部品などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。**Form control** ラッパー（VtInput / VtSelect / VtCheckbox / VtSwitch）は grill-with-docs で合意済み（[ADR 0021](docs/adr/0021-form-control-design-system.md)）。**Feedback & Badges**（Alert / Toast / Badge / Loading の横断チャネル）は grill-with-docs で合意済み（[ADR 0022](docs/adr/0022-feedback-badges-design-system.md)）。**Iconography**（アイコン・グリフのサイズ・色・部品化）（[ADR 0023](docs/adr/0023-iconography-design-system.md)）は grill-with-docs で合意済み。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
 
 ### Language
 
@@ -1190,6 +1190,90 @@ _Avoid_: Feedback & Badges（v1 範囲を指すときは scope とセットで�
 **Feedback & Badges v1 deliverables**:
 Issue／PR で最初に届ける具体物。(1) **VtAlert** + テスト + **VtAlert Storybook catalog**、(2) **VtTag**（semantic 4 + neutral + primary）+ テスト + **VtTag Storybook catalog**、(3) **showToast** + テスト、(4) `.cursor/rules/feedback-design-system.mdc`、(5) `docs/adr/0022-feedback-badges-design-system.md`、(6) `CONTEXT.md` 同期。移行は **VtAlert adoption** / **VtTag adoption** / **showToast adoption** のみ（触ったところから）。
 _Avoid_: Feedback & Badges v1 scope（届け物リストを指すときは deliverables とセットで書く）, 全画面置換（adoption と矛盾するため）
+
+**Iconography**:
+アプリ横断のアイコン・グリフのルール。**Icon size scale**・**Icon color rule**・部品化手順を含む。**Spacing** の Sizing（余白以外の寸法）・**Typography** のフォントサイズとは別カテゴリ。絵文字・SVG・Element Plus アイコンを横断して同じサイズ段階と色の意味論で揃える（実装移行は **Iconography adoption** で段階的）。
+_Avoid_: アイコン（実装部品名だけ）, 絵文字（**Navigation glyph** を含意しない俗称）, Sizing（アバター・サムネまで含む総称）
+
+**UI icon**:
+装飾または操作補助の SVG グリフ。v1 正本は `@element-plus/icons-vue`（`el-icon` または将来の **VtIcon** で包む）。入力 prefix（Search）、ボタン内、折りたたみ矢印（Caret）、コピー（CopyDocument）など。**Domain icon**・**Navigation glyph** とは用途で分けるが、**Icon size scale** と **Icon color rule** は共有する。
+_Avoid_: el-icon（実装タグ名だけ）, アイコンフォント（EP は Vue コンポーネント）
+
+**Navigation glyph**:
+サイドバー等のナビ項目左に置く目的地を示すグリフ。現行は Unicode 絵文字（🏠 等）だが、**Iconography** では **UI icon** と同じサイズ段階・スロット幅で扱う（将来 SVG／EP アイコンへ置換してよい）。テキストラベル（`nav.*`）とは別要素。
+_Avoid_: サイドバーアイコン（実装クラス名だけ）, ファビコン, アプリアイコン（OS／インストーラ資産）
+
+**Domain icon**:
+特定画面・ドメインだけが持つ意味付きグリフ。**Domain badge**（`el-tag` チップ）・**Semantic button**（Presence 色ボタン）・Server status の色ドットとは別。サイズと配置は **Iconography**、色の意味は各ドメイン（例: **Encounter friend mark** は **Neutral text** 系）。**Semantic color catalog** や **Presence color** を横断フィードバックとして流用しない。
+_Avoid_: Domain badge, User tag chip, フレンドマーク（**Encounter friend mark** の俗称だけ）
+
+**Custom icon**:
+Element Plus 一覧に無く、リポジトリ内 SVG として追加するグリフ。v1 の **Iconography v1 deliverables** では新規資産は作らないが、追加手順（SVG コンポーネント化）は ADR で定義する。
+_Avoid_: 外部画像（PNG 等のラスタ）, インライン data URL プレースホルダ（Gallery サムネ用など **Iconography** 外）
+
+**Iconography v1 scope**:
+Iconography 策定の最初の届け範囲。**UI icon**・**Navigation glyph**・**Domain icon** のサイズ規律と **Icon color rule**、**Custom icon** の手順文書化、ADR、`.cursor/rules/`、**Iconography Storybook catalog**、`CONTEXT.md` に限定する。含めないもの: サイドバー絵文字の即時 SVG 化、全画面一括置換、ESLint 強制、アバター・サムネ・Server status 色ドット・Presence 色ボタン、**Custom icon** の新規 SVG 追加 PR。
+_Avoid_: Iconography（v1 範囲を指すときは scope とセットで書く）, 将来拡張（スコープ外リストの総称として曖昧なため）
+
+**Icon size scale**:
+Iconography で使ってよいアイコン・グリフの辺長（正方形スロット）の段階列。許容値は **12, 16, 20, 24**（px）のみ。**UI icon**・**Navigation glyph**・**Domain icon** は同じ列を共有する。新規・改修ではこの列以外の任意 px を増やさない（**Iconography adoption**）。**Typography scale** や **Spacing scale** とは別カテゴリ（数値が近くても流用しない）。
+_Avoid_: 16/20/24 のみ（compact 12 を落とす印象）, font-size 直書き（トークン化前の俗称）
+
+**Icon size token**:
+**Icon size scale** の各段階を表す CSS カスタムプロパティ。値は **px リテラル**（例: `--icon-size-16: 16px`）。トークン名の数値は実 px と一致させる（`--icon-size-12` … `--icon-size-24`）。`rem` / `em` は使わない。実装は `el-icon` の `font-size`、絵文字の `font-size`、**Domain icon** の固定スロット幅・高さに同じ値を当てる。
+_Avoid_: --font-size-16（Typography トークンの流用）, icon-md（数値と名前がずれるため）
+
+**Icon size pattern**:
+繰り返し現れるアイコン寸法に付ける意味別の名前。**Icon size token** のセマンティック・エイリアスとして定義し、実体は必ず `--icon-size-*` へ委譲する。v1: `--icon-size-compact` → 12px、`--icon-size-default` → 16px、`--icon-size-emphasis` → 20px、`--icon-size-large` → 24px。
+_Avoid_: small/medium/large（px 数と対応が曖昧なため）, Form control size（入力部品の EP size と混同しやすいため）
+
+**Iconography migration rounding**:
+既存の任意 px / `rem` アイコン寸法を **Icon size token** へ置き換えるとき、スケールに無い値は **四捨五入で最寄りの段階**へ寄せる（例: 14px → 16、12.6px → 12、18px → 20）。**Iconography v1 deliverables** では寄せない（**Iconography v1 visual policy**）。アバター・サムネ・意図的な非正方形は対象外。
+_Avoid_: 目視のみ（置換ごとに判断がぶれるため）, Typography migration rounding と同一視（フォントサイズは別スケール）
+
+**Iconography v1 visual policy**:
+Iconography v1 では **見た目を変えない**（**Color v1 visual policy** / **Typography v1 visual policy** と同型）。tokenize PR では現行 computed 寸法をそのまま **Icon size token** に移し、**Iconography migration rounding**（14→16 等）は adoption 時のみ。サイドバー絵文字の SVG 化も v1 deliverables 外。
+_Avoid_: リデザイン（v1 で見た目変更を含意するため）, deliverables での一括 16px 化（回帰レビューと混ぜないため）
+
+**Icon color rule**:
+Iconography における色の付け方の正本。SVG／Element Plus アイコンは原則 **`currentColor`**（親の `color` を継承）。親は **Neutral text token**（`--color-text-primary` / `--color-text-secondary` / `--color-text-muted`）で役割を決める。単体の装飾 **UI icon** は **secondary**、無効文脈は **muted**、テキストリンクと一体の操作アイコンのみ **Brand color token** を親に使ってよい。**Semantic color**・**Domain color**（**Presence color** 等）を汎用 **UI icon** に直付けしない（**VtAlert** 等 EP 部品内のアイコンは部品側の Semantic mapping に任せる）。**Domain icon** の色は各ドメイン正本（例: **Encounter friend mark** → **Neutral text secondary**）。
+_Avoid_: アイコン専用パレット（**App color token** と二重管理）, hex 直書き, danger 赤の単独 UI icon（**Semantic button** / **VtButton** と混同しやすいため）
+
+**Navigation glyph color**:
+**Navigation glyph** が Unicode 絵文字の間は **Icon color rule** の CSS `color` は効かない（絵文字固有の色）。v1 では **Icon size scale** のみ揃える。SVG／EP アイコンへ置換後は、メニュー項目の `color` 継承（`currentColor`）に従い **Neutral text**／active 時 **primary** を親が担当する。**Brand color** をナビ専用に追加しない（サイドバー active は既存の左ボーダー等で足りる）。
+_Avoid_: 絵文字の色統一（不可能なため）, ナビ active の Brand 固定（**Icon color rule** 案 C）
+
+**Icon color adoption**:
+**Icon color rule** への移行方針。新規・改修で触ったファイルではレガシー `--text-*` や hex をアイコンに増やさず、親の **Neutral text token** または `currentColor` に寄せる。未着手の既存 View は一括置換しない。
+_Avoid_: 全面置換, アイコンに Brand 直指定の新規増殖
+
+**VtIcon**:
+**UI icon**・**Custom icon** の標準ラッパー。内部は `el-icon`。**Icon size pattern** に対応する `size` prop（`compact` | `default` | `emphasis` | `large`）を**必須**とし、暗黙既定は持たない。色は **Icon color rule** に従い `currentColor`（親の **Neutral text token**）。`data-testid` 等は透過。**Navigation glyph** の Unicode 絵文字は v1 では `VtIcon` で包まず、同じ **Icon size token**／pattern クラスを `span` 等に当てる（SVG 化後は `VtIcon` に寄せる）。
+_Avoid_: el-icon（移行完了後の直呼び）, Icon component（汎用フレームワークの俗称）
+
+**VtIcon adoption**:
+VtIcon への移行方針。新規・改修で **UI icon** には **VtIcon** を使う。未着手の `<el-icon>` 直書きは一括置換しない（触ったところから順次）。ESLint 強制は v1 では入れない。見た目の正本は **Iconography Storybook catalog**。
+_Avoid_: 全面置換, el-icon 禁止の CI 強制（即時一括・CI 強制を含意するため）
+
+**Custom icon component**:
+**Custom icon** の Vue SFC（`frontend/src/icons/*.vue`）。単一ルート `<svg>`、`viewBox` 必須、`width`/`height` 属性なし、塗り／線は `currentColor`（`fill` または `stroke`）。利用は `<VtIcon size="…"><FooIcon /></VtIcon>`。EP 一覧に無いグリフの追加手順の正本。
+_Avoid_: 生 SVG ファイル直置き（`.svg` を import するだけ）, PNG アイコン, インライン `<svg>` の View 直書き（再利用グリフの場合）
+
+**Iconography Storybook catalog**:
+Iconography の Storybook 一覧。**Icon size scale**・**Icon size pattern** 対応表、**Icon color rule** 要点、**VtIcon** の 4 `size`、EP 代表アイコン（Search / Caret）と **Custom icon component** 1 例、**Navigation glyph**（絵文字サイズ揃え）の使用例を載せる（**Spacing Storybook catalog** / **Color Storybook catalog** と同型）。
+_Avoid_: 全画面 Storybook, EP Icons 全件一覧
+
+**Iconography adoption**:
+Iconography トークン・**VtIcon**・**Icon color rule** への移行方針。新規・改修で触ったファイルでは **Icon size token**／**VtIcon**／`currentColor` を使う。未着手の既存 `<el-icon>`・任意 px・絵文字サイズ直書きは一括置換しない。**Iconography v1 deliverables** の共有スタイルと Storybook は v1 で寄せる。サイドバー SVG 化は後続。**Iconography migration rounding** は adoption 時のみ。
+_Avoid_: 全面置換, 絵文字即時 SVG 化の v1 強制
+
+**Iconography v1 deliverables**:
+Issue／PR で最初に届ける具体物。(1) `frontend/src/assets/style.css` の **Icon size token**・**Icon size pattern**、(2) `frontend/src/design/iconTokens.ts` + 単体テスト、(3) **VtIcon** + variants + 単体テスト、(4) **Iconography Storybook catalog**（EP 代表 + **Custom icon component** サンプル 1 例 + **Navigation glyph** サイズ例）、(5) 共有スタイル（`.section-card__toggle-icon` 等）のトークン参照化（**Iconography v1 visual policy**）、(6) `.cursor/rules/iconography-design-system.mdc`、(7) `docs/adr/0023-iconography-design-system.md`（**Icon accessibility rule** を含む）、(8) `CONTEXT.md` 同期。各 View の `<el-icon>` 直書きは **Iconography adoption** のみ。
+_Avoid_: Iconography v1 scope（届け物リストを指すときは deliverables とセットで書く）, 全画面置換（adoption と矛盾するため）
+
+**Icon accessibility rule**:
+**VtIcon**・**Domain icon** の支援技術向けルール。**装飾 icon**（ボタン・リンク横の補助、折りたたみ Caret、入力 prefix の Search 等）は `aria-hidden="true"`。操作意味は隣のテキスト・ボタンラベル・`aria-labelledby` が担う。**意味 icon**（ラベル無しで情報を伝える **Domain icon** 等）は `role="img"` + `aria-label`（i18n 固定文）。**アイコンのみボタン**（テキストラベル無し）は v1 では新規に増やさない。既存は `aria-label` 必須。v1 では文書化と **VtIcon**／Storybook の既定に留め、既存 View の一括修正は **Iconography adoption** に委ねる。
+_Avoid_: 全 icon に aria-label（装飾まで読み上げる）, 装飾 icon の role="img", v1 での a11y 一括置換
 
 ## Agent contribution
 

--- a/docs/adr/0023-iconography-design-system.md
+++ b/docs/adr/0023-iconography-design-system.md
@@ -1,0 +1,151 @@
+# ADR 0023: Iconography design system
+
+## Status
+
+Accepted（grill-with-docs で合意）
+
+## Context
+
+- **UI icon** が `<el-icon>` + 任意 `font-size`（14px・`1rem`・`0.9rem` 等）で混在し、**Icon size scale** が未定義
+- **Navigation glyph**（サイドバー絵文字）と **Domain icon**（Encounter friend mark 等）が同じ寸法・色の規律を共有していない
+- **Spacing**（[ADR 0018](0018-spacing-design-system.md)）・**Typography**（[ADR 0020](0020-typography-design-system.md)）はアイコン寸法をスコープ外とした
+- **Color**（[ADR 0019](0019-color-design-system.md)）は整備済みだが、アイコンへの **Neutral text token** / `currentColor` の適用ルールが未定義
+- カスタム SVG の追加手順・標準ラッパーが無い
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Design system** セクション（**Iconography**、**UI icon**、**Navigation glyph**、**Domain icon**、**VtIcon** 等）を正本とする。
+
+## Decision
+
+### 1. スコープ
+
+| 含む | 含まない |
+|------|----------|
+| **UI icon**（`@element-plus/icons-vue`） | アバター・サムネ |
+| **Navigation glyph**（サイドバー絵文字。v1 はサイズ規律のみ） | Server status 色ドット |
+| **Domain icon**（friend mark 等。色はドメイン正本） | **Semantic button**（Presence 色ボタン） |
+| **Custom icon** 手順（v1 は Storybook サンプルのみ） | `main.ts` での EP アイコン全登録 |
+
+### 2. Icon size scale
+
+| px | CSS 変数 |
+|----|----------|
+| 12 | `--icon-size-12` |
+| 16 | `--icon-size-16` |
+| 20 | `--icon-size-20` |
+| 24 | `--icon-size-24` |
+
+**Icon size pattern**:
+
+| Pattern | CSS 変数 | 委譲先 |
+|---------|----------|--------|
+| compact | `--icon-size-compact` | `--icon-size-12` |
+| default | `--icon-size-default` | `--icon-size-16` |
+| emphasis | `--icon-size-emphasis` | `--icon-size-20` |
+| large | `--icon-size-large` | `--icon-size-24` |
+
+- 上記以外の任意 px は新規・改修で増やさない
+- 値は **px リテラル**。`rem` / `em` は使わない
+- **Typography scale** / **Spacing scale** とは別カテゴリ（数値が近くても流用しない）
+
+**Icon size legacy derivative**（v1 visual policy・スケール外）:
+
+| 用途 | CSS 変数 | 値 | adoption 先 |
+|------|----------|-----|-------------|
+| Section card toggle | `--icon-size-legacy-toggle` | `var(--font-size-14)`（14px） | `--icon-size-default`（16px） |
+
+### 3. Icon color rule
+
+- SVG / Element Plus アイコンは原則 **`currentColor`**（親の `color` を継承）
+- 親は **Neutral text token**（`--color-text-primary` / `--color-text-secondary` / `--color-text-muted`）
+- 単体装飾 **UI icon** は **secondary**、無効文脈は **muted**
+- **Semantic color**・**Domain color** を汎用 **UI icon** に直付けしない
+- **Navigation glyph**（絵文字期）は CSS `color` が効かない。**Icon size scale** のみ揃える
+- **Domain icon** の色は各ドメイン正本（例: friend mark → `--color-text-secondary`）
+
+### 4. Icon accessibility rule
+
+| 種別 | ルール |
+|------|--------|
+| 装飾 **UI icon** | `aria-hidden="true"`（**VtIcon** 既定 `decorative=true`） |
+| 意味 **Domain icon** | `role="img"` + `aria-label`（i18n）。**VtIcon** は使わず既存パターン維持 |
+| アイコンのみボタン | v1 では新規禁止。既存は `aria-label` 必須 |
+
+v1 では文書化と **VtIcon** 既定のみ。既存 View の一括 a11y 修正は **Iconography adoption** に委ねる。
+
+### 5. VtIcon
+
+- **UI icon** と **Custom icon** の標準ラッパー。内部は `el-icon`
+- `size`: `compact` \| `default` \| `emphasis` \| `large`（**必須**、暗黙既定なし）
+- `decorative`: 既定 `true` → `aria-hidden="true"`
+- `data-testid` 等は透過（`inheritAttrs: false` + `v-bind="$attrs"`）
+- **Navigation glyph** の絵文字は v1 では `VtIcon` で包まない。共有クラス `.nav-glyph-size-default` 等で **Icon size token** を当てる
+
+### 6. Custom icon component
+
+1. `frontend/src/icons/FooIcon.vue` を追加
+2. 単一ルート `<svg>`、`viewBox` 必須、`width`/`height` なし
+3. `fill="currentColor"` または `stroke="currentColor"`
+4. 利用: `<VtIcon size="default"><FooIcon /></VtIcon>`
+
+v1 deliverables では `SampleIcon.vue`（Storybook 用）のみ。
+
+### 7. Iconography v1 visual policy
+
+tokenize 時は **見た目を変えない**。14px の toggle は **Icon size legacy derivative** を維持。**Iconography migration rounding**（14→16 等）は adoption 時のみ。サイドバー絵文字の SVG 化は v1 外。
+
+### 8. 実装正本
+
+- トークン・共有クラス: `frontend/src/assets/style.css`
+- カタログ定数: `frontend/src/design/iconTokens.ts`
+- ラッパー: `frontend/src/components/VtIcon.vue`
+- 見た目と使い方: **Iconography Storybook catalog**（`frontend/src/design/Iconography.stories.ts`）
+- Agent 規約: `.cursor/rules/iconography-design-system.mdc`
+
+### 9. Iconography adoption
+
+- 新規・改修で **VtIcon** + **Icon size token** + **Icon color rule** を使う
+- `style.css` の共有スタイル（`.section-card__toggle-icon` 等）は v1 で icon トークンへ寄せる（legacy derivative 可）
+- 既存 View の `<el-icon>` 直書き・絵文字サイズ直書きは一括置換しない
+- **Iconography migration rounding**: スケール外は四捨五入で最寄りトークンへ（v1 deliverables では寄せない）
+- ESLint 強制は v1 では入れない
+
+## Considered options
+
+| 案 | 却下理由 |
+|----|----------|
+| Typography `--font-size-*` をアイコンに流用 | Sizing カテゴリが混ざり、14px 本文とアイコン 16px の役割が曖昧になる |
+| 16 / 20 / 24 のみ（12 なし） | friend mark 12px スロットを 16 に上げると行密度が落ちる |
+| ナビ active を **Brand color** 固定 | サイドバー左ボーダーと二重強調になりうる |
+| `main.ts` で EP アイコン全登録 | v1 スコープ肥大。現行はファイル単位 import で十分 |
+| v1 で絵文字を SVG 一括置換 | 見た目・選定コストが大きく visual policy と矛盾 |
+| アイコン専用 hex パレット | **App color token** と二重管理になる |
+| 全 View 一括 VtIcon 化 | 他 adoption と方針が矛盾しリグレッションリスクが大きい |
+
+## v1 scope
+
+**含む:**
+
+- `style.css` への **Icon size token**・pattern・legacy derivative・`.vt-icon--size-*`・`.nav-glyph-size-*`
+- `iconTokens.ts` + 単体テスト
+- **VtIcon** + 単体テスト
+- **Iconography Storybook catalog**（EP 代表 + SampleIcon + 絵文字サイズ例）
+- 共有スタイルのトークン参照化（`.section-card__toggle-icon`）
+- `.cursor/rules/iconography-design-system.mdc`
+- `CONTEXT.md` / 本 ADR
+
+**含まない:**
+
+- サイドバー絵文字 → SVG / EP 置換
+- 各 View の `<el-icon>` 一括 VtIcon 化
+- **Custom icon** の製品画面への追加（Storybook サンプル除く）
+- `main.ts` EP グローバル登録
+- 最小タップ領域 44px 等の新規 a11y 規定
+- ESLint 強制
+
+## Consequences
+
+- 新規・改修 PR では **VtIcon** + `var(--icon-size-*)` が期待される
+- **Iconography Storybook catalog** がアイコンの正本となり、Spacing / Color / Typography catalog と並べて参照できる
+- 14px legacy toggle は adoption で 16px へ寄せる入口が残る
+- v1 マージ直後の視覚差は意図しない（legacy derivative は現行 computed と同等）
+- 絵文字ナビはサイズクラスで揃えつつ、SVG 化は後続 Issue で **Navigation glyph** として実施できる

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -94,6 +94,21 @@
   --font-weight-700: 700;
 
   --font-family-ui: "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+
+  /* Icon size scale (ADR 0023) */
+  --icon-size-12: 12px;
+  --icon-size-16: 16px;
+  --icon-size-20: 20px;
+  --icon-size-24: 24px;
+
+  /* Icon size pattern catalog */
+  --icon-size-compact: var(--icon-size-12);
+  --icon-size-default: var(--icon-size-16);
+  --icon-size-emphasis: var(--icon-size-20);
+  --icon-size-large: var(--icon-size-24);
+
+  /* Outside scale: preserves legacy section toggle (14px). Adoption → --icon-size-default. */
+  --icon-size-legacy-toggle: var(--font-size-14);
 }
 
 /* ─── Element Plus dark theme CSS variable overrides ───────────── */
@@ -357,9 +372,62 @@ a:hover {
 
 .section-card__toggle-icon {
   flex-shrink: 0;
-  font-size: var(--font-size-14);
+  font-size: var(--icon-size-legacy-toggle);
 }
 
 .section-card.section-card--collapsed > .el-card__body {
   display: none;
+}
+
+/* ─── Iconography (ADR 0023) ─────────────────────────────────────── */
+
+.vt-icon--size-compact {
+  font-size: var(--icon-size-compact);
+}
+
+.vt-icon--size-default {
+  font-size: var(--icon-size-default);
+}
+
+.vt-icon--size-emphasis {
+  font-size: var(--icon-size-emphasis);
+}
+
+.vt-icon--size-large {
+  font-size: var(--icon-size-large);
+}
+
+.nav-glyph-size-compact {
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: var(--icon-size-compact);
+  line-height: 1;
+}
+
+.nav-glyph-size-default {
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: var(--icon-size-default);
+  line-height: 1;
+}
+
+.nav-glyph-size-legacy {
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: var(--icon-size-legacy-toggle);
+  line-height: 1;
+}
+
+.nav-glyph-size-emphasis {
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: var(--icon-size-emphasis);
+  line-height: 1;
+}
+
+.nav-glyph-size-large {
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: var(--icon-size-large);
+  line-height: 1;
 }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -385,7 +385,12 @@ a:hover {
 .vt-icon--size-compact,
 .vt-icon--size-default,
 .vt-icon--size-emphasis,
-.vt-icon--size-large {
+.vt-icon--size-large,
+.nav-glyph-size-compact,
+.nav-glyph-size-default,
+.nav-glyph-size-legacy,
+.nav-glyph-size-emphasis,
+.nav-glyph-size-large {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -408,19 +413,6 @@ a:hover {
 
 .vt-icon--size-large {
   font-size: var(--icon-size-large);
-}
-
-.nav-glyph-size-compact,
-.nav-glyph-size-default,
-.nav-glyph-size-legacy,
-.nav-glyph-size-emphasis,
-.nav-glyph-size-large {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  line-height: 1;
-  vertical-align: middle;
 }
 
 .nav-glyph-size-compact {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -108,7 +108,7 @@
   --icon-size-large: var(--icon-size-24);
 
   /* Outside scale: preserves legacy section toggle (14px). Adoption → --icon-size-default. */
-  --icon-size-legacy-toggle: var(--font-size-14);
+  --icon-size-legacy-toggle: 14px;
 }
 
 /* ─── Element Plus dark theme CSS variable overrides ───────────── */
@@ -387,8 +387,11 @@ a:hover {
 .vt-icon--size-emphasis,
 .vt-icon--size-large {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   line-height: 1;
+  vertical-align: middle;
 }
 
 .vt-icon--size-compact {
@@ -413,8 +416,11 @@ a:hover {
 .nav-glyph-size-emphasis,
 .nav-glyph-size-large {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   line-height: 1;
+  vertical-align: middle;
 }
 
 .nav-glyph-size-compact {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -407,7 +407,11 @@ a:hover {
   font-size: var(--icon-size-large);
 }
 
-[class^="nav-glyph-size-"] {
+.nav-glyph-size-compact,
+.nav-glyph-size-default,
+.nav-glyph-size-legacy,
+.nav-glyph-size-emphasis,
+.nav-glyph-size-large {
   display: inline-flex;
   flex-shrink: 0;
   line-height: 1;

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -381,6 +381,16 @@ a:hover {
 
 /* ─── Iconography (ADR 0023) ─────────────────────────────────────── */
 
+.vt-icon,
+.vt-icon--size-compact,
+.vt-icon--size-default,
+.vt-icon--size-emphasis,
+.vt-icon--size-large {
+  display: inline-flex;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
 .vt-icon--size-compact {
   font-size: var(--icon-size-compact);
 }
@@ -397,37 +407,28 @@ a:hover {
   font-size: var(--icon-size-large);
 }
 
-.nav-glyph-size-compact {
+[class^="nav-glyph-size-"] {
   display: inline-flex;
   flex-shrink: 0;
-  font-size: var(--icon-size-compact);
   line-height: 1;
+}
+
+.nav-glyph-size-compact {
+  font-size: var(--icon-size-compact);
 }
 
 .nav-glyph-size-default {
-  display: inline-flex;
-  flex-shrink: 0;
   font-size: var(--icon-size-default);
-  line-height: 1;
 }
 
 .nav-glyph-size-legacy {
-  display: inline-flex;
-  flex-shrink: 0;
   font-size: var(--icon-size-legacy-toggle);
-  line-height: 1;
 }
 
 .nav-glyph-size-emphasis {
-  display: inline-flex;
-  flex-shrink: 0;
   font-size: var(--icon-size-emphasis);
-  line-height: 1;
 }
 
 .nav-glyph-size-large {
-  display: inline-flex;
-  flex-shrink: 0;
   font-size: var(--icon-size-large);
-  line-height: 1;
 }

--- a/frontend/src/components/VtIcon.vue
+++ b/frontend/src/components/VtIcon.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, useAttrs } from "vue";
 import type { VtIconProps } from "./vtIconVariants";
 
 const props = withDefaults(defineProps<VtIconProps>(), {
   decorative: true,
 });
 
+const attrs = useAttrs();
+
 defineOptions({
   inheritAttrs: false,
 });
 
 const sizeClass = computed(() => `vt-icon--size-${props.size}`);
+
+const ariaHidden = computed(() => {
+  if (props.decorative) return "true";
+  const fromAttrs = attrs["aria-hidden"];
+  return fromAttrs !== undefined ? String(fromAttrs) : undefined;
+});
 </script>
 
 <template>
@@ -18,7 +26,7 @@ const sizeClass = computed(() => `vt-icon--size-${props.size}`);
     v-bind="$attrs"
     class="vt-icon"
     :class="sizeClass"
-    :aria-hidden="decorative ? 'true' : undefined"
+    :aria-hidden="ariaHidden"
   >
     <slot />
   </el-icon>

--- a/frontend/src/components/VtIcon.vue
+++ b/frontend/src/components/VtIcon.vue
@@ -13,8 +13,9 @@ defineOptions({
 });
 
 const passthroughAttrs = computed(() => {
-  const { "aria-hidden": _ariaHidden, ...rest } = attrs;
-  return rest;
+  const result = { ...attrs };
+  delete result["aria-hidden"];
+  return result;
 });
 
 const sizeClass = computed(() => `vt-icon--size-${props.size}`);

--- a/frontend/src/components/VtIcon.vue
+++ b/frontend/src/components/VtIcon.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { VtIconProps } from "./vtIconVariants";
+
+const props = withDefaults(defineProps<VtIconProps>(), {
+  decorative: true,
+});
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const sizeClass = computed(() => `vt-icon--size-${props.size}`);
+</script>
+
+<template>
+  <el-icon
+    v-bind="$attrs"
+    class="vt-icon"
+    :class="sizeClass"
+    :aria-hidden="decorative ? 'true' : undefined"
+  >
+    <slot />
+  </el-icon>
+</template>

--- a/frontend/src/components/VtIcon.vue
+++ b/frontend/src/components/VtIcon.vue
@@ -14,6 +14,7 @@ defineOptions({
 
 const passthroughAttrs = computed(() => {
   const result = { ...attrs };
+  // aria-hidden is controlled by `ariaHidden` computed below; remove to avoid conflict
   delete result["aria-hidden"];
   return result;
 });

--- a/frontend/src/components/VtIcon.vue
+++ b/frontend/src/components/VtIcon.vue
@@ -12,18 +12,24 @@ defineOptions({
   inheritAttrs: false,
 });
 
+const passthroughAttrs = computed(() => {
+  const { "aria-hidden": _ariaHidden, ...rest } = attrs;
+  return rest;
+});
+
 const sizeClass = computed(() => `vt-icon--size-${props.size}`);
 
 const ariaHidden = computed(() => {
   if (props.decorative) return "true";
   const fromAttrs = attrs["aria-hidden"];
-  return fromAttrs !== undefined ? String(fromAttrs) : undefined;
+  if (fromAttrs !== undefined) return String(fromAttrs);
+  return "false";
 });
 </script>
 
 <template>
   <el-icon
-    v-bind="$attrs"
+    v-bind="passthroughAttrs"
     class="vt-icon"
     :class="sizeClass"
     :aria-hidden="ariaHidden"

--- a/frontend/src/components/__tests__/VtIcon.spec.ts
+++ b/frontend/src/components/__tests__/VtIcon.spec.ts
@@ -29,6 +29,17 @@ describe("VtIcon", () => {
     expect(wrapper.find(".el-icon").attributes("aria-hidden")).toBe("true");
   });
 
+  it("sets aria-hidden false when decorative is false and attr omitted", () => {
+    const wrapper = mount(VtIcon, {
+      props: { size: "default", decorative: false },
+      attrs: { "aria-label": "Search" },
+      slots: { default: Search },
+    });
+    const icon = wrapper.find(".el-icon");
+    expect(icon.attributes("aria-hidden")).toBe("false");
+    expect(icon.attributes("aria-label")).toBe("Search");
+  });
+
   it("passes through aria-hidden when decorative is false", () => {
     const wrapper = mount(VtIcon, {
       props: { size: "default", decorative: false },

--- a/frontend/src/components/__tests__/VtIcon.spec.ts
+++ b/frontend/src/components/__tests__/VtIcon.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { Search } from "@element-plus/icons-vue";
+import VtIcon from "../VtIcon.vue";
+import { VT_ICON_SIZES } from "../../design/iconTokens";
+
+describe("VtIcon", () => {
+  it.each(VT_ICON_SIZES)("applies size class for %s", (size) => {
+    const wrapper = mount(VtIcon, {
+      props: { size },
+      slots: { default: Search },
+    });
+    expect(wrapper.find(`.vt-icon--size-${size}`).exists()).toBe(true);
+  });
+
+  it("renders el-icon wrapper with slotted icon", () => {
+    const wrapper = mount(VtIcon, {
+      props: { size: "default" },
+      slots: { default: Search },
+    });
+    expect(wrapper.find(".el-icon").exists()).toBe(true);
+  });
+
+  it("defaults decorative icons to aria-hidden", () => {
+    const wrapper = mount(VtIcon, {
+      props: { size: "default" },
+      slots: { default: Search },
+    });
+    expect(wrapper.find(".el-icon").attributes("aria-hidden")).toBe("true");
+  });
+
+  it("omits aria-hidden when decorative is false", () => {
+    const wrapper = mount(VtIcon, {
+      props: { size: "default", decorative: false },
+      attrs: { "aria-label": "Search" },
+      slots: { default: Search },
+    });
+    const icon = wrapper.find(".el-icon");
+    expect(icon.attributes("aria-hidden")).toBeUndefined();
+    expect(icon.attributes("aria-label")).toBe("Search");
+  });
+
+  it("forwards attrs such as data-testid", () => {
+    const wrapper = mount(VtIcon, {
+      props: { size: "compact" },
+      attrs: { "data-testid": "search-icon" },
+      slots: { default: Search },
+    });
+    expect(wrapper.find(".el-icon").attributes("data-testid")).toBe(
+      "search-icon",
+    );
+  });
+});

--- a/frontend/src/components/__tests__/VtIcon.spec.ts
+++ b/frontend/src/components/__tests__/VtIcon.spec.ts
@@ -29,15 +29,13 @@ describe("VtIcon", () => {
     expect(wrapper.find(".el-icon").attributes("aria-hidden")).toBe("true");
   });
 
-  it("omits aria-hidden when decorative is false", () => {
+  it("passes through aria-hidden when decorative is false", () => {
     const wrapper = mount(VtIcon, {
       props: { size: "default", decorative: false },
-      attrs: { "aria-label": "Search" },
+      attrs: { "aria-hidden": "true" },
       slots: { default: Search },
     });
-    const icon = wrapper.find(".el-icon");
-    expect(icon.attributes("aria-hidden")).toBeUndefined();
-    expect(icon.attributes("aria-label")).toBe("Search");
+    expect(wrapper.find(".el-icon").attributes("aria-hidden")).toBe("true");
   });
 
   it("forwards attrs such as data-testid", () => {

--- a/frontend/src/components/vtIconVariants.ts
+++ b/frontend/src/components/vtIconVariants.ts
@@ -4,6 +4,6 @@ export type { VtIconSize };
 
 export type VtIconProps = {
   size: VtIconSize;
-  /** When true (default), sets aria-hidden for decorative icons. */
+  /** When true, sets aria-hidden for decorative icons (default in VtIcon.vue). */
   decorative?: boolean;
 };

--- a/frontend/src/components/vtIconVariants.ts
+++ b/frontend/src/components/vtIconVariants.ts
@@ -1,0 +1,9 @@
+import type { VtIconSize } from "../design/iconTokens";
+
+export type { VtIconSize };
+
+export type VtIconProps = {
+  size: VtIconSize;
+  /** When true (default), sets aria-hidden for decorative icons. */
+  decorative?: boolean;
+};

--- a/frontend/src/design/Iconography.stories.css
+++ b/frontend/src/design/Iconography.stories.css
@@ -24,9 +24,13 @@
 
 .iconography-story-table th,
 .iconography-story-table td {
-  border: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
   padding: var(--space-8) var(--space-12);
   text-align: left;
+}
+
+.iconography-story-table th {
+  border-bottom: 2px solid var(--color-border);
 }
 
 .iconography-story-size-row {
@@ -83,5 +87,17 @@
 }
 
 .iconography-story-color-swatch span {
+  color: inherit;
+}
+
+.iconography-story-color--secondary {
   color: var(--color-text-secondary);
+}
+
+.iconography-story-color--primary {
+  color: var(--color-text-primary);
+}
+
+.iconography-story-color--muted {
+  color: var(--color-text-muted);
 }

--- a/frontend/src/design/Iconography.stories.css
+++ b/frontend/src/design/Iconography.stories.css
@@ -40,14 +40,6 @@
   margin-bottom: var(--space-12);
 }
 
-.iconography-story-size-box {
-  align-items: center;
-  color: var(--color-text-secondary);
-  display: inline-flex;
-  flex-shrink: 0;
-  justify-content: center;
-}
-
 .iconography-story-examples {
   display: flex;
   flex-direction: column;

--- a/frontend/src/design/Iconography.stories.css
+++ b/frontend/src/design/Iconography.stories.css
@@ -1,0 +1,87 @@
+.iconography-story {
+  color: var(--color-text-primary);
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-14);
+  line-height: var(--line-height-normal);
+  max-width: 40rem;
+}
+
+.iconography-story h2 {
+  font-size: var(--font-size-18);
+  font-weight: var(--font-weight-600);
+  margin: 0 0 var(--space-block);
+}
+
+.iconography-story p {
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-block);
+}
+
+.iconography-story-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.iconography-story-table th,
+.iconography-story-table td {
+  border: 1px solid var(--color-border);
+  padding: var(--space-8) var(--space-12);
+  text-align: left;
+}
+
+.iconography-story-size-row {
+  align-items: center;
+  display: flex;
+  gap: var(--space-block);
+  margin-bottom: var(--space-12);
+}
+
+.iconography-story-size-box {
+  align-items: center;
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  flex-shrink: 0;
+  justify-content: center;
+}
+
+.iconography-story-examples {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-section);
+}
+
+.iconography-story-example-block {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-block);
+}
+
+.iconography-story-example-block h3 {
+  font-size: var(--font-size-16);
+  font-weight: var(--font-weight-600);
+  margin: 0 0 var(--space-12);
+}
+
+.iconography-story-inline {
+  align-items: center;
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  gap: var(--space-action-group);
+}
+
+.iconography-story-nav-row {
+  align-items: center;
+  color: var(--color-text-secondary);
+  display: flex;
+  gap: var(--space-action-group);
+}
+
+.iconography-story-color-swatch {
+  align-items: center;
+  display: flex;
+  gap: var(--space-block);
+}
+
+.iconography-story-color-swatch span {
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/design/Iconography.stories.css
+++ b/frontend/src/design/Iconography.stories.css
@@ -83,6 +83,7 @@
 }
 
 .iconography-story-color--secondary {
+  /* App Neutral text tokens (Color ADR 0019); contrast verified on dark canvas. */
   color: var(--color-text-secondary);
 }
 

--- a/frontend/src/design/Iconography.stories.ts
+++ b/frontend/src/design/Iconography.stories.ts
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { CaretRight, Search } from "@element-plus/icons-vue";
+import VtIcon from "../components/VtIcon.vue";
+import SampleIcon from "../icons/SampleIcon.vue";
+import {
+  ICON_SIZE_LEGACY,
+  ICON_SIZE_PATTERNS,
+  ICON_SIZE_SCALE_PX,
+  VT_ICON_SIZES,
+} from "./iconTokens";
+import "./Iconography.stories.css";
+
+const catalogParameters = {
+  controls: { disable: true },
+};
+
+const meta = {
+  title: "Design System/Iconography",
+  tags: ["autodocs"],
+  parameters: catalogParameters,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Scale: Story = {
+  name: "Icon size scale",
+  render: () => ({
+    components: { VtIcon, Search },
+    setup: () => ({ scale: ICON_SIZE_SCALE_PX }),
+    template: `
+      <div class="iconography-story">
+        <h2>Icon size scale</h2>
+        <p>Square slot via <code>font-size</code> on <code>VtIcon</code> / <code>el-icon</code>.</p>
+        <div v-for="px in scale" :key="px" class="iconography-story-size-row">
+          <VtIcon :size="px === 12 ? 'compact' : px === 16 ? 'default' : px === 20 ? 'emphasis' : 'large'">
+            <Search />
+          </VtIcon>
+          <span>--icon-size-{{ px }} · {{ px }}px</span>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const Patterns: Story = {
+  name: "Icon size pattern catalog",
+  render: () => ({
+    setup: () => ({ patterns: ICON_SIZE_PATTERNS, legacy: ICON_SIZE_LEGACY }),
+    template: `
+      <div class="iconography-story">
+        <h2>Icon size pattern catalog</h2>
+        <table class="iconography-story-table">
+          <thead>
+            <tr>
+              <th>Pattern</th>
+              <th>Delegates to</th>
+              <th>px</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in patterns" :key="row.varName">
+              <td><code>{{ row.varName }}</code> (VtIcon <code>{{ row.name }}</code>)</td>
+              <td><code>{{ row.scaleVar }}</code></td>
+              <td>{{ row.px }}</td>
+            </tr>
+            <tr>
+              <td><code>{{ legacy.toggle.varName }}</code> (legacy)</td>
+              <td><code>{{ legacy.toggle.delegatesTo }}</code></td>
+              <td>{{ legacy.toggle.px }} → adoption: <code>{{ legacy.toggle.adoptionTarget }}</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    `,
+  }),
+};
+
+export const VtIconSizes: Story = {
+  name: "VtIcon sizes",
+  render: () => ({
+    components: { VtIcon, Search, SampleIcon },
+    setup: () => ({ sizes: VT_ICON_SIZES }),
+    template: `
+      <div class="iconography-story">
+        <h2>VtIcon</h2>
+        <p><code>size</code> is required. Decorative icons default to <code>aria-hidden="true"</code>.</p>
+        <div class="iconography-story-examples">
+          <div v-for="size in sizes" :key="size" class="iconography-story-example-block">
+            <h3>{{ size }}</h3>
+            <div class="iconography-story-inline">
+              <VtIcon :size="size"><Search /></VtIcon>
+              <span>Element Plus Search</span>
+            </div>
+            <div class="iconography-story-inline">
+              <VtIcon :size="size"><SampleIcon /></VtIcon>
+              <span>Custom SampleIcon</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const ColorRule: Story = {
+  name: "Icon color rule",
+  render: () => ({
+    components: { VtIcon, CaretRight },
+    template: `
+      <div class="iconography-story">
+        <h2>Icon color rule</h2>
+        <p>Icons use <code>currentColor</code>. Parent sets Neutral text tokens.</p>
+        <div class="iconography-story-color-swatch" style="color: var(--color-text-secondary)">
+          <VtIcon size="default"><CaretRight /></VtIcon>
+          <span>secondary (decorative)</span>
+        </div>
+        <div class="iconography-story-color-swatch" style="color: var(--color-text-primary)">
+          <VtIcon size="default"><CaretRight /></VtIcon>
+          <span>primary (hover / active parent)</span>
+        </div>
+        <div class="iconography-story-color-swatch" style="color: var(--color-text-muted)">
+          <VtIcon size="default"><CaretRight /></VtIcon>
+          <span>muted (disabled context)</span>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const NavigationGlyph: Story = {
+  name: "Navigation glyph (emoji)",
+  render: () => ({
+    template: `
+      <div class="iconography-story">
+        <h2>Navigation glyph</h2>
+        <p>Emoji keep intrinsic colors. Align size with <code>.nav-glyph-size-default</code> until SVG migration.</p>
+        <div class="iconography-story-nav-row">
+          <span class="nav-glyph-size-legacy" aria-hidden="true">🏠</span>
+          <span>Dashboard (legacy 14px — current sidebar)</span>
+        </div>
+        <div class="iconography-story-nav-row">
+          <span class="nav-glyph-size-default" aria-hidden="true">🏠</span>
+          <span>Dashboard (default 16px — adoption target)</span>
+        </div>
+        <div class="iconography-story-nav-row">
+          <span class="nav-glyph-size-compact" aria-hidden="true">📊</span>
+          <span>Activity (compact)</span>
+        </div>
+      </div>
+    `,
+  }),
+};

--- a/frontend/src/design/Iconography.stories.ts
+++ b/frontend/src/design/Iconography.stories.ts
@@ -27,13 +27,21 @@ export const Scale: Story = {
   name: "Icon size scale",
   render: () => ({
     components: { VtIcon, Search },
-    setup: () => ({ scale: ICON_SIZE_SCALE_PX }),
+    setup: () => {
+      const sizeByPx = Object.fromEntries(
+        ICON_SIZE_PATTERNS.map((pattern) => [pattern.px, pattern.name]),
+      ) as Record<
+        (typeof ICON_SIZE_SCALE_PX)[number],
+        (typeof ICON_SIZE_PATTERNS)[number]["name"]
+      >;
+      return { scale: ICON_SIZE_SCALE_PX, sizeByPx };
+    },
     template: `
       <div class="iconography-story">
         <h2>Icon size scale</h2>
         <p>Square slot via <code>font-size</code> on <code>VtIcon</code> / <code>el-icon</code>.</p>
         <div v-for="px in scale" :key="px" class="iconography-story-size-row">
-          <VtIcon :size="px === 12 ? 'compact' : px === 16 ? 'default' : px === 20 ? 'emphasis' : 'large'">
+          <VtIcon :size="sizeByPx[px]">
             <Search />
           </VtIcon>
           <span>--icon-size-{{ px }} · {{ px }}px</span>
@@ -111,15 +119,15 @@ export const ColorRule: Story = {
       <div class="iconography-story">
         <h2>Icon color rule</h2>
         <p>Icons use <code>currentColor</code>. Parent sets Neutral text tokens.</p>
-        <div class="iconography-story-color-swatch" style="color: var(--color-text-secondary)">
+        <div class="iconography-story-color-swatch iconography-story-color--secondary">
           <VtIcon size="default"><CaretRight /></VtIcon>
           <span>secondary (decorative)</span>
         </div>
-        <div class="iconography-story-color-swatch" style="color: var(--color-text-primary)">
+        <div class="iconography-story-color-swatch iconography-story-color--primary">
           <VtIcon size="default"><CaretRight /></VtIcon>
           <span>primary (hover / active parent)</span>
         </div>
-        <div class="iconography-story-color-swatch" style="color: var(--color-text-muted)">
+        <div class="iconography-story-color-swatch iconography-story-color--muted">
           <VtIcon size="default"><CaretRight /></VtIcon>
           <span>muted (disabled context)</span>
         </div>

--- a/frontend/src/design/Iconography.stories.ts
+++ b/frontend/src/design/Iconography.stories.ts
@@ -5,7 +5,6 @@ import SampleIcon from "../icons/SampleIcon.vue";
 import {
   ICON_SIZE_LEGACY,
   ICON_SIZE_PATTERNS,
-  ICON_SIZE_SCALE_PX,
   VT_ICON_SIZES,
 } from "./iconTokens";
 import "./Iconography.stories.css";
@@ -27,24 +26,16 @@ export const Scale: Story = {
   name: "Icon size scale",
   render: () => ({
     components: { VtIcon, Search },
-    setup: () => {
-      const sizeByPx = Object.fromEntries(
-        ICON_SIZE_PATTERNS.map((pattern) => [pattern.px, pattern.name]),
-      ) as Record<
-        (typeof ICON_SIZE_SCALE_PX)[number],
-        (typeof ICON_SIZE_PATTERNS)[number]["name"]
-      >;
-      return { scale: ICON_SIZE_SCALE_PX, sizeByPx };
-    },
+    setup: () => ({ patterns: ICON_SIZE_PATTERNS }),
     template: `
       <div class="iconography-story">
         <h2>Icon size scale</h2>
         <p>Square slot via <code>font-size</code> on <code>VtIcon</code> / <code>el-icon</code>.</p>
-        <div v-for="px in scale" :key="px" class="iconography-story-size-row">
-          <VtIcon :size="sizeByPx[px]">
+        <div v-for="pattern in patterns" :key="pattern.px" class="iconography-story-size-row">
+          <VtIcon :size="pattern.name">
             <Search />
           </VtIcon>
-          <span>--icon-size-{{ px }} · {{ px }}px</span>
+          <span>{{ pattern.scaleVar }} · {{ pattern.px }}px</span>
         </div>
       </div>
     `,

--- a/frontend/src/design/iconTokens.spec.ts
+++ b/frontend/src/design/iconTokens.spec.ts
@@ -47,6 +47,14 @@ describe("iconTokens", () => {
 
   it("documents legacy toggle size for v1 visual policy", () => {
     expect(ICON_SIZE_LEGACY.toggle.px).toBe(14);
+    expect(ICON_SIZE_LEGACY.toggle.delegatesTo).toBe("14px");
     expect(ICON_SIZE_LEGACY.toggle.adoptionTarget).toBe("--icon-size-default");
+  });
+
+  it("keeps pattern scale values on ICON_SIZE_SCALE_PX", () => {
+    const patternPx = ICON_SIZE_PATTERNS.map((pattern) => pattern.px);
+    expect([...new Set(patternPx)].sort((a, b) => a - b)).toEqual([
+      ...ICON_SIZE_SCALE_PX,
+    ]);
   });
 });

--- a/frontend/src/design/iconTokens.spec.ts
+++ b/frontend/src/design/iconTokens.spec.ts
@@ -31,6 +31,20 @@ describe("iconTokens", () => {
     ]);
   });
 
+  it("keeps each pattern name, varName, and px aligned", () => {
+    const pxByName = {
+      compact: 12,
+      default: 16,
+      emphasis: 20,
+      large: 24,
+    } as const;
+    for (const pattern of ICON_SIZE_PATTERNS) {
+      expect(pattern.px).toBe(pxByName[pattern.name]);
+      expect(pattern.varName).toBe(`--icon-size-${pattern.name}`);
+      expect(pattern.scaleVar).toBe(`--icon-size-${pattern.px}`);
+    }
+  });
+
   it("documents legacy toggle size for v1 visual policy", () => {
     expect(ICON_SIZE_LEGACY.toggle.px).toBe(14);
     expect(ICON_SIZE_LEGACY.toggle.adoptionTarget).toBe("--icon-size-default");

--- a/frontend/src/design/iconTokens.spec.ts
+++ b/frontend/src/design/iconTokens.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  ICON_SIZE_LEGACY,
+  ICON_SIZE_PATTERNS,
+  ICON_SIZE_SCALE_PX,
+  VT_ICON_SIZES,
+  iconSizeScaleVar,
+} from "./iconTokens";
+
+describe("iconTokens", () => {
+  it("defines the agreed icon size scale", () => {
+    expect([...ICON_SIZE_SCALE_PX]).toEqual([12, 16, 20, 24]);
+  });
+
+  it("maps scale px to CSS variable names", () => {
+    expect(iconSizeScaleVar(16)).toBe("--icon-size-16");
+  });
+
+  it("delegates each pattern to the matching scale token", () => {
+    for (const pattern of ICON_SIZE_PATTERNS) {
+      expect(pattern.scaleVar).toBe(`--icon-size-${pattern.px}`);
+    }
+  });
+
+  it("exposes VtIcon size props matching patterns", () => {
+    expect([...VT_ICON_SIZES]).toEqual([
+      "compact",
+      "default",
+      "emphasis",
+      "large",
+    ]);
+  });
+
+  it("documents legacy toggle size for v1 visual policy", () => {
+    expect(ICON_SIZE_LEGACY.toggle.px).toBe(14);
+    expect(ICON_SIZE_LEGACY.toggle.adoptionTarget).toBe("--icon-size-default");
+  });
+});

--- a/frontend/src/design/iconTokens.ts
+++ b/frontend/src/design/iconTokens.ts
@@ -47,17 +47,12 @@ export const ICON_SIZE_PATTERNS = [
   },
 ] as const satisfies readonly IconSizePattern[];
 
-/** VtIcon `size` prop values (1:1 with Icon size pattern names). */
-export const VT_ICON_SIZES = ICON_SIZE_PATTERNS.map(
-  (pattern) => pattern.name,
-) as unknown as readonly [
-  IconSizePatternName,
-  IconSizePatternName,
-  IconSizePatternName,
-  IconSizePatternName,
-];
-
 export type VtIconSize = IconSizePatternName;
+
+/** VtIcon `size` prop values (1:1 with Icon size pattern names). */
+export const VT_ICON_SIZES: readonly VtIconSize[] = ICON_SIZE_PATTERNS.map(
+  (pattern) => pattern.name,
+);
 
 /** Legacy icon size outside scale (v1 visual policy). */
 export const ICON_SIZE_LEGACY = {

--- a/frontend/src/design/iconTokens.ts
+++ b/frontend/src/design/iconTokens.ts
@@ -19,33 +19,25 @@ export type IconSizePattern = {
   scaleVar: ReturnType<typeof iconSizeScaleVar>;
 };
 
+const ICON_SIZE_PATTERN_SCALE = {
+  compact: 12,
+  default: 16,
+  emphasis: 20,
+  large: 24,
+} as const satisfies Record<IconSizePatternName, IconSizeScalePx>;
+
 /** Icon size pattern catalog (v1). Each pattern delegates to a scale token. */
-export const ICON_SIZE_PATTERNS = [
-  {
-    name: "compact",
-    varName: "--icon-size-compact",
-    px: 12,
-    scaleVar: iconSizeScaleVar(12),
-  },
-  {
-    name: "default",
-    varName: "--icon-size-default",
-    px: 16,
-    scaleVar: iconSizeScaleVar(16),
-  },
-  {
-    name: "emphasis",
-    varName: "--icon-size-emphasis",
-    px: 20,
-    scaleVar: iconSizeScaleVar(20),
-  },
-  {
-    name: "large",
-    varName: "--icon-size-large",
-    px: 24,
-    scaleVar: iconSizeScaleVar(24),
-  },
-] as const satisfies readonly IconSizePattern[];
+export const ICON_SIZE_PATTERNS = (
+  Object.entries(ICON_SIZE_PATTERN_SCALE) as [
+    IconSizePatternName,
+    IconSizeScalePx,
+  ][]
+).map(([name, px]) => ({
+  name,
+  varName: `--icon-size-${name}`,
+  px,
+  scaleVar: iconSizeScaleVar(px),
+})) satisfies readonly IconSizePattern[];
 
 export type VtIconSize = IconSizePatternName;
 
@@ -58,7 +50,7 @@ export const VT_ICON_SIZES: readonly VtIconSize[] = ICON_SIZE_PATTERNS.map(
 export const ICON_SIZE_LEGACY = {
   toggle: {
     varName: "--icon-size-legacy-toggle",
-    delegatesTo: "--font-size-14",
+    delegatesTo: "14px",
     px: 14,
     adoptionTarget: "--icon-size-default",
   },

--- a/frontend/src/design/iconTokens.ts
+++ b/frontend/src/design/iconTokens.ts
@@ -19,25 +19,22 @@ export type IconSizePattern = {
   scaleVar: ReturnType<typeof iconSizeScaleVar>;
 };
 
-const ICON_SIZE_PATTERN_SCALE = {
-  compact: 12,
-  default: 16,
-  emphasis: 20,
-  large: 24,
-} as const satisfies Record<IconSizePatternName, IconSizeScalePx>;
+const ICON_SIZE_PATTERN_ENTRIES = [
+  ["compact", 12],
+  ["default", 16],
+  ["emphasis", 20],
+  ["large", 24],
+] as const satisfies readonly [IconSizePatternName, IconSizeScalePx][];
 
 /** Icon size pattern catalog (v1). Each pattern delegates to a scale token. */
-export const ICON_SIZE_PATTERNS = (
-  Object.entries(ICON_SIZE_PATTERN_SCALE) as [
-    IconSizePatternName,
-    IconSizeScalePx,
-  ][]
-).map(([name, px]) => ({
-  name,
-  varName: `--icon-size-${name}`,
-  px,
-  scaleVar: iconSizeScaleVar(px),
-})) satisfies readonly IconSizePattern[];
+export const ICON_SIZE_PATTERNS = ICON_SIZE_PATTERN_ENTRIES.map(
+  ([name, px]) => ({
+    name,
+    varName: `--icon-size-${name}`,
+    px,
+    scaleVar: iconSizeScaleVar(px),
+  }),
+) satisfies readonly IconSizePattern[];
 
 export type VtIconSize = IconSizePatternName;
 

--- a/frontend/src/design/iconTokens.ts
+++ b/frontend/src/design/iconTokens.ts
@@ -1,0 +1,70 @@
+/** Icon size scale px values (ADR 0023). */
+export const ICON_SIZE_SCALE_PX = [12, 16, 20, 24] as const;
+
+export type IconSizeScalePx = (typeof ICON_SIZE_SCALE_PX)[number];
+
+/** CSS custom property for a numeric icon size step, e.g. `--icon-size-16`. */
+export function iconSizeScaleVar(
+  px: IconSizeScalePx,
+): `--icon-size-${IconSizeScalePx}` {
+  return `--icon-size-${px}`;
+}
+
+export type IconSizePatternName = "compact" | "default" | "emphasis" | "large";
+
+export type IconSizePattern = {
+  name: IconSizePatternName;
+  varName: `--icon-size-${IconSizePatternName}`;
+  px: IconSizeScalePx;
+  scaleVar: ReturnType<typeof iconSizeScaleVar>;
+};
+
+/** Icon size pattern catalog (v1). Each pattern delegates to a scale token. */
+export const ICON_SIZE_PATTERNS = [
+  {
+    name: "compact",
+    varName: "--icon-size-compact",
+    px: 12,
+    scaleVar: iconSizeScaleVar(12),
+  },
+  {
+    name: "default",
+    varName: "--icon-size-default",
+    px: 16,
+    scaleVar: iconSizeScaleVar(16),
+  },
+  {
+    name: "emphasis",
+    varName: "--icon-size-emphasis",
+    px: 20,
+    scaleVar: iconSizeScaleVar(20),
+  },
+  {
+    name: "large",
+    varName: "--icon-size-large",
+    px: 24,
+    scaleVar: iconSizeScaleVar(24),
+  },
+] as const satisfies readonly IconSizePattern[];
+
+/** VtIcon `size` prop values (1:1 with Icon size pattern names). */
+export const VT_ICON_SIZES = ICON_SIZE_PATTERNS.map(
+  (pattern) => pattern.name,
+) as unknown as readonly [
+  IconSizePatternName,
+  IconSizePatternName,
+  IconSizePatternName,
+  IconSizePatternName,
+];
+
+export type VtIconSize = IconSizePatternName;
+
+/** Legacy icon size outside scale (v1 visual policy). */
+export const ICON_SIZE_LEGACY = {
+  toggle: {
+    varName: "--icon-size-legacy-toggle",
+    delegatesTo: "--font-size-14",
+    px: 14,
+    adoptionTarget: "--icon-size-default",
+  },
+} as const;

--- a/frontend/src/design/iconTokens.ts
+++ b/frontend/src/design/iconTokens.ts
@@ -4,9 +4,9 @@ export const ICON_SIZE_SCALE_PX = [12, 16, 20, 24] as const;
 export type IconSizeScalePx = (typeof ICON_SIZE_SCALE_PX)[number];
 
 /** CSS custom property for a numeric icon size step, e.g. `--icon-size-16`. */
-export function iconSizeScaleVar(
-  px: IconSizeScalePx,
-): `--icon-size-${IconSizeScalePx}` {
+export function iconSizeScaleVar<const P extends IconSizeScalePx>(
+  px: P,
+): `--icon-size-${P}` {
   return `--icon-size-${px}`;
 }
 

--- a/frontend/src/icons/SampleIcon.vue
+++ b/frontend/src/icons/SampleIcon.vue
@@ -1,0 +1,11 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+  >
+    <path
+      d="M12 2a1 1 0 0 1 .894.553l8 16A1 1 0 0 1 20 20H4a1 1 0 0 1-.894-1.447l8-16A1 1 0 0 1 12 2zm0 4.236L6.618 18h10.764L12 6.236zM11 10h2v5h-2v-5zm0 6h2v2h-2v-2z"
+    />
+  </svg>
+</template>

--- a/frontend/src/icons/SampleIcon.vue
+++ b/frontend/src/icons/SampleIcon.vue
@@ -4,7 +4,6 @@
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     fill="currentColor"
-    aria-hidden="true"
   >
     <path
       d="M12 2a1 1 0 0 1 .894.553l8 16A1 1 0 0 1 20 20H4a1 1 0 0 1-.894-1.447l8-16A1 1 0 0 1 12 2zm0 4.236L6.618 18h10.764L12 6.236zM11 10h2v5h-2v-5zm0 6h2v2h-2v-2z"

--- a/frontend/src/icons/SampleIcon.vue
+++ b/frontend/src/icons/SampleIcon.vue
@@ -1,8 +1,10 @@
+<!-- Storybook-only placeholder for Custom icon component procedure (ADR 0023). -->
 <template>
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     fill="currentColor"
+    aria-hidden="true"
   >
     <path
       d="M12 2a1 1 0 0 1 .894.553l8 16A1 1 0 0 1 20 20H4a1 1 0 0 1-.894-1.447l8-16A1 1 0 0 1 12 2zm0 4.236L6.618 18h10.764L12 6.236zM11 10h2v5h-2v-5zm0 6h2v2h-2v-2z"


### PR DESCRIPTION
## Summary
- Add ADR 0023 and CONTEXT glossary for Iconography (UI icon, navigation glyph, domain icon).
- Introduce icon size tokens (12/16/20/24), `VtIcon` wrapper, `iconTokens.ts`, and Storybook catalog.
- Tokenize shared toggle icon sizing via legacy 14px derivative without changing on-screen appearance.

## Test plan
- [x] `make fmt`
- [x] `make test` (frontend Vitest includes VtIcon + iconTokens)
- [ ] `make lint` (blocked by missing `frontend/dist` in this worktree)
- [ ] Storybook: Design System / Iconography stories


Made with [Cursor](https://cursor.com)