### PR TITLE
feat(frontend): apply design system across all views (ADR 0024)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -708,9 +708,13 @@ _Avoid_: 常時実行, バックグラウンドサービス（v1 で含意しな
 
 ## Design system
 
-ボタン様式・余白・色・タイポグラフィ・アイコン・フォーム入力部品などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。**Form control** ラッパー（VtInput / VtSelect / VtCheckbox / VtSwitch）は grill-with-docs で合意済み（[ADR 0021](docs/adr/0021-form-control-design-system.md)）。**Feedback & Badges**（Alert / Toast / Badge / Loading の横断チャネル）は grill-with-docs で合意済み（[ADR 0022](docs/adr/0022-feedback-badges-design-system.md)）。**Iconography**（アイコン・グリフのサイズ・色・部品化）（[ADR 0023](docs/adr/0023-iconography-design-system.md)）は grill-with-docs で合意済み。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
+ボタン様式・余白・色・タイポグラフィ・アイコン・フォーム入力部品などアプリ横断 UI 部品の用語。**VtButton** と 4 **Button variant**（[ADR 0017](docs/adr/0017-button-design-system-vtbutton.md)）は grill-with-docs で合意済み。**Spacing**（余白ルール）（[ADR 0018](docs/adr/0018-spacing-design-system.md)）は grill-with-docs で合意済み。**Color**（カラーパレット）（[ADR 0019](docs/adr/0019-color-design-system.md)）は grill-with-docs で合意済み。**Typography**（タイポグラフィ）（[ADR 0020](docs/adr/0020-typography-design-system.md)）は grill-with-docs で合意済み。**Form control** ラッパー（VtInput / VtSelect / VtCheckbox / VtSwitch）は grill-with-docs で合意済み（[ADR 0021](docs/adr/0021-form-control-design-system.md)）。**Feedback & Badges**（Alert / Toast / Badge / Loading の横断チャネル）は grill-with-docs で合意済み（[ADR 0022](docs/adr/0022-feedback-badges-design-system.md)）。**Iconography**（アイコン・グリフのサイズ・色・部品化）（[ADR 0023](docs/adr/0023-iconography-design-system.md)）は grill-with-docs で合意済み。既存画面への一括適用は **Bulk design-system adoption campaign**（[ADR 0024](docs/adr/0024-bulk-design-system-adoption-campaign.md)）で行う。実装契約は各 ADR を正本とする。色コード・hex 値・個別 props など実装詳細はここに書かない。
 
 ### Language
+
+**Bulk design-system adoption campaign**:
+既存の全 View と関連共有 UI に、Design system 全層（Button / Form / Feedback / Color / Spacing / Typography / Iconography）を意図的に一括適用する期間限定の作業。ADR 0017–0023 の「触ったところから順次・一括置換しない」adoption の **例外**。通常の機能 PR では引き続き触ったファイルだけ寄せる。ESLint 強制・Sidebar 絵文字の SVG 化・Domain badge / Semantic button の無理な Vt* 化・レイアウトリデザインは含めない。完了条件と対象外は [ADR 0024](docs/adr/0024-bulk-design-system-adoption-campaign.md)。
+_Avoid_: 全面置換（通常 adoption の常時方針と混同するため）, Design system v1 deliverables（トークン／ラッパー初回届けと混同するため）
 
 **VtButton**:
 VRCTweaker の標準操作ボタンコンポーネント。画面に置く **Primary / Secondary / Tertiary / Danger** は VtButton の `variant` で指定する（**必須**。省略時の暗黙既定は持たない）。`el-button` の直接利用は新規・改修時に VtButton へ寄せる。**Semantic button** は VtButton の variant に含めない（専用 UI を別に持つ）。

--- a/docs/adr/0024-bulk-design-system-adoption-campaign.md
+++ b/docs/adr/0024-bulk-design-system-adoption-campaign.md
@@ -1,0 +1,77 @@
+# ADR 0024: Bulk design-system adoption campaign
+
+## Status
+
+Accepted（Done）
+
+## Context
+
+- Design system の正本（[ADR 0017](0017-button-design-system-vtbutton.md)–[0023](0023-iconography-design-system.md)）と Vt* / トークン / Storybook は揃っている
+- 各 ADR の adoption 方針は「新規・改修で触ったファイルから順次。一括置換しない」
+- 既存 View / 共有 UI には `el-button` / Form 直書き / `ElMessage` / レガシー CSS が残っており、画面間の一貫性が低い
+- 意図的に全画面・全層を一度に寄せるキャンペーンを行う
+
+用語は [`CONTEXT.md`](../../CONTEXT.md) の **Design system** 節および本 ADR の **Bulk design-system adoption campaign** を正本とする。
+
+## Decision
+
+### 1. キャンペーン範囲
+
+| 含む | 含まない |
+|------|----------|
+| 全 View と関連共有 UI コンポーネント | ESLint による `el-*` / `ElMessage` 禁止 |
+| Button / Form / Feedback / Color / Spacing / Typography / Iconography の全層 | Sidebar 絵文字の SVG 化 |
+| 画面グループ単位の複数 PR | レイアウトリデザイン・機能追加 |
+| | Domain badge（`VrcStatusTag` / `VrcUserTagChip`）の VtTag 化 |
+| | Semantic button（Presence 色ボタン）の VtButton 化 |
+| | TitleBar ウィンドウクローム固有サイズの強制トークン化 |
+
+本キャンペーンは ADR 0017–0023 の「一括置換しない」adoption 方針の **意図的な例外**である。通常の機能 PR では引き続き「触ったところから」を適用する。
+
+### 2. 置換対応
+
+| 現行 | 寄せ先 |
+|------|--------|
+| `el-button` | **VtButton**（`variant` 必須） |
+| `el-input` / `el-select` / `el-checkbox` / `el-switch` | **VtInput** / **VtSelect** / **VtCheckbox** / **VtSwitch** |
+| `el-alert` | **VtAlert** |
+| 汎用 `el-tag` | **VtTag**（Domain badge 除く） |
+| `ElMessage.*` | **showToast** |
+| `ElMessageBox` の confirm/cancel class | `VT_BUTTON_DANGER_CONFIRM_CLASS` / `VT_BUTTON_SECONDARY_CANCEL_CLASS` |
+| rem / hex / レガシー色変数 | `--space-*` / `--color-*` / `--font-*` / `--icon-*` |
+| `<el-icon>` / 素のアイコン寸法 | **VtIcon** + icon size token |
+
+Spacing / Typography / Icon のスケール外値は四捨五入で最寄り段階へ。Color は値を変えず参照名のみ。
+
+### 3. PR 単位
+
+1 PR = 対象画面（と直結コンポーネント）の **全層**適用。層ごと横断置換はしない。
+
+### 4. 完了条件（ゲート）
+
+対象外を除き、Views + 共有 UI で次が残っていないこと。
+
+- テンプレートの `el-button` / `el-input` / `el-select` / `el-checkbox` / `el-switch` / `el-alert` / 汎用 `el-tag`
+- 本番の `ElMessage.success|error|warning|info` 直叩き（`showToast` 実装・テスト除く）
+- scoped のレガシー `--accent` / `--bg-primary` 等の参照（`:root` alias 定義は残してよい）
+- スケール外の余白・font-size・icon 辺長の直書き（TitleBar クローム等の明示除外を除く）
+
+完了後、本 ADR の Status を **Accepted（Done）** に更新する。
+
+## Consequences
+
+- レビュー負荷が高いため画面グループ分割が必須
+- DOM は多くが `.el-*` のままなので E2E は比較的安定するが、コンポーネント名アサーションは要確認
+- 通常 adoption 文言と矛盾しないよう、CONTEXT に本キャンペーン用語を置く
+
+## Completion notes（Done）
+
+意図的に残した例外（ゲート対象外）:
+
+- **Semantic button**: `PresenceChangeSection` の Presence 色 `el-button`
+- **UI mode toggle**: `FriendsViewToolbar` の Online/Offline `el-switch`
+- **`el-checkbox-group`**: Automation 曜日選択のグループラッパー（子は `VtCheckbox`）
+- **未整備 EP**: `el-input-number` / `el-slider` / `el-date-picker` / `el-progress` / `el-autocomplete` / `el-radio-*` / `el-table` / `el-card` / `el-form*` 等
+- **Domain badge**: `VrcStatusTag` / `VrcUserTagChip`
+- **TitleBar** クローム固有寸法、**Sidebar** 絵文字（サイズトークンのみ）
+- **レイアウト sizing**（`max-width: Nrem` 等）は Spacing 対象外として残存可

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -372,7 +372,7 @@ a:hover {
 
 .section-card__toggle-icon {
   flex-shrink: 0;
-  font-size: var(--icon-size-legacy-toggle);
+  font-size: var(--icon-size-default);
 }
 
 .section-card.section-card--collapsed > .el-card__body {

--- a/frontend/src/components/CollapsibleSectionCard.vue
+++ b/frontend/src/components/CollapsibleSectionCard.vue
@@ -12,10 +12,14 @@
         :aria-controls="panelId"
         @click="toggle"
       >
-        <el-icon class="section-card__toggle-icon" aria-hidden="true">
+        <VtIcon
+          size="default"
+          class="section-card__toggle-icon"
+          aria-hidden="true"
+        >
           <CaretBottom v-if="expanded" />
           <CaretRight v-else />
-        </el-icon>
+        </VtIcon>
         <span class="section-card__toggle-label">
           <slot name="title">{{ title }}</slot>
         </span>
@@ -33,6 +37,7 @@ let nextCollapsibleSectionId = 0;
 
 <script setup lang="ts">
 import { CaretBottom, CaretRight } from "@element-plus/icons-vue";
+import VtIcon from "./VtIcon.vue";
 
 defineOptions({ name: "CollapsibleSectionCard" });
 

--- a/frontend/src/components/CookieLinkageSection.vue
+++ b/frontend/src/components/CookieLinkageSection.vue
@@ -10,35 +10,27 @@
         {{ t("video.cookieLinkage.section") }}
       </h2>
       <div class="cookie-alerts">
-        <el-alert
+        <VtAlert
           v-if="cookieActionError"
+          variant="danger"
           :title="cookieActionError"
-          type="error"
-          :closable="false"
-          show-icon
           class="cookie-action-error"
         />
-        <el-alert
-          type="warning"
-          :closable="false"
-          show-icon
+        <VtAlert
+          variant="warning"
           class="cookie-always-warn"
           :title="t('video.cookieLinkage.alwaysWarn')"
         />
-        <el-alert
+        <VtAlert
           v-if="!toolsEffectiveOfficial"
-          type="info"
-          :closable="false"
-          show-icon
+          variant="info"
           class="cookie-official-hint"
           data-testid="video-cookie-official-hint"
           :title="t('video.cookieLinkage.officialHint')"
         />
-        <el-alert
+        <VtAlert
           v-if="cookieSourceKind === 'unsupported'"
-          type="warning"
-          :closable="false"
-          show-icon
+          variant="warning"
           :title="t('video.cookieLinkage.unsupportedForm')"
         />
       </div>
@@ -49,7 +41,7 @@
             t("video.cookieLinkage.lockHint")
           }}</el-text>
         </div>
-        <el-switch
+        <VtSwitch
           v-model="cookieEnabled"
           class="cookie-switch"
           data-testid="video-cookie-enable"
@@ -77,7 +69,7 @@
           v-if="cookieDraftSource === 'browser'"
           :label="t('video.cookieLinkage.browserLabel')"
         >
-          <el-select
+          <VtSelect
             v-model="cookieDraftBrowser"
             data-testid="video-cookie-browser"
             :disabled="cookieBusy"
@@ -86,34 +78,33 @@
             <el-option value="chrome" label="Chrome" />
             <el-option value="edge" label="Edge" />
             <el-option value="firefox" label="Firefox" />
-          </el-select>
+          </VtSelect>
         </el-form-item>
         <el-form-item v-else :label="t('video.cookieLinkage.cookiesFileLabel')">
           <div class="path-input-group">
-            <el-input
+            <VtInput
               v-model="cookieDraftCookiesPath"
               data-testid="video-cookie-file-path"
               :placeholder="t('video.cookieLinkage.cookiesFilePh')"
               :disabled="cookieBusy"
               @change="onCookiePathChange"
             />
-            <el-button
+            <VtButton
+              variant="secondary"
               data-testid="video-cookie-file-browse"
               :disabled="cookieBusy"
               @click="browseCookieFile"
             >
               {{ t("video.cookieLinkage.browse") }}
-            </el-button>
+            </VtButton>
           </div>
         </el-form-item>
       </el-form>
     </template>
-    <el-alert
+    <VtAlert
       v-else-if="cookieActionError"
+      variant="danger"
       :title="cookieActionError"
-      type="error"
-      :closable="false"
-      show-icon
       class="cookie-action-error cookie-unsupported-error"
     />
   </section>
@@ -123,6 +114,15 @@
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { ElMessageBox } from "element-plus";
+import VtAlert from "./VtAlert.vue";
+import VtButton from "./VtButton.vue";
+import VtInput from "./VtInput.vue";
+import VtSelect from "./VtSelect.vue";
+import VtSwitch from "./VtSwitch.vue";
+import {
+  VT_BUTTON_DANGER_CONFIRM_CLASS,
+  VT_BUTTON_SECONDARY_CANCEL_CLASS,
+} from "./vtButtonClasses";
 import { App, type CookieLinkageStatusDTO } from "../wails/app";
 import { cookieLinkageErrorI18nKey } from "../views/cookieLinkageErrors";
 
@@ -217,6 +217,8 @@ async function ensureCookieRiskAck(gen: number): Promise<boolean> {
       confirmButtonText: t("video.cookieLinkage.riskAckConfirm"),
       cancelButtonText: t("common.cancel"),
       type: "warning",
+      confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
+      cancelButtonClass: VT_BUTTON_SECONDARY_CANCEL_CLASS,
     },
   );
   if (isCookieViewStale(gen)) return false;
@@ -390,23 +392,23 @@ onMounted(async () => {
 
 <style scoped>
 .cookie-section {
-  margin-top: 1.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--border);
+  margin-top: var(--space-section);
+  padding-top: var(--space-form-field);
+  border-top: 1px solid var(--color-border);
   width: 100%;
 }
 .video-block-title {
-  margin: 0 0 0.75rem;
-  font-size: 1rem;
-  font-weight: 600;
+  margin: 0 0 var(--space-form-field);
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-600);
 }
 .cookie-alerts {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-form-field);
 }
-.cookie-alerts .el-alert {
-  margin-bottom: 0.75rem;
+.cookie-alerts :deep(.el-alert) {
+  margin-bottom: var(--space-form-field);
 }
-.cookie-alerts .el-alert:last-child {
+.cookie-alerts :deep(.el-alert:last-child) {
   margin-bottom: 0;
 }
 .cookie-unsupported-error {
@@ -415,8 +417,8 @@ onMounted(async () => {
 .cookie-switch-row {
   display: flex;
   align-items: flex-start;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-block);
+  margin-bottom: var(--space-action-group);
 }
 .cookie-toggle-label {
   flex: 1;
@@ -424,18 +426,18 @@ onMounted(async () => {
 }
 .block-hint {
   display: block;
-  margin-top: 0.35rem;
+  margin-top: var(--space-inline-tight);
 }
 .cookie-switch {
   flex-shrink: 0;
-  margin-top: 0.15rem;
+  margin-top: var(--space-inline-tight);
 }
 .cookie-form {
-  margin-top: 0.75rem;
+  margin-top: var(--space-form-field);
 }
 .path-input-group {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   align-items: center;
   flex-wrap: wrap;
   width: 100%;
@@ -445,6 +447,6 @@ onMounted(async () => {
   min-width: 0;
 }
 .hint {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 </style>

--- a/frontend/src/components/DashboardLaunchBlock.vue
+++ b/frontend/src/components/DashboardLaunchBlock.vue
@@ -6,7 +6,7 @@
   >
     <div
       v-if="loading"
-      class="launch-block-message"
+      class="launch-block-message text-body-sm"
       data-testid="launch-block-loading"
     >
       {{ t("dashboard.launchBlock.loading") }}
@@ -14,7 +14,7 @@
 
     <div
       v-else-if="loadError"
-      class="launch-block-message"
+      class="launch-block-message text-body-sm"
       data-testid="launch-block-load-error"
     >
       {{ t("dashboard.launchBlock.loadError") }}

--- a/frontend/src/components/DashboardLaunchBlock.vue
+++ b/frontend/src/components/DashboardLaunchBlock.vue
@@ -23,7 +23,7 @@
     <template v-else>
       <p
         v-if="isEmpty"
-        class="launch-block-empty"
+        class="launch-block-empty text-body-sm"
         data-testid="launch-block-empty-state"
       >
         {{ t("dashboard.launchBlock.emptyState") }}
@@ -37,7 +37,7 @@
       </p>
 
       <div class="launch-block-controls">
-        <el-select
+        <VtSelect
           v-model="selectedProfileId"
           class="launch-block-profile"
           data-testid="launch-block-profile-select"
@@ -50,13 +50,13 @@
             :label="p.name"
             :value="p.id"
           />
-        </el-select>
+        </VtSelect>
         <div
           class="launch-block-actions"
           :class="{ 'launch-block-actions--solo': !rejoin }"
         >
-          <el-button
-            type="primary"
+          <VtButton
+            variant="primary"
             class="launch-block-quick-btn"
             data-testid="launch-block-quick-btn"
             :disabled="isEmpty || !selectedProfileId || launching"
@@ -64,10 +64,10 @@
             @click="launchQuick"
           >
             {{ t("dashboard.launchBlock.quickLaunch") }}
-          </el-button>
-          <el-button
+          </VtButton>
+          <VtButton
             v-if="rejoin"
-            type="primary"
+            variant="secondary"
             class="launch-block-rejoin-btn"
             data-testid="launch-block-rejoin-btn"
             :disabled="
@@ -80,7 +80,7 @@
             @click="launchRejoin"
           >
             {{ rejoinButtonLabel }}
-          </el-button>
+          </VtButton>
         </div>
       </div>
     </template>
@@ -90,7 +90,8 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { ElMessage } from "element-plus";
+import VtButton from "./VtButton.vue";
+import VtSelect from "./VtSelect.vue";
 import {
   App,
   type DashboardLaunchBlockDTO,
@@ -99,6 +100,7 @@ import {
 } from "../wails/app";
 import { getRuntime } from "../wails/runtime";
 import { formatError } from "../utils/formatError";
+import { showToast } from "../utils/showToast";
 import { truncateRejoinWorldName } from "../utils/truncateText";
 
 const ACTIVITY_ENCOUNTERS_CHANGED_DEBOUNCE_MS = 400;
@@ -167,7 +169,7 @@ async function load(): Promise<void> {
       selectedProfileId.value = "";
       rejoin.value = null;
     } else {
-      ElMessage.warning(t("dashboard.launchBlock.refreshError"));
+      showToast.warning(t("dashboard.launchBlock.refreshError"));
     }
   } finally {
     inFlight = false;
@@ -197,7 +199,7 @@ async function launchQuick(): Promise<void> {
   try {
     await App.launchVRChat(selectedProfileId.value);
   } catch (e) {
-    ElMessage.error(formatError(e, t("dashboard.launchBlock.launchError")));
+    showToast.error(formatError(e, t("dashboard.launchBlock.launchError")));
   } finally {
     launching.value = false;
   }
@@ -210,7 +212,7 @@ async function launchRejoin(): Promise<void> {
   try {
     await App.instanceRejoin(selectedProfileId.value, playSessionId);
   } catch (e) {
-    ElMessage.error(formatError(e, t("dashboard.launchBlock.rejoinError")));
+    showToast.error(formatError(e, t("dashboard.launchBlock.rejoinError")));
     void load();
   } finally {
     launching.value = false;
@@ -240,26 +242,24 @@ onUnmounted(() => {
 
 <style scoped>
 .dashboard-launch-block {
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .launch-block-message,
 .launch-block-empty {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  margin: 0 0 0.75rem;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-form-field);
 }
 
 .launch-block-launcher-link {
-  margin-left: 0.35rem;
+  margin-left: var(--space-inline-tight);
 }
 
 .launch-block-controls {
-  --launch-block-gap: 0.5rem;
   display: flex;
   flex-direction: column;
-  gap: var(--launch-block-gap);
+  gap: var(--space-action-group);
 }
 
 .launch-block-profile {
@@ -268,7 +268,7 @@ onUnmounted(() => {
 
 .launch-block-actions {
   display: flex;
-  gap: var(--launch-block-gap);
+  gap: var(--space-action-group);
   width: 100%;
 }
 

--- a/frontend/src/components/EncounterHistoryList.vue
+++ b/frontend/src/components/EncounterHistoryList.vue
@@ -2,13 +2,7 @@
   <div class="encounter-history-list">
     <template v-if="canLoad">
       <div v-if="loading" class="message">{{ t("common.loading") }}</div>
-      <el-alert
-        v-else-if="error"
-        :title="error"
-        type="error"
-        :closable="false"
-        show-icon
-      />
+      <VtAlert v-else-if="error" variant="danger" :title="error" />
       <div v-else-if="rows.length === 0" class="message">
         {{ t("encounterHistory.empty") }}
       </div>
@@ -59,6 +53,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
+import VtAlert from "./VtAlert.vue";
 import { App, type UserEncounterDTO } from "../wails/app";
 import { formatEncounteredAt } from "../utils/formatEncounteredAt";
 import { appLocaleToBcp47 } from "../i18n";
@@ -130,19 +125,19 @@ watch(
 .encounter-history-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   min-height: 0;
 }
 
 .message {
-  padding: 1rem;
+  padding: var(--space-block);
   text-align: center;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .mono {
   font-family: monospace;
-  font-size: 0.78rem;
+  font-size: var(--font-size-12);
   word-break: break-all;
 }
 </style>

--- a/frontend/src/components/PlayTimeChart.vue
+++ b/frontend/src/components/PlayTimeChart.vue
@@ -121,9 +121,9 @@ function draw(): void {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
   const { cssW, cssH, plotW, plotH, maxY } = L;
-  const textMuted = readCssVar("--text-secondary", "#a0a0a0");
-  const border = readCssVar("--border", "#333333");
-  const accent = readCssVar("--accent", "#5b9bd5");
+  const textMuted = readCssVar("--color-text-secondary", "#a0a0a0");
+  const border = readCssVar("--color-border", "#333333");
+  const accent = readCssVar("--color-brand", "#5b9bd5");
 
   ctx.clearRect(0, 0, cssW, cssH);
   if (props.series.length === 0) return;
@@ -280,11 +280,11 @@ onBeforeUnmount(() => {
   pointer-events: none;
   padding: 6px 8px;
   border-radius: 4px;
-  border: 1px solid var(--border, #333);
-  background: var(--bg-tertiary, #1a1a1a);
-  color: var(--text-primary, #e0e0e0);
-  font-size: 12px;
-  line-height: 1.4;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-muted);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-12);
+  line-height: var(--line-height-normal);
   white-space: nowrap;
   z-index: 1;
 }

--- a/frontend/src/components/PlayTimeChart.vue
+++ b/frontend/src/components/PlayTimeChart.vue
@@ -284,7 +284,8 @@ onBeforeUnmount(() => {
   background: var(--color-bg-muted);
   color: var(--color-text-primary);
   font-size: var(--font-size-12);
-  line-height: var(--line-height-normal);
+  /* Preserve 1.4: Typography scale has 1.25/1.5/1.75 only; tip offset assumes ~1.4 */
+  line-height: 1.4;
   white-space: nowrap;
   z-index: 1;
 }

--- a/frontend/src/components/PresenceChangeSection.vue
+++ b/frontend/src/components/PresenceChangeSection.vue
@@ -5,14 +5,14 @@
     data-testid="presence-change-section"
   >
     <template #header>
-      <span class="presence-change-title">{{
+      <span class="presence-change-title text-body-sm">{{
         t("dashboard.presenceChange.title")
       }}</span>
     </template>
 
     <div
       v-if="loading"
-      class="presence-change-message"
+      class="presence-change-message text-body-sm"
       data-testid="presence-change-loading"
     >
       {{ t("dashboard.presenceChange.loading") }}
@@ -20,7 +20,7 @@
 
     <div
       v-else-if="loadError"
-      class="presence-change-message"
+      class="presence-change-message text-body-sm"
       data-testid="presence-change-load-error"
     >
       <p class="presence-change-error-text">
@@ -39,7 +39,7 @@
     <template v-else>
       <p
         v-if="!loggedIn"
-        class="presence-change-login-hint"
+        class="presence-change-login-hint text-body-sm"
         data-testid="presence-change-login-required"
       >
         {{ t("dashboard.presenceChange.loginRequired") }}
@@ -103,10 +103,10 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { ElMessage } from "element-plus";
 import { App, type PresenceChangeSectionDTO } from "../wails/app";
 import { getRuntime } from "../wails/runtime";
 import { formatError } from "../utils/formatError";
+import { showToast } from "../utils/showToast";
 import { useSessionUnlock } from "../composables/useSessionUnlock";
 import VtButton from "./VtButton.vue";
 
@@ -256,7 +256,7 @@ async function load(options?: LoadOptions): Promise<void> {
       loggedIn.value = false;
       history.value = [];
     } else {
-      ElMessage.warning(t("dashboard.presenceChange.refreshError"));
+      showToast.warning(t("dashboard.presenceChange.refreshError"));
     }
   } finally {
     inFlight = false;
@@ -324,10 +324,10 @@ async function applyPresenceChange(): Promise<void> {
       draftDescription.value,
     );
     syncSnapshotFromApply(result.status, result.statusDescription);
-    ElMessage.success(t("dashboard.presenceChange.applySuccess"));
+    showToast.success(t("dashboard.presenceChange.applySuccess"));
     void load({ skipSnapshotUpdate: true });
   } catch (e) {
-    ElMessage.error(formatError(e, t("dashboard.presenceChange.applyError")));
+    showToast.error(formatError(e, t("dashboard.presenceChange.applyError")));
   } finally {
     applying.value = false;
   }
@@ -362,35 +362,33 @@ onUnmounted(() => {
 
 <style scoped>
 .presence-change-section {
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .presence-change-title {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .presence-change-message,
 .presence-change-login-hint {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  margin: 0 0 0.75rem;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-form-field);
 }
 
 .presence-change-error-text {
-  margin: 0 0 0.5rem;
+  margin: 0 0 var(--space-action-group);
 }
 
 .presence-change-settings-link {
-  margin-left: 0.35rem;
+  margin-left: var(--space-inline-tight);
 }
 
 .presence-color-buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-inline-tight);
+  margin-bottom: var(--space-action-group);
 }
 
 .presence-color-buttons :deep(.el-button + .el-button) {
@@ -437,7 +435,7 @@ onUnmounted(() => {
 .presence-description-row {
   display: flex;
   flex-wrap: nowrap;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   align-items: center;
 }
 

--- a/frontend/src/components/ServerStatusSection.vue
+++ b/frontend/src/components/ServerStatusSection.vue
@@ -5,20 +5,23 @@
     data-testid="server-status-section"
   >
     <template #header>
-      <span class="server-status-title">{{
+      <span class="server-status-title text-body-sm">{{
         t("dashboard.serverStatus.title")
       }}</span>
     </template>
 
     <div
       v-if="loading"
-      class="server-status-message"
+      class="server-status-message text-body-sm"
       data-testid="server-status-loading"
     >
       {{ t("dashboard.serverStatus.loading") }}
     </div>
 
-    <div v-else-if="fetchState === 'unavailable'" class="server-status-message">
+    <div
+      v-else-if="fetchState === 'unavailable'"
+      class="server-status-message text-body-sm"
+    >
       {{ t("dashboard.serverStatus.fetchUnavailable") }}
     </div>
 
@@ -34,7 +37,7 @@
 
       <p
         v-if="fetchState === 'partial'"
-        class="server-status-message"
+        class="server-status-message text-body-sm"
         data-testid="server-status-detail-unavailable"
       >
         {{ t("dashboard.serverStatus.detailUnavailable") }}
@@ -48,7 +51,7 @@
         <li
           v-for="(row, idx) in componentRows"
           :key="`component-${idx}`"
-          class="server-status-detail-row"
+          class="server-status-detail-row text-body-sm"
           :class="row.colorClass"
         >
           <span class="server-status-dot" aria-hidden="true" />
@@ -58,14 +61,14 @@
         <li
           v-for="(headline, idx) in headlineRows"
           :key="`headline-${idx}`"
-          class="server-status-detail-row server-status-detail-headline"
+          class="server-status-detail-row server-status-detail-headline text-body-sm"
         >
           {{ headline }}
         </li>
       </ul>
 
       <a
-        class="server-status-link"
+        class="server-status-link text-caption"
         :href="statusPageUrl"
         target="_blank"
         rel="noopener noreferrer"
@@ -180,44 +183,41 @@ onUnmounted(() => {
 
 <style scoped>
 .server-status-panel {
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .server-status-title {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .server-status-summary {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
+  gap: var(--space-action-group);
+  font-weight: var(--font-weight-600);
+  margin-bottom: var(--space-action-group);
 }
 
 .server-status-message {
-  margin: 0 0 0.5rem;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
+  margin: 0 0 var(--space-action-group);
+  color: var(--color-text-secondary);
 }
 
 .server-status-detail {
   list-style: none;
-  margin: 0 0 0.75rem;
+  margin: 0 0 var(--space-form-field);
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--space-inline-tight);
 }
 
 .server-status-detail-row {
   display: flex;
   align-items: baseline;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   flex-wrap: wrap;
-  font-size: 0.9rem;
 }
 
 .server-status-detail-name {
@@ -226,25 +226,24 @@ onUnmounted(() => {
 }
 
 .server-status-detail-status {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   white-space: nowrap;
 }
 
 .server-status-detail-headline {
-  padding-left: 1.1rem;
-  color: var(--text-secondary);
+  padding-left: var(--space-block);
+  color: var(--color-text-secondary);
 }
 
 .server-status-dot {
-  width: 0.55rem;
-  height: 0.55rem;
+  width: var(--space-action-group);
+  height: var(--space-action-group);
   border-radius: 50%;
   flex-shrink: 0;
   background: currentColor;
 }
 
 .server-status-link {
-  font-size: 0.85rem;
   color: var(--color-brand);
 }
 

--- a/frontend/src/components/Sidebar.stories.ts
+++ b/frontend/src/components/Sidebar.stories.ts
@@ -34,7 +34,7 @@ export const Default: Story = {
   render: () => ({
     components: { Sidebar },
     template: `
-      <div style="height: 28rem; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden">
+      <div style="height: 28rem; border: 1px solid var(--color-border); border-radius: var(--radius); overflow: hidden">
         <Sidebar />
       </div>
     `,
@@ -46,7 +46,7 @@ export const ActiveActivity: Story = {
   render: () => ({
     components: { Sidebar },
     template: `
-      <div style="height: 28rem; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden">
+      <div style="height: 28rem; border: 1px solid var(--color-border); border-radius: var(--radius); overflow: hidden">
         <Sidebar />
       </div>
     `,

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -6,14 +6,14 @@
         :key="item.path"
         :index="item.path"
       >
-        <span class="sidebar-icon">{{ item.icon }}</span>
+        <span class="sidebar-icon nav-glyph-size-default">{{ item.icon }}</span>
         <template #title>{{ item.label }}</template>
       </el-menu-item>
     </el-menu>
     <div class="sidebar-footer">
       <el-menu :default-active="route.path" router class="sidebar-nav">
         <el-menu-item index="/settings">
-          <span class="sidebar-icon">⚙️</span>
+          <span class="sidebar-icon nav-glyph-size-default">⚙️</span>
           <template #title>{{ t("nav.settings") }}</template>
         </el-menu-item>
       </el-menu>
@@ -66,8 +66,8 @@ const menuItems = computed(() => {
 <style scoped>
 .sidebar {
   width: var(--sidebar-width);
-  background: var(--bg-secondary);
-  border-right: 1px solid var(--border);
+  background: var(--color-bg-elevated);
+  border-right: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -79,28 +79,27 @@ const menuItems = computed(() => {
 }
 
 .sidebar-nav :deep(.el-menu-item) {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   height: 42px;
   line-height: 42px;
 }
 
 .sidebar-nav :deep(.el-menu-item:hover),
 .sidebar-nav :deep(.el-menu-item.is-active) {
-  background: var(--bg-tertiary) !important;
-  color: var(--text-primary) !important;
+  background: var(--color-bg-muted) !important;
+  color: var(--color-text-primary) !important;
 }
 
 .sidebar-nav :deep(.el-menu-item.is-active) {
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--color-brand);
 }
 
 .sidebar-footer {
   margin-top: auto;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--color-border);
 }
 
 .sidebar-icon {
-  margin-right: 0.5rem;
-  font-size: 1rem;
+  margin-right: var(--space-action-group);
 }
 </style>

--- a/frontend/src/components/TitleBar.stories.ts
+++ b/frontend/src/components/TitleBar.stories.ts
@@ -18,7 +18,7 @@ export const Default: Story = {
   render: () => ({
     components: { TitleBar },
     template: `
-      <div style="max-width: 720px; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden">
+      <div style="max-width: 720px; border: 1px solid var(--color-border); border-radius: var(--radius); overflow: hidden">
         <TitleBar />
       </div>
     `,

--- a/frontend/src/components/TitleBar.vue
+++ b/frontend/src/components/TitleBar.vue
@@ -35,8 +35,8 @@ function close() {
   justify-content: space-between;
   height: 36px;
   padding: 0 0.5rem;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border);
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border);
   user-select: none;
   flex-shrink: 0;
 }
@@ -44,7 +44,7 @@ function close() {
 .title-bar-text {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .title-bar-actions {
@@ -57,7 +57,7 @@ function close() {
   height: 36px;
   border: none;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-size: 16px;
   line-height: 1;
   cursor: pointer;
@@ -67,12 +67,12 @@ function close() {
 }
 
 .title-bar-btn:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
+  background: var(--color-bg-muted);
+  color: var(--color-text-primary);
 }
 
 .title-bar-btn.close:hover {
-  background: var(--danger);
-  color: white;
+  background: var(--color-danger);
+  color: var(--color-text-inverse);
 }
 </style>

--- a/frontend/src/components/VrcUserCacheDetail.vue
+++ b/frontend/src/components/VrcUserCacheDetail.vue
@@ -49,12 +49,12 @@
             <div v-else class="profile-avatar profile-avatar--placeholder" />
           </div>
           <div v-if="variant !== 'self'" class="profile-toolbar-actions">
-            <el-checkbox
+            <VtCheckbox
               :model-value="selected.isFavorite"
               @update:model-value="onFavoriteUpdate"
             >
               {{ t("userDetail.favorite") }}
-            </el-checkbox>
+            </VtCheckbox>
           </div>
         </div>
       </div>
@@ -62,17 +62,17 @@
       <div class="profile-body">
         <div ref="nameAnchor" class="profile-name-row">
           <h2 class="profile-display-name">{{ selected.displayName }}</h2>
-          <el-button
+          <VtButton
+            variant="primary"
             link
-            type="primary"
             :title="t('userDetail.copyDisplayName')"
             :aria-label="t('userDetail.copyDisplayName')"
             data-testid="friend-copy-display-name"
             class="profile-copy-name"
             @click="copyDisplayName(selected.displayName)"
           >
-            <el-icon><CopyDocument /></el-icon>
-          </el-button>
+            <VtIcon size="default"><CopyDocument /></VtIcon>
+          </VtButton>
         </div>
         <p v-if="selected.username" class="profile-handle">
           @{{ selected.username }}
@@ -104,14 +104,14 @@
         >
           <el-tab-pane :label="t('userDetail.tabDetail')" name="detail">
             <div v-if="variant === 'self'" class="self-profile-actions">
-              <el-button
-                type="primary"
+              <VtButton
+                variant="primary"
                 data-testid="self-profile-refresh"
                 :loading="refreshLoading"
                 @click="emit('refresh')"
               >
                 {{ t("selfProfile.refresh") }}
-              </el-button>
+              </VtButton>
             </div>
             <el-descriptions :column="1" border size="small">
               <el-descriptions-item
@@ -276,6 +276,9 @@ import { useI18n } from "vue-i18n";
 import EncounterHistoryList from "./EncounterHistoryList.vue";
 import VrcStatusTag from "./VrcStatusTag.vue";
 import VrcUserTagChip from "./VrcUserTagChip.vue";
+import VtButton from "./VtButton.vue";
+import VtCheckbox from "./VtCheckbox.vue";
+import VtIcon from "./VtIcon.vue";
 import type { UserCacheDTO } from "../wails/app";
 import {
   copyDisplayName,
@@ -418,8 +421,8 @@ onUnmounted(() => {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .friend-detail-card :deep(.el-card__body) {
@@ -435,17 +438,17 @@ onUnmounted(() => {
   z-index: 20;
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: var(--space-action-group);
   box-sizing: border-box;
   max-height: 0;
   min-height: 0;
-  padding: 0 0.75rem;
+  padding: 0 var(--space-form-field);
   overflow: hidden;
-  border-bottom: 0 solid var(--border);
-  background: color-mix(in srgb, var(--bg-secondary) 92%, #000);
+  border-bottom: 0 solid var(--color-border);
+  background: color-mix(in srgb, var(--color-bg-elevated) 92%, #000);
   backdrop-filter: blur(6px);
   opacity: 0;
-  transform: translateY(-0.35rem);
+  transform: translateY(calc(-1 * var(--space-inline-tight)));
   pointer-events: none;
   transition:
     max-height 0.2s ease,
@@ -457,7 +460,7 @@ onUnmounted(() => {
 
 .detail-sticky-header.visible {
   max-height: 3.5rem;
-  padding: 0.55rem 0.75rem;
+  padding: var(--space-action-group) var(--space-form-field);
   border-bottom-width: 1px;
   opacity: 1;
   transform: translateY(0);
@@ -474,14 +477,14 @@ onUnmounted(() => {
 
 .detail-sticky-avatar--placeholder {
   background: var(--el-fill-color-light);
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
 }
 
 .detail-sticky-main {
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: var(--space-inline-tight);
 }
 
 .detail-sticky-name {
@@ -490,9 +493,9 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.92rem;
-  font-weight: 700;
-  color: var(--el-text-color-primary);
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-700);
+  color: var(--color-text-primary);
 }
 
 .profile-hero {
@@ -531,8 +534,8 @@ onUnmounted(() => {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0 1rem;
+  gap: var(--space-form-field);
+  padding: 0 var(--space-block);
   margin-top: -44px;
   position: relative;
   z-index: 1;
@@ -548,9 +551,9 @@ onUnmounted(() => {
   height: 88px;
   border-radius: 12px;
   object-fit: cover;
-  border: 3px solid var(--bg-secondary);
+  border: 3px solid var(--color-bg-elevated);
   box-sizing: border-box;
-  background: var(--bg-secondary);
+  background: var(--color-bg-elevated);
 }
 
 .profile-avatar--placeholder {
@@ -559,26 +562,26 @@ onUnmounted(() => {
 }
 
 .profile-toolbar-actions {
-  padding-bottom: 0.35rem;
+  padding-bottom: var(--space-inline-tight);
 }
 
 .profile-body {
-  padding: 0.65rem 1rem 1rem;
+  padding: var(--space-form-field) var(--space-block) var(--space-block);
 }
 
 .profile-name-row {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-inline-tight);
   flex-wrap: wrap;
 }
 
 .profile-display-name {
   margin: 0;
-  font-size: 1.25rem;
-  font-weight: 700;
-  line-height: 1.25;
-  color: var(--el-text-color-primary);
+  font-size: var(--font-size-20);
+  font-weight: var(--font-weight-700);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
 }
 
 .profile-copy-name {
@@ -586,35 +589,35 @@ onUnmounted(() => {
 }
 
 .profile-handle {
-  margin: 0.15rem 0 0;
-  font-size: 0.9rem;
-  color: var(--el-text-color-secondary);
+  margin: var(--space-inline-tight) 0 0;
+  font-size: var(--font-size-14);
+  color: var(--color-text-secondary);
 }
 
 .profile-status-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.35rem 0.5rem;
-  margin-top: 0.5rem;
+  gap: var(--space-inline-tight) var(--space-action-group);
+  margin-top: var(--space-action-group);
 }
 
 .profile-status-desc {
-  font-size: 0.85rem;
-  color: var(--el-text-color-regular);
+  font-size: var(--font-size-14);
+  color: var(--color-text-secondary);
 }
 
 .profile-bio {
-  margin: 0.75rem 0 0;
-  font-size: 0.9rem;
-  line-height: 1.45;
-  color: var(--el-text-color-primary);
+  margin: var(--space-form-field) 0 0;
+  font-size: var(--font-size-14);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-primary);
 }
 
 .profile-bio-links {
-  margin: 0.5rem 0 0;
-  padding-left: 1.1rem;
-  font-size: 0.9rem;
+  margin: var(--space-action-group) 0 0;
+  padding-left: var(--space-block);
+  font-size: var(--font-size-14);
 }
 
 .profile-bio-links a {
@@ -623,7 +626,7 @@ onUnmounted(() => {
 }
 
 .profile-details-wrap {
-  padding: 0 1rem 1rem;
+  padding: 0 var(--space-block) var(--space-block);
   min-height: 0;
 }
 
@@ -636,11 +639,11 @@ onUnmounted(() => {
 }
 
 .self-profile-actions {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-form-field);
 }
 
 .profile-detail-tabs :deep(.el-tabs__header) {
-  margin-bottom: 0.65rem;
+  margin-bottom: var(--space-form-field);
 }
 
 .profile-detail-tabs :deep(.el-tabs__content),
@@ -650,7 +653,7 @@ onUnmounted(() => {
 
 .mono {
   font-family: ui-monospace, monospace;
-  font-size: 0.85rem;
+  font-size: var(--font-size-14);
 }
 
 .wrap {

--- a/frontend/src/components/__tests__/DashboardLaunchBlock.spec.ts
+++ b/frontend/src/components/__tests__/DashboardLaunchBlock.spec.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createRouter, createMemoryHistory } from "vue-router";
-import { ElMessage, ElSelect } from "element-plus";
+import { ElSelect } from "element-plus";
 import DashboardLaunchBlock from "../DashboardLaunchBlock.vue";
 import type { LaunchProfileDTO } from "../../wails/app";
+import { showToast } from "../../utils/showToast";
 
 const {
   mockGetDashboardLaunchBlock,
@@ -172,11 +173,11 @@ describe("DashboardLaunchBlock", () => {
       },
     });
     mockGetDashboardLaunchBlock.mockRejectedValueOnce(new Error("db down"));
-    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+    const errorSpy = vi.spyOn(showToast, "error").mockImplementation(() => ({
       close: () => {},
     }));
     const warningSpy = vi
-      .spyOn(ElMessage, "warning")
+      .spyOn(showToast, "warning")
       .mockImplementation(() => ({
         close: () => {},
       }));
@@ -226,7 +227,7 @@ describe("DashboardLaunchBlock", () => {
 
   it("shows inline error on load failure without toast", async () => {
     mockGetDashboardLaunchBlock.mockRejectedValueOnce(new Error("db down"));
-    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+    const errorSpy = vi.spyOn(showToast, "error").mockImplementation(() => ({
       close: () => {},
     }));
     const consoleSpy = vi
@@ -325,7 +326,7 @@ describe("DashboardLaunchBlock", () => {
       rejoin: null,
     });
     mockLaunchVRChat.mockRejectedValueOnce(new Error("launch failed"));
-    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+    const errorSpy = vi.spyOn(showToast, "error").mockImplementation(() => ({
       close: () => {},
     }));
     const wrapper = mountBlock();
@@ -346,7 +347,7 @@ describe("DashboardLaunchBlock", () => {
       rejoin: { playSessionId: "ps-1", worldDisplayName: "" },
     });
     mockInstanceRejoin.mockRejectedValueOnce(new Error("rejoin failed"));
-    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+    const errorSpy = vi.spyOn(showToast, "error").mockImplementation(() => ({
       close: () => {},
     }));
     const wrapper = mountBlock();

--- a/frontend/src/components/__tests__/PresenceChangeSection.spec.ts
+++ b/frontend/src/components/__tests__/PresenceChangeSection.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises, type VueWrapper } from "@vue/test-utils";
-import { ElMessage } from "element-plus";
 import PresenceChangeSection from "../PresenceChangeSection.vue";
 import { unlockState } from "./sessionUnlockTestState";
+import { showToast } from "../../utils/showToast";
 
 const {
   mockGetPresenceChangeSection,
@@ -214,7 +214,7 @@ describe("PresenceChangeSection", () => {
 
   it("applies presence change and shows success message", async () => {
     const successSpy = vi
-      .spyOn(ElMessage, "success")
+      .spyOn(showToast, "success")
       .mockImplementation(() => ({ close: () => {} }));
     const wrapper = mountSection();
     await flushPromises();
@@ -232,7 +232,7 @@ describe("PresenceChangeSection", () => {
   it("shows error when apply fails", async () => {
     mockApplyPresenceChange.mockRejectedValueOnce(new Error("apply failed"));
     const errorSpy = vi
-      .spyOn(ElMessage, "error")
+      .spyOn(showToast, "error")
       .mockImplementation(() => ({ close: () => {} }));
     const wrapper = mountSection();
     await flushPromises();
@@ -249,7 +249,7 @@ describe("PresenceChangeSection", () => {
   it("shows warning when refresh fails after initial load", async () => {
     vi.useFakeTimers();
     const warnSpy = vi
-      .spyOn(ElMessage, "warning")
+      .spyOn(showToast, "warning")
       .mockImplementation(() => ({ close: () => {} }));
     mountSection();
     await flushPromises();

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -13,19 +13,19 @@
     >
       <!-- フィルタ -->
       <div class="filters">
-        <el-input
+        <VtInput
           v-model="displayNameFilter"
           :placeholder="t('activity.searchDisplayName')"
           clearable
           style="max-width: 220px"
         >
           <template #prefix>
-            <el-icon><Search /></el-icon>
+            <VtIcon size="default"><Search /></VtIcon>
           </template>
-        </el-input>
-        <el-button @click="refreshActivity(false)">{{
+        </VtInput>
+        <VtButton variant="tertiary" @click="refreshActivity(false)">{{
           t("common.refresh")
-        }}</el-button>
+        }}</VtButton>
       </div>
 
       <div class="encounter-log-scroll">
@@ -66,8 +66,10 @@
             <template #default="{ row }">
               <div class="encounter-name-cell">
                 <span class="encounter-friend-mark-slot">
-                  <el-icon
+                  <VtIcon
                     v-if="row.isListableFriend"
+                    size="compact"
+                    :decorative="false"
                     class="encounter-friend-mark"
                     data-testid="encounter-friend-mark"
                     role="img"
@@ -75,17 +77,17 @@
                     :aria-label="t('activity.friendMark')"
                   >
                     <UserFilled />
-                  </el-icon>
+                  </VtIcon>
                 </span>
-                <el-button
+                <VtButton
                   v-if="row.vrcUserId"
+                  variant="primary"
                   link
-                  type="primary"
                   class="timeline-link"
                   @click="openUserFromEncounter(row)"
                 >
                   {{ row.displayName }}
-                </el-button>
+                </VtButton>
                 <span v-else class="timeline-name-muted">{{
                   row.displayName
                 }}</span>
@@ -94,16 +96,16 @@
           </el-table-column>
           <el-table-column :label="t('activity.colWorldName')" min-width="120">
             <template #default="{ row }">
-              <el-button
+              <VtButton
                 v-if="row.worldId"
+                variant="primary"
                 link
-                type="primary"
                 class="timeline-link"
                 :title="row.worldId"
                 @click="openWorldHistory(row.worldId)"
               >
                 {{ row.worldDisplayName || row.worldId }}
-              </el-button>
+              </VtButton>
               <span v-else>{{ t("common.dash") }}</span>
             </template>
           </el-table-column>
@@ -132,6 +134,9 @@ import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import CollapsibleSectionCard from "../components/CollapsibleSectionCard.vue";
+import VtButton from "../components/VtButton.vue";
+import VtIcon from "../components/VtIcon.vue";
+import VtInput from "../components/VtInput.vue";
 import {
   App,
   type ActivityStatsDTO,
@@ -325,7 +330,7 @@ onUnmounted(() => {
 .activity-view {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--space-section);
   min-width: 0;
   width: 100%;
   min-height: 0;
@@ -338,17 +343,17 @@ onUnmounted(() => {
 }
 
 .section-card {
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
   width: 100%;
   min-width: 0;
   padding: 0;
 }
 
 .section-card :deep(.el-card__header) {
-  font-weight: 600;
-  border-bottom-color: var(--border);
-  color: var(--text-secondary);
+  font-weight: var(--font-weight-600);
+  border-bottom-color: var(--color-border);
+  color: var(--color-text-secondary);
 }
 
 /* プレイ時間カード全体の縦幅を固定（ヘッダー + グラフ 280px 相当の body） */
@@ -392,7 +397,7 @@ onUnmounted(() => {
 
 .section-card--playtime :deep(.el-card__body) .loading,
 .section-card--playtime :deep(.el-card__body) .empty-stats {
-  padding: 1rem;
+  padding: var(--space-block);
 }
 
 .section-card--encounters.section-card--collapsed {
@@ -434,22 +439,22 @@ onUnmounted(() => {
 
 .filters {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   align-items: center;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-action-group);
   flex-wrap: wrap;
   flex-shrink: 0;
 }
 
 .retention-hint {
-  margin: 0 0 1rem;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
+  margin: 0 0 var(--space-block);
+  font-size: var(--font-size-12);
+  color: var(--color-text-secondary);
   flex-shrink: 0;
 }
 
 .page-retention-hint {
-  margin-top: -0.75rem;
+  margin-top: calc(-1 * var(--space-form-field));
 }
 
 /* セクションカードの残り高さに合わせてスクロール（親チェーンに flex + min-height:0 あり） */
@@ -465,14 +470,14 @@ onUnmounted(() => {
 .loading,
 .empty,
 .empty-stats {
-  padding: 2rem;
+  padding: var(--space-page);
   text-align: center;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .timeline-time {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
+  font-size: var(--font-size-12);
+  color: var(--color-text-secondary);
 }
 
 .timeline-link {
@@ -484,28 +489,27 @@ onUnmounted(() => {
 }
 
 .timeline-name-muted {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .encounter-name-cell {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-inline-tight);
   max-width: 100%;
   min-width: 0;
 }
 
 .encounter-friend-mark-slot {
-  flex: 0 0 12px;
-  width: 12px;
-  height: 12px;
+  flex: 0 0 var(--icon-size-compact);
+  width: var(--icon-size-compact);
+  height: var(--icon-size-compact);
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 
 .encounter-friend-mark {
-  font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 </style>

--- a/frontend/src/views/AutomationView.vue
+++ b/frontend/src/views/AutomationView.vue
@@ -1,41 +1,44 @@
 <template>
   <div class="automation-view">
     <h1 class="page-title">{{ t("automation.title") }}</h1>
-    <el-alert
+    <VtAlert
       v-if="!runtime.available"
-      type="warning"
+      class="runtime-alert"
+      variant="warning"
       :title="t('automation.unavailableTitle')"
       :description="
         t(`automation.reason.${runtime.reasonKey || 'subsystemUnavailable'}`)
       "
-      show-icon
-      :closable="false"
-      style="margin-bottom: 1rem"
     />
-    <el-text
-      type="info"
-      size="small"
-      style="display: block; margin-bottom: 1rem"
-    >
+    <p class="text-body-sm automation-intro">
       {{ t("automation.intro") }}
-    </el-text>
-    <div
+    </p>
+    <VtAlert
       v-if="isDirty"
       class="unsaved-banner"
       data-testid="unsaved-banner"
+      variant="warning"
       :title="t('automation.unsavedBanner')"
-    >
-      {{ t("automation.unsavedBanner") }}
-    </div>
+    />
 
     <div class="automation-layout">
       <div class="items-list">
-        <el-button class="btn-add" data-testid="add-rule" @click="addRule">
+        <VtButton
+          variant="secondary"
+          class="btn-add"
+          data-testid="add-rule"
+          @click="addRule"
+        >
           {{ t("automation.addRule") }}
-        </el-button>
-        <el-button class="btn-add" data-testid="add-script" @click="addScript">
+        </VtButton>
+        <VtButton
+          variant="secondary"
+          class="btn-add"
+          data-testid="add-script"
+          @click="addScript"
+        >
           {{ t("automation.addScript") }}
-        </el-button>
+        </VtButton>
         <div
           v-for="item in items"
           :key="item.id"
@@ -49,7 +52,7 @@
           <div class="rule-header">
             <span class="rule-name">{{ item.name }}</span>
             <div class="toggle-wrap" @click.stop>
-              <el-switch
+              <VtSwitch
                 :model-value="item.isEnabled"
                 size="small"
                 @change="(v: boolean) => toggleItem(item, v)"
@@ -57,11 +60,11 @@
             </div>
           </div>
           <div class="rule-summary">
-            <el-tag size="small" type="info">{{
+            <VtTag size="small" variant="info">{{
               item.kind === "script"
                 ? t("automation.kindScript")
                 : t("automation.kindRule")
-            }}</el-tag>
+            }}</VtTag>
             <span>{{ itemSummary(item) }}</span>
           </div>
         </div>
@@ -89,7 +92,7 @@
 
         <el-form label-position="top" @submit.prevent="save">
           <el-form-item :label="t('automation.itemName')">
-            <el-input
+            <VtInput
               v-model="editor.name"
               :placeholder="t('automation.ruleNamePh')"
               required
@@ -99,27 +102,27 @@
           <template v-if="editor.kind === 'rule'">
             <el-divider>{{ t("automation.sectionWhen") }}</el-divider>
             <el-form-item :label="t('automation.trigger')">
-              <el-select v-model="editor.triggerType" style="width: 100%">
+              <VtSelect v-model="editor.triggerType" class="field-full-width">
                 <el-option
                   v-for="opt in triggerOptions"
                   :key="opt.value"
                   :value="opt.value"
                   :label="opt.label"
                 />
-              </el-select>
+              </VtSelect>
             </el-form-item>
             <el-form-item
               v-if="editor.triggerType === 'schedule.tick'"
               :label="t('automation.schedule')"
             >
               <el-checkbox-group v-model="editor.scheduleWeekdays">
-                <el-checkbox
+                <VtCheckbox
                   v-for="d in weekdayOptions"
                   :key="d.value"
                   :value="d.value"
                 >
                   {{ d.label }}
-                </el-checkbox>
+                </VtCheckbox>
               </el-checkbox-group>
               <div class="time-row">
                 <el-input-number
@@ -138,19 +141,19 @@
 
             <el-divider>{{ t("automation.sectionIf") }}</el-divider>
             <el-form-item>
-              <el-checkbox v-model="editor.vrchatRunning">
+              <VtCheckbox v-model="editor.vrchatRunning">
                 {{ t("automation.conditionVrchatRunning") }}
-              </el-checkbox>
+              </VtCheckbox>
             </el-form-item>
             <el-form-item
               v-if="editor.triggerType === 'friend_joined'"
               :label="t('automation.conditionFriendIs')"
             >
-              <el-select
+              <VtSelect
                 v-model="editor.friendUserId"
                 clearable
                 filterable
-                style="width: 100%"
+                class="field-full-width"
               >
                 <el-option
                   v-for="f in friends"
@@ -158,7 +161,7 @@
                   :value="f.vrcUserId"
                   :label="f.displayName"
                 />
-              </el-select>
+              </VtSelect>
             </el-form-item>
 
             <el-divider>{{ t("automation.sectionThen") }}</el-divider>
@@ -168,7 +171,7 @@
               class="action-row"
             >
               <el-form-item :label="t('automation.action')">
-                <el-select v-model="action.type" style="width: 100%">
+                <VtSelect v-model="action.type" class="field-full-width">
                   <el-option
                     v-for="opt in actionOptions"
                     :key="opt.value"
@@ -176,20 +179,20 @@
                     :label="opt.label"
                     :disabled="opt.disabled"
                   />
-                </el-select>
+                </VtSelect>
               </el-form-item>
               <el-form-item
                 v-if="action.type === 'change_status'"
                 :label="t('automation.status')"
               >
-                <el-select v-model="action.status" style="width: 100%">
+                <VtSelect v-model="action.status" class="field-full-width">
                   <el-option
                     v-for="opt in statusOptions"
                     :key="opt.value"
                     :value="opt.value"
                     :label="opt.label"
                   />
-                </el-select>
+                </VtSelect>
               </el-form-item>
               <template v-if="action.type === 'set_power_plan'">
                 <el-form-item :label="t('automation.powerPlanMode')">
@@ -206,9 +209,9 @@
                   v-if="action.powerPlanMode === 'preset'"
                   :label="t('automation.powerPlanPreset')"
                 >
-                  <el-select
+                  <VtSelect
                     v-model="action.powerPlanPreset"
-                    style="width: 100%"
+                    class="field-full-width"
                   >
                     <el-option
                       v-for="p in powerPlanPresets"
@@ -216,17 +219,20 @@
                       :value="p.value"
                       :label="p.label"
                     />
-                  </el-select>
+                  </VtSelect>
                 </el-form-item>
                 <el-form-item v-else :label="t('automation.powerPlanDetected')">
-                  <el-select v-model="action.powerPlanGuid" style="width: 100%">
+                  <VtSelect
+                    v-model="action.powerPlanGuid"
+                    class="field-full-width"
+                  >
                     <el-option
                       v-for="p in powerPlans"
                       :key="p.guid"
                       :value="p.guid"
                       :label="p.name"
                     />
-                  </el-select>
+                  </VtSelect>
                 </el-form-item>
               </template>
               <template v-if="action.type === 'set_vrchat_window_size'">
@@ -247,33 +253,33 @@
                   />
                 </el-form-item>
               </template>
-              <el-checkbox v-model="action.continueOnError">
+              <VtCheckbox v-model="action.continueOnError">
                 {{ t("automation.continueOnError") }}
-              </el-checkbox>
-              <el-button
+              </VtCheckbox>
+              <VtButton
                 v-if="editor.actions.length > 1"
-                type="danger"
-                text
+                variant="tertiary"
                 @click="removeAction(idx)"
               >
                 {{ t("automation.removeAction") }}
-              </el-button>
+              </VtButton>
             </div>
-            <el-button
+            <VtButton
               v-if="editor.actions.length < 10"
+              variant="secondary"
               class="btn-add-action"
               @click="addAction"
             >
               {{ t("automation.addAction") }}
-            </el-button>
-            <el-text type="info" size="small" class="partial-hint">
+            </VtButton>
+            <p class="text-body-sm partial-hint">
               {{ t("automation.partialApplyHint") }}
-            </el-text>
+            </p>
           </template>
 
           <template v-else>
             <el-divider>{{ t("automation.scriptSource") }}</el-divider>
-            <el-input
+            <VtInput
               v-model="editor.scriptSource"
               type="textarea"
               :rows="14"
@@ -283,25 +289,25 @@
           </template>
 
           <div class="editor-actions">
-            <el-button
-              type="primary"
+            <VtButton
+              variant="primary"
               data-testid="save-item"
               :loading="saving"
               @click="save"
             >
               {{ t("automation.save") }}
-            </el-button>
-            <el-button
+            </VtButton>
+            <VtButton
               v-if="editor.id && !editor.isNew"
-              type="danger"
+              variant="danger"
               plain
               @click="confirmDelete"
             >
               {{ t("automation.delete") }}
-            </el-button>
-            <el-button @click="cancelEdit">{{
+            </VtButton>
+            <VtButton variant="secondary" @click="cancelEdit">{{
               t("automation.cancel")
-            }}</el-button>
+            }}</VtButton>
           </div>
         </el-form>
       </el-card>
@@ -309,9 +315,9 @@
       <el-card class="run-log-panel" shadow="never">
         <template #header>
           <span>{{ t("automation.runLogTitle") }}</span>
-          <el-button text size="small" @click="loadRunLog">
+          <VtButton variant="tertiary" size="small" @click="loadRunLog">
             {{ t("common.refresh") }}
-          </el-button>
+          </VtButton>
         </template>
         <el-table :data="runLog" size="small" stripe empty-text="—">
           <el-table-column
@@ -327,13 +333,13 @@
           />
           <el-table-column :label="t('automation.runLogResult')" width="100">
             <template #default="{ row }">
-              <el-tag :type="row.success ? 'success' : 'danger'" size="small">
+              <VtTag :variant="row.success ? 'success' : 'danger'" size="small">
                 {{
                   row.success
                     ? t("automation.runLogSuccess")
                     : t("automation.runLogFailure")
                 }}
-              </el-tag>
+              </VtTag>
             </template>
           </el-table-column>
           <el-table-column :label="t('automation.runLogActions')" width="80">
@@ -355,7 +361,14 @@
 import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import { onBeforeRouteLeave } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { ElMessage, ElMessageBox } from "element-plus";
+import { ElMessageBox } from "element-plus";
+import VtAlert from "../components/VtAlert.vue";
+import VtButton from "../components/VtButton.vue";
+import VtCheckbox from "../components/VtCheckbox.vue";
+import VtInput from "../components/VtInput.vue";
+import VtSelect from "../components/VtSelect.vue";
+import VtSwitch from "../components/VtSwitch.vue";
+import VtTag from "../components/VtTag.vue";
 import {
   App,
   type AutomationItemDTO,
@@ -376,6 +389,7 @@ import {
   VT_BUTTON_DANGER_CONFIRM_CLASS,
   VT_BUTTON_SECONDARY_CANCEL_CLASS,
 } from "../components/vtButtonClasses";
+import { showToast } from "../utils/showToast";
 
 const { t } = useI18n();
 
@@ -537,7 +551,7 @@ async function selectItem(item: AutomationItemDTO) {
   } catch {
     editor.value = null;
     savedSnapshot.value = "";
-    ElMessage.error(t("automation.itemParseError"));
+    showToast.error(t("automation.itemParseError"));
   }
 }
 
@@ -623,7 +637,7 @@ async function save(): Promise<boolean> {
           editor.value.isNew = false;
         } catch {
           editor.value.isNew = false;
-          ElMessage.error(t("automation.itemParseError"));
+          showToast.error(t("automation.itemParseError"));
         }
       } else {
         editor.value.isNew = false;
@@ -635,7 +649,7 @@ async function save(): Promise<boolean> {
     captureSnapshot();
     return true;
   } catch {
-    ElMessage.error(t("automation.saveError"));
+    showToast.error(t("automation.saveError"));
     return false;
   } finally {
     saving.value = false;
@@ -650,7 +664,7 @@ async function toggleItem(item: AutomationItemDTO, enabled: boolean) {
     await loadItems();
   } catch {
     item.isEnabled = previous;
-    ElMessage.error(t("automation.toggleError"));
+    showToast.error(t("automation.toggleError"));
   }
 }
 
@@ -679,10 +693,20 @@ async function confirmDelete() {
 </script>
 
 <style scoped>
+.automation-intro {
+  display: block;
+  margin: 0 0 var(--space-block);
+  color: var(--color-text-secondary);
+}
+
+.runtime-alert {
+  margin-bottom: var(--space-block);
+}
+
 .automation-layout {
   display: grid;
   grid-template-columns: 280px 1fr 320px;
-  gap: 1rem;
+  gap: var(--space-block);
   align-items: start;
 }
 
@@ -698,21 +722,21 @@ async function confirmDelete() {
 
 .btn-add {
   width: 100%;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-action-group);
   border-style: dashed !important;
-  color: var(--text-secondary) !important;
+  color: var(--color-text-secondary) !important;
 }
 
 .rule-card {
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-  background: var(--bg-secondary);
+  padding: var(--space-form-field);
+  margin-bottom: var(--space-action-group);
+  background: var(--color-bg-elevated);
   border-radius: var(--radius);
   cursor: pointer;
 }
 
 .rule-card.active {
-  background: var(--bg-tertiary);
+  background: var(--color-bg-muted);
 }
 
 .rule-card.disabled {
@@ -723,12 +747,12 @@ async function confirmDelete() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
-  margin-bottom: 0.35rem;
+  gap: var(--space-action-group);
+  margin-bottom: var(--space-inline-tight);
 }
 
 .rule-name {
-  font-weight: 500;
+  font-weight: var(--font-weight-500);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -738,81 +762,81 @@ async function confirmDelete() {
 .rule-summary {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
+  gap: var(--space-inline-tight);
+  font-size: var(--font-size-12);
+  color: var(--color-text-secondary);
 }
 
 .rule-editor,
 .run-log-panel {
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .rule-editor :deep(.el-card__header) {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
+  gap: var(--space-action-group);
+  font-weight: var(--font-weight-600);
+}
+
+.field-full-width {
+  width: 100%;
 }
 
 .editor-actions {
-  margin-top: 1rem;
+  margin-top: var(--space-block);
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   flex-wrap: wrap;
 }
 
 .weekday-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-action-group);
+  margin-bottom: var(--space-action-group);
 }
 
 .time-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
 }
 
 .action-row {
-  padding: 0.75rem;
-  margin-bottom: 0.75rem;
-  border: 1px solid var(--border);
+  padding: var(--space-form-field);
+  margin-bottom: var(--space-form-field);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
 }
 
 .btn-add-action {
   width: 100%;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-action-group);
   border-style: dashed !important;
 }
 
 .partial-hint {
   display: block;
-  margin-bottom: 1rem;
+  margin: 0 0 var(--space-block);
+  color: var(--color-text-secondary);
 }
 
 .script-editor :deep(textarea) {
   font-family: ui-monospace, monospace;
-  font-size: 0.85rem;
+  font-size: var(--font-size-12);
 }
 
 .unsaved-banner {
-  margin-bottom: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--el-color-warning) 18%, transparent);
-  color: var(--el-color-warning);
-  font-size: 0.85rem;
+  margin-bottom: var(--space-form-field);
 }
 
 .unsaved-dot {
-  width: 8px;
-  height: 8px;
+  width: var(--space-action-group);
+  height: var(--space-action-group);
   border-radius: 50%;
-  background: var(--el-color-warning);
+  background: var(--color-warning);
   flex-shrink: 0;
 }
 

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -1,14 +1,10 @@
 <template>
   <div class="config-view">
     <h1 class="page-title">{{ t("config.title") }}</h1>
-    <el-text
-      type="info"
-      size="small"
-      style="display: block; margin-bottom: 1.5rem"
-    >
+    <p class="text-body-sm config-intro">
       {{ t("config.intro") }}
       <code>%LocalAppData%Low\VRChat\VRChat\config.json</code>
-    </el-text>
+    </p>
 
     <el-card
       v-if="!configExists && !editing"
@@ -16,54 +12,46 @@
       class="config-card"
     >
       <div class="config-not-found">
-        <el-text type="info">
+        <p class="text-body-sm config-not-found-text">
           {{ t("config.notFound") }}
-        </el-text>
-        <el-button
-          type="primary"
+        </p>
+        <VtButton
+          variant="primary"
+          class="config-create-btn"
           data-testid="create-config-btn"
-          style="margin-top: 1rem"
           @click="createConfig"
         >
           {{ t("config.create") }}
-        </el-button>
+        </VtButton>
       </div>
     </el-card>
 
     <div v-if="editing" class="config-editor">
-      <el-alert
+      <VtAlert
         v-if="saveError"
+        variant="danger"
         :title="saveError"
-        type="error"
-        :closable="false"
-        show-icon
-        style="margin-bottom: 1rem"
+        class="config-alert"
       />
-      <el-alert
+      <VtAlert
         v-if="saveSuccess"
+        variant="success"
         :title="t('config.saved')"
-        type="success"
-        :closable="false"
-        show-icon
-        style="margin-bottom: 1rem"
+        class="config-alert"
       />
 
       <!-- Camera Resolution -->
       <el-card shadow="never" class="config-card">
         <template #header>{{ t("config.cameraHeader") }}</template>
-        <el-text
-          type="info"
-          size="small"
-          style="display: block; margin-bottom: 0.75rem"
-        >
+        <p class="text-body-sm config-help">
           {{ t("config.cameraHelp") }}
-        </el-text>
+        </p>
         <div class="resolution-section">
           <el-radio-group
             v-model="cameraPreset"
             :aria-label="t('config.cameraPresetAria')"
             size="small"
-            style="flex-wrap: wrap; gap: 4px"
+            class="resolution-presets"
             @change="applyCameraPreset"
           >
             <el-radio-button value="HD" data-testid="camera-preset-hd"
@@ -96,7 +84,7 @@
               data-testid="camera-width-input"
               size="small"
               :placeholder="t('launcher.widthPh')"
-              style="width: 130px"
+              class="resolution-number-input"
             />
             <span class="resolution-sep">×</span>
             <el-input-number
@@ -107,7 +95,7 @@
               data-testid="camera-height-input"
               size="small"
               :placeholder="t('launcher.heightPh')"
-              style="width: 130px"
+              class="resolution-number-input"
             />
           </div>
         </div>
@@ -116,19 +104,15 @@
       <!-- Screenshot Resolution -->
       <el-card shadow="never" class="config-card">
         <template #header>{{ t("config.screenshotHeader") }}</template>
-        <el-text
-          type="info"
-          size="small"
-          style="display: block; margin-bottom: 0.75rem"
-        >
+        <p class="text-body-sm config-help">
           {{ t("config.screenshotHelp") }}
-        </el-text>
+        </p>
         <div class="resolution-section">
           <el-radio-group
             v-model="screenshotPreset"
             :aria-label="t('config.screenshotPresetAria')"
             size="small"
-            style="flex-wrap: wrap; gap: 4px"
+            class="resolution-presets"
             @change="applyScreenshotPreset"
           >
             <el-radio-button value="HD" data-testid="screenshot-preset-hd"
@@ -158,7 +142,7 @@
               data-testid="screenshot-width-input"
               size="small"
               :placeholder="t('launcher.widthPh')"
-              style="width: 130px"
+              class="resolution-number-input"
             />
             <span class="resolution-sep">×</span>
             <el-input-number
@@ -169,7 +153,7 @@
               data-testid="screenshot-height-input"
               size="small"
               :placeholder="t('launcher.heightPh')"
-              style="width: 130px"
+              class="resolution-number-input"
             />
           </div>
         </div>
@@ -180,28 +164,29 @@
         <template #header>{{ t("config.photoHeader") }}</template>
         <el-form label-position="top" size="default">
           <el-form-item :label="t('config.outputFolder')">
-            <div class="path-row">
-              <el-input
+            <div class="path-input-group">
+              <VtInput
                 id="picture-output-folder"
                 v-model="config.pictureOutputFolder"
                 :placeholder="t('config.outputFolderPh')"
                 data-testid="picture-output-folder-input"
               />
-              <el-button
+              <VtButton
+                variant="secondary"
                 data-testid="picture-output-folder-browse"
                 @click="browsePictureOutputFolder"
               >
                 {{ t("common.browse") }}
-              </el-button>
+              </VtButton>
             </div>
           </el-form-item>
           <el-form-item>
-            <el-checkbox
+            <VtCheckbox
               v-model="pictureOutputSplitByDate"
               data-testid="picture-split-by-date-checkbox"
             >
               {{ t("config.splitByDate") }}
-            </el-checkbox>
+            </VtCheckbox>
           </el-form-item>
         </el-form>
       </el-card>
@@ -209,19 +194,15 @@
       <!-- Steadycam FOV -->
       <el-card shadow="never" class="config-card">
         <template #header>{{ t("config.steadycamHeader") }}</template>
-        <el-text
-          type="info"
-          size="small"
-          style="display: block; margin-bottom: 0.75rem"
-        >
+        <p class="text-body-sm config-help">
           {{ t("config.steadycamHelp") }}
-        </el-text>
+        </p>
         <div class="fov-row">
           <el-slider
             :model-value="steadycamFovSliderValue"
             :min="STEADYCAM_FOV_MIN"
             :max="STEADYCAM_FOV_MAX"
-            style="flex: 1; max-width: 240px"
+            class="fov-slider"
             data-testid="steadycam-fov-slider"
             @input="onSteadycamFovSliderInput"
           />
@@ -233,7 +214,7 @@
             :placeholder="String(STEADYCAM_FOV_PLACEHOLDER)"
             data-testid="steadycam-fov-input"
             size="small"
-            style="width: 100px"
+            class="fov-number-input"
             @change="onSteadycamFovChange"
             @blur="clampSteadycamFov"
           />
@@ -243,28 +224,25 @@
       <!-- Cache -->
       <el-card shadow="never" class="config-card">
         <template #header>{{ t("config.cacheHeader") }}</template>
-        <el-text
-          type="info"
-          size="small"
-          style="display: block; margin-bottom: 0.75rem"
-        >
+        <p class="text-body-sm config-help">
           {{ t("config.cacheHelp") }}
-        </el-text>
+        </p>
         <el-form label-position="top" size="default">
           <el-form-item :label="t('config.cacheDir')">
-            <div class="path-row">
-              <el-input
+            <div class="path-input-group">
+              <VtInput
                 id="cache-directory"
                 v-model="config.cacheDirectory"
                 :placeholder="t('config.cacheDirPh')"
                 data-testid="cache-directory-input"
               />
-              <el-button
+              <VtButton
+                variant="secondary"
                 data-testid="cache-directory-browse"
                 @click="browseCacheDirectory"
               >
                 {{ t("common.browse") }}
-              </el-button>
+              </VtButton>
             </div>
           </el-form-item>
           <el-form-item :label="t('config.cacheSizeGb')">
@@ -290,17 +268,15 @@
             />
           </el-form-item>
         </el-form>
-        <el-alert
+        <VtAlert
           v-if="assetCacheClearError"
+          variant="danger"
           :title="assetCacheClearError"
-          type="error"
-          :closable="false"
-          show-icon
-          style="margin: 0.75rem 0"
+          class="config-cache-alert"
           data-testid="asset-cache-clear-error"
         />
-        <el-button
-          type="danger"
+        <VtButton
+          variant="danger"
           plain
           :loading="assetCacheClearLoading"
           data-testid="asset-cache-clear-btn"
@@ -311,37 +287,37 @@
               ? t("config.assetCacheClearRunning")
               : t("config.assetCacheClear")
           }}
-        </el-button>
+        </VtButton>
       </el-card>
 
       <!-- Rich Presence -->
       <el-card shadow="never" class="config-card">
         <template #header>{{ t("config.otherHeader") }}</template>
-        <el-checkbox
+        <VtCheckbox
           v-model="disableRichPresence"
           data-testid="disable-rich-presence-checkbox"
         >
           {{ t("config.richPresenceOff") }}
-        </el-checkbox>
+        </VtCheckbox>
       </el-card>
 
       <!-- Actions -->
       <div class="config-actions">
-        <el-button
-          type="primary"
+        <VtButton
+          variant="primary"
           data-testid="save-config-btn"
           @click="saveConfig"
         >
           {{ t("config.save") }}
-        </el-button>
-        <el-button
-          type="danger"
+        </VtButton>
+        <VtButton
+          variant="danger"
           plain
           data-testid="delete-config-btn"
           @click="deleteConfig"
         >
           {{ t("config.deleteConfig") }}
-        </el-button>
+        </VtButton>
       </div>
     </div>
   </div>
@@ -350,14 +326,19 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import { useI18n } from "vue-i18n";
-import { ElMessageBox, ElMessage } from "element-plus";
-import { App } from "../wails/app";
-import type { VRChatConfigDTO } from "../wails/app";
-import { AssetCacheErr } from "../utils/assetCacheErrors";
+import { ElMessageBox } from "element-plus";
+import VtAlert from "../components/VtAlert.vue";
+import VtButton from "../components/VtButton.vue";
+import VtCheckbox from "../components/VtCheckbox.vue";
+import VtInput from "../components/VtInput.vue";
 import {
   VT_BUTTON_DANGER_CONFIRM_CLASS,
   VT_BUTTON_SECONDARY_CANCEL_CLASS,
 } from "../components/vtButtonClasses";
+import { showToast } from "../utils/showToast";
+import { App } from "../wails/app";
+import type { VRChatConfigDTO } from "../wails/app";
+import { AssetCacheErr } from "../utils/assetCacheErrors";
 
 const { t } = useI18n();
 
@@ -686,7 +667,7 @@ async function doClearAssetCache() {
   try {
     const n = await App.clearVRChatAssetCache();
     if (gen !== clearGeneration) return;
-    ElMessage.success(t("config.assetCacheClearDone", { n: String(n ?? 0) }));
+    showToast.success(t("config.assetCacheClearDone", { n: String(n ?? 0) }));
   } catch (e) {
     if (gen !== clearGeneration) return;
     assetCacheClearError.value = classifyAssetCacheClearError(e);
@@ -703,60 +684,107 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+.config-intro {
+  display: block;
+  margin: 0 0 var(--space-section);
+  color: var(--color-text-secondary);
+}
+
 .config-card {
-  margin-bottom: 1.25rem;
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  margin-bottom: var(--space-section);
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .config-card :deep(.el-card__header) {
-  font-weight: 600;
-  border-bottom-color: var(--border);
+  font-weight: var(--font-weight-600);
+  border-bottom-color: var(--color-border);
 }
 
 .config-not-found {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.5rem;
+  padding: var(--space-section);
+}
+
+.config-not-found-text {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.config-create-btn {
+  margin-top: var(--space-block);
+}
+
+.config-alert {
+  margin-bottom: var(--space-block);
+}
+
+.config-help {
+  margin: 0 0 var(--space-form-field);
+  color: var(--color-text-secondary);
 }
 
 .resolution-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-form-field);
+}
+
+.resolution-presets {
+  flex-wrap: wrap;
+  gap: var(--space-inline-tight);
 }
 
 .resolution-fields {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
+}
+
+.resolution-number-input {
+  width: 130px;
 }
 
 .resolution-sep {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
-.path-row {
+.path-input-group {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   width: 100%;
   max-width: 480px;
 }
 
-.path-row :deep(.el-input) {
+.path-input-group :deep(.el-input) {
   flex: 1;
+  min-width: 0;
 }
 
 .fov-row {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-block);
+}
+
+.fov-slider {
+  flex: 1;
+  max-width: 240px;
+}
+
+.fov-number-input {
+  width: 100px;
+}
+
+.config-cache-alert {
+  margin: var(--space-form-field) 0;
 }
 
 .config-actions {
   display: flex;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
+  gap: var(--space-form-field);
+  margin-top: var(--space-action-group);
 }
 </style>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -27,6 +27,6 @@ const { t } = useI18n();
 .quick-actions {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-block);
 }
 </style>

--- a/frontend/src/views/EncounterHistoryDetailView.vue
+++ b/frontend/src/views/EncounterHistoryDetailView.vue
@@ -1,14 +1,12 @@
 <template>
   <div class="encounter-history-view">
     <h1 class="page-title">{{ pageTitle }}</h1>
-    <p v-if="idLine" class="id-line">{{ idLine }}</p>
+    <p v-if="idLine" class="text-caption id-line">{{ idLine }}</p>
 
-    <el-alert
+    <VtAlert
       v-if="invalidQuery"
+      variant="warning"
       :title="t('encounterHistory.invalidQuery')"
-      type="warning"
-      :closable="false"
-      show-icon
     />
     <EncounterHistoryList
       v-else
@@ -25,6 +23,7 @@ import { computed } from "vue";
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
 import EncounterHistoryList from "../components/EncounterHistoryList.vue";
+import VtAlert from "../components/VtAlert.vue";
 
 const route = useRoute();
 const { t } = useI18n();
@@ -73,14 +72,13 @@ const idLine = computed(() => {
 .encounter-history-view {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-form-field);
   min-height: 0;
 }
 
 .id-line {
   margin: 0;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   word-break: break-all;
 }
 </style>

--- a/frontend/src/views/FriendsView.vue
+++ b/frontend/src/views/FriendsView.vue
@@ -10,12 +10,10 @@
           :refresh-loading="refreshLoading"
           @refresh="doRefresh"
         />
-        <el-alert
+        <VtAlert
           v-if="!isLoggedIn"
+          variant="info"
           :title="t('friends.loginRequired')"
-          type="info"
-          :closable="false"
-          show-icon
           class="login-hint"
         />
         <div class="friends-list-wrap">
@@ -41,12 +39,13 @@
 import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { ElMessage } from "element-plus";
+import VtAlert from "../components/VtAlert.vue";
 import FriendsDetailPane from "./friends/FriendsDetailPane.vue";
 import FriendsListPanel from "./friends/FriendsListPanel.vue";
 import FriendsViewToolbar from "./friends/FriendsViewToolbar.vue";
 import { friendIsOffline } from "@/utils/vrcUserCacheDisplay";
 import { useSessionUnlock } from "../composables/useSessionUnlock";
+import { showToast } from "../utils/showToast";
 import { App } from "../wails/app";
 import type { UserCacheDTO } from "../wails/app";
 import { getRuntime } from "../wails/runtime";
@@ -151,7 +150,7 @@ async function applyVrcUserIdFromQuery(): Promise<void> {
     f = friends.value.find((x) => x.vrcUserId === id);
   }
   if (!f) {
-    ElMessage.warning(t("friends.userNotFound"));
+    showToast.warning(t("friends.userNotFound"));
     await stripVrcUserIdFromQuery();
     return;
   }
@@ -251,7 +250,7 @@ async function onDetailFavoriteChange(f: UserCacheDTO, isFavorite: boolean) {
 }
 
 .login-hint {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-block);
 }
 
 .friends-section {
@@ -260,7 +259,7 @@ async function onDetailFavoriteChange(f: UserCacheDTO, isFavorite: boolean) {
   flex: 1;
   min-height: 0;
   overflow: hidden;
-  gap: 1.5rem;
+  gap: var(--space-section);
 }
 
 .friends-pane--left {

--- a/frontend/src/views/GalleryView.vue
+++ b/frontend/src/views/GalleryView.vue
@@ -3,7 +3,7 @@
     <h1 class="page-title">{{ t("routes.gallery") }}</h1>
 
     <div class="filters">
-      <el-input
+      <VtInput
         v-model="filterWorldSearch"
         data-testid="gallery-world-filter"
         type="search"
@@ -13,9 +13,9 @@
         @keyup.enter="onFilterEnter"
       >
         <template #prefix>
-          <el-icon><Search /></el-icon>
+          <VtIcon size="default"><Search /></VtIcon>
         </template>
-      </el-input>
+      </VtInput>
       <el-date-picker
         v-model="filterDateRange"
         data-testid="gallery-date-range"
@@ -28,33 +28,26 @@
         class="gallery-date-range"
         @change="onFilterEnter"
       />
-      <el-button :disabled="loading || scanning" @click="onRefreshClick">
+      <VtButton
+        variant="tertiary"
+        :disabled="loading || scanning"
+        @click="onRefreshClick"
+      >
         {{ t("common.refresh") }}
-      </el-button>
-      <el-button
+      </VtButton>
+      <VtButton
+        variant="secondary"
         data-testid="gallery-scan-folder"
         :disabled="loading || scanning"
         :loading="scanning"
         @click="scanFolder"
       >
         {{ scanning ? t("gallery.scanning") : t("gallery.scanFolder") }}
-      </el-button>
+      </VtButton>
     </div>
 
-    <el-alert
-      v-if="loadError"
-      :title="loadError"
-      type="error"
-      :closable="false"
-      show-icon
-    />
-    <el-alert
-      v-if="scanError"
-      :title="scanError"
-      type="warning"
-      :closable="false"
-      show-icon
-    />
+    <VtAlert v-if="loadError" variant="danger" :title="loadError" />
+    <VtAlert v-if="scanError" variant="warning" :title="scanError" />
 
     <div class="gallery-body">
       <!-- グリッド一覧 -->
@@ -177,51 +170,48 @@
             {{ selected.authorDisplayName || t("common.dash") }}
           </el-descriptions-item>
           <el-descriptions-item :label="t('gallery.filePath')">
-            <el-button
+            <VtButton
+              variant="primary"
               link
-              type="primary"
               data-testid="gallery-detail-open-file"
               :title="t('gallery.openWithDefaultApp')"
               class="file-path-btn"
               @click="openSelectedFileExternally"
             >
               {{ selected.filePath }}
-            </el-button>
+            </VtButton>
           </el-descriptions-item>
         </el-descriptions>
-        <el-alert
+        <VtAlert
           v-if="detailActionError"
+          variant="danger"
+          class="detail-action-alert"
           :title="detailActionError"
-          type="error"
-          :closable="false"
-          show-icon
-          style="margin: 0.75rem 0"
         />
-        <el-button
-          style="width: 100%; margin: 0.75rem 0 0.5rem"
+        <VtButton
+          variant="secondary"
+          class="detail-panel-action-btn"
           data-testid="gallery-detail-open-folder"
           :title="openFolderButtonTitle"
           @click="revealSelectedInFolder"
         >
           {{ t("gallery.openFolder") }}
-        </el-button>
-        <el-alert
+        </VtButton>
+        <VtAlert
           v-if="joinError"
+          variant="danger"
+          class="join-error-alert"
           :title="joinError"
-          type="error"
-          :closable="false"
-          show-icon
-          style="margin-bottom: 0.5rem"
         />
-        <el-button
-          type="primary"
-          style="width: 100%"
+        <VtButton
+          variant="primary"
+          class="detail-panel-action-btn detail-panel-action-btn--last"
           :disabled="!selected.worldId || selected.worldId.trim() === ''"
           :title="joinButtonTitle"
           @click="onJoin"
         >
           {{ t("gallery.joinWorld") }}
-        </el-button>
+        </VtButton>
       </el-card>
     </div>
   </div>
@@ -230,6 +220,10 @@
 <script setup lang="ts">
 import { Search } from "@element-plus/icons-vue";
 import { useVirtualizer, type VirtualItem } from "@tanstack/vue-virtual";
+import VtAlert from "../components/VtAlert.vue";
+import VtButton from "../components/VtButton.vue";
+import VtIcon from "../components/VtIcon.vue";
+import VtInput from "../components/VtInput.vue";
 import {
   ref,
   onMounted,
@@ -948,14 +942,14 @@ onMounted(() => {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-block);
   overflow: hidden;
 }
 
 .filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   align-items: center;
   flex-shrink: 0;
 }
@@ -976,7 +970,7 @@ onMounted(() => {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-block);
   align-items: stretch;
   min-height: 0;
   min-width: 0;
@@ -1004,23 +998,23 @@ onMounted(() => {
 
 .loading,
 .empty {
-  padding: 2rem;
+  padding: var(--space-page);
   text-align: center;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .gallery-scan-progress {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  padding: 2rem;
+  gap: var(--space-form-field);
+  padding: var(--space-page);
 }
 
 .gallery-scan-status {
   margin: 0;
-  font-size: 0.95rem;
-  color: var(--text-secondary);
+  font-size: var(--font-size-14);
+  color: var(--color-text-secondary);
   max-width: 28rem;
   word-break: break-all;
 }
@@ -1053,14 +1047,14 @@ onMounted(() => {
 
 .grid-item:hover,
 .grid-item.selected {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
+  border-color: var(--color-brand);
+  box-shadow: 0 0 0 1px var(--color-brand);
 }
 
 .thumbnail-wrap {
   width: 100%;
   height: 100%;
-  background: var(--bg-tertiary);
+  background: var(--color-bg-muted);
 }
 
 .thumbnail {
@@ -1072,25 +1066,42 @@ onMounted(() => {
 
 .detail-panel {
   flex-shrink: 0;
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .detail-panel :deep(.el-card__header) {
-  font-weight: 600;
-  border-bottom-color: var(--border);
+  font-weight: var(--font-weight-600);
+  border-bottom-color: var(--color-border);
 }
 
 .detail-preview {
-  margin: 0 0 1rem;
+  margin: 0 0 var(--space-block);
   border-radius: var(--radius);
   overflow: hidden;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  background: var(--color-bg-muted);
+  border: 1px solid var(--color-border);
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 4rem;
+  min-height: var(--space-64);
+}
+
+.detail-action-alert {
+  margin: var(--space-form-field) 0;
+}
+
+.detail-panel-action-btn {
+  width: 100%;
+  margin: var(--space-form-field) 0 var(--space-action-group);
+}
+
+.detail-panel-action-btn--last {
+  margin-bottom: 0;
+}
+
+.join-error-alert {
+  margin-bottom: var(--space-action-group);
 }
 
 .detail-preview-img {
@@ -1113,41 +1124,41 @@ onMounted(() => {
   height: 100%;
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0 0.35rem;
+  gap: var(--space-inline-tight);
+  padding: 0 var(--space-inline-tight);
   margin: 0;
-  background: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, transparent);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  color: var(--text-primary);
-  font-size: 0.9rem;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-14);
   cursor: pointer;
   text-align: left;
   box-sizing: border-box;
 }
 
 .gallery-group-header:hover {
-  background: var(--bg-tertiary);
+  background: var(--color-bg-muted);
 }
 
 .gallery-group-h-year {
-  font-weight: 600;
+  font-weight: var(--font-weight-600);
 }
 
 .gallery-group-h-month {
-  padding-left: 1.1rem;
-  font-weight: 550;
+  padding-left: var(--space-block);
+  font-weight: var(--font-weight-500);
 }
 
 .gallery-group-h-day {
-  padding-left: 2rem;
-  font-weight: 450;
+  padding-left: var(--space-page);
+  font-weight: var(--font-weight-400);
 }
 
 .gallery-group-chevron {
   flex-shrink: 0;
-  width: 0.85rem;
-  font-size: 0.6rem;
+  width: var(--icon-size-compact);
+  font-size: var(--font-size-10);
   opacity: 0.85;
   line-height: 1;
 }

--- a/frontend/src/views/LauncherView.vue
+++ b/frontend/src/views/LauncherView.vue
@@ -4,18 +4,26 @@
     <div class="launcher-layout" :class="{ 'sidebar-collapsed': !sidebarOpen }">
       <aside class="profiles-sidebar">
         <div class="sidebar-toolbar">
-          <el-button
+          <VtButton
+            variant="tertiary"
             class="sidebar-toggle"
             data-testid="sidebar-toggle-btn"
             :aria-label="t('launcher.toggleSidebar')"
             @click="toggleSidebar"
           >
-            <el-icon><component :is="sidebarOpen ? Fold : Expand" /></el-icon>
-          </el-button>
+            <VtIcon size="default"
+              ><component :is="sidebarOpen ? Fold : Expand"
+            /></VtIcon>
+          </VtButton>
         </div>
-        <el-button v-show="sidebarOpen" class="btn-add" @click="requestAddNew">
+        <VtButton
+          v-show="sidebarOpen"
+          variant="secondary"
+          class="btn-add"
+          @click="requestAddNew"
+        >
           {{ t("launcher.newProfile") }}
-        </el-button>
+        </VtButton>
         <div v-show="sidebarOpen" class="profiles-list">
           <div
             v-for="p in profiles"
@@ -32,68 +40,67 @@
               data-testid="unsaved-dot"
               :title="t('launcher.unsavedBanner')"
             />
-            <el-tag v-if="p.isDefault" size="small" type="primary">{{
+            <VtTag v-if="p.isDefault" variant="primary" size="small">{{
               t("launcher.defaultTag")
-            }}</el-tag>
+            }}</VtTag>
           </div>
         </div>
       </aside>
 
       <div v-if="selected" class="profile-editor">
         <div class="editor-toolbar">
-          <el-alert
+          <VtAlert
             v-if="isDirty"
             class="unsaved-banner"
             data-testid="unsaved-banner"
-            type="warning"
+            variant="warning"
             :title="t('launcher.unsavedBanner')"
-            :closable="false"
-            show-icon
           />
           <div class="toolbar-actions">
-            <el-button class="btn-launch" @click="launch">
+            <VtButton variant="secondary" class="btn-launch" @click="launch">
               {{ t("launcher.launchWithThis") }}
-            </el-button>
-            <el-button class="btn-save" type="primary" @click="save">
+            </VtButton>
+            <VtButton variant="primary" class="btn-save" @click="save">
               {{ t("launcher.save") }}
-            </el-button>
-            <el-button
+            </VtButton>
+            <VtButton
+              variant="secondary"
               data-testid="duplicate-profile-btn"
               @click="requestDuplicate"
             >
               {{ t("launcher.duplicate") }}
-            </el-button>
-            <el-button
-              type="danger"
+            </VtButton>
+            <VtButton
+              variant="danger"
               plain
               data-testid="delete-profile-btn"
               @click="confirmDelete"
             >
               {{ t("launcher.delete") }}
-            </el-button>
+            </VtButton>
           </div>
         </div>
 
         <el-form label-position="top" size="default">
           <el-form-item :label="t('launcher.profileName')">
-            <el-input v-model="selected.name" />
+            <VtInput v-model="selected.name" />
           </el-form-item>
 
           <el-form-item>
-            <el-checkbox v-model="selected.isDefault">
+            <VtCheckbox v-model="selected.isDefault">
               {{ t("launcher.setAsDefault") }}
-            </el-checkbox>
+            </VtCheckbox>
           </el-form-item>
 
           <el-form-item :label="t('launcher.launchArgs')">
             <div class="launch-args-gui">
               <div class="arg-row">
-                <el-checkbox
+                <VtCheckbox
                   v-model="launchArgs.noVr"
                   data-testid="no-vr-checkbox"
                 >
                   {{ t("launcher.desktopMode") }}
-                </el-checkbox>
+                </VtCheckbox>
               </div>
 
               <el-form-item
@@ -124,7 +131,7 @@
               </el-form-item>
 
               <el-form-item :label="t('launcher.customArgs')">
-                <el-input
+                <VtInput
                   v-model="launchArgs.custom"
                   placeholder="-batchmode"
                   data-testid="custom-args-input"
@@ -145,13 +152,13 @@
                     </h3>
                     <div class="launch-args-advanced">
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.resolution"
                           data-testid="resolution-enabled-checkbox"
                           @change="onResolutionEnabledChange"
                         >
                           {{ t("launcher.resolutionHint") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.resolution"
@@ -220,13 +227,13 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.monitor"
                           data-testid="monitor-enabled-checkbox"
                           @change="onMonitorEnabledChange"
                         >
                           {{ t("launcher.monitorHint") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.monitor"
@@ -243,13 +250,13 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.fps"
                           data-testid="fps-enabled-checkbox"
                           @change="onFpsEnabledChange"
                         >
                           {{ t("launcher.fpsHint") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div v-if="valueOptionsEnabled.fps" class="sub-options">
                         <el-input-number
@@ -263,22 +270,22 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.skipRegistry"
                           data-testid="skip-registry-checkbox"
                         >
                           {{ t("launcher.skipRegistry") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.processPriority"
                           data-testid="process-priority-enabled-checkbox"
                           @change="onProcessPriorityEnabledChange"
                         >
                           {{ t("launcher.processPriority") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.processPriority"
@@ -296,13 +303,13 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.mainThreadPriority"
                           data-testid="main-thread-priority-enabled-checkbox"
                           @change="onMainThreadPriorityEnabledChange"
                         >
                           {{ t("launcher.mainThreadPriority") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.mainThreadPriority"
@@ -320,13 +327,13 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.profile"
                           data-testid="profile-enabled-checkbox"
                           @change="onProfileEnabledChange"
                         >
                           {{ t("launcher.profileHint") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.profile"
@@ -351,65 +358,65 @@
                     </h3>
                     <div class="launch-args-advanced">
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.enableDebugGui"
                           data-testid="enable-debug-gui-checkbox"
                         >
                           {{ t("launcher.debugGui") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.enableSDKLogLevels"
                           data-testid="enable-sdk-log-levels-checkbox"
                         >
                           {{ t("launcher.sdkLog") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.enableUdonDebugLogging"
                           data-testid="enable-udon-debug-logging-checkbox"
                         >
                           {{ t("launcher.udonDebug") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.watchWorlds"
                           data-testid="watch-worlds-checkbox"
                         >
                           {{ t("launcher.watchWorlds") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.watchAvatars"
                           data-testid="watch-avatars-checkbox"
                         >
                           {{ t("launcher.watchAvatars") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.enforceWorldServerChecks"
                           data-testid="enforce-world-server-checks-checkbox"
                         >
                           {{ t("launcher.enforceWorldServer") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.midi"
                           data-testid="midi-enabled-checkbox"
                           @change="onMidiEnabledChange"
                         >
                           {{ t("launcher.midi") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div v-if="valueOptionsEnabled.midi" class="sub-options">
-                        <el-input
+                        <VtInput
                           v-model="launchArgs.midi"
                           :placeholder="t('launcher.midiPh')"
                           data-testid="midi-input"
@@ -419,19 +426,19 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.ignoreTrackers"
                           data-testid="ignore-trackers-enabled-checkbox"
                           @change="onIgnoreTrackersEnabledChange"
                         >
                           {{ t("launcher.ignoreTrackers") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.ignoreTrackers"
                         class="sub-options"
                       >
-                        <el-input
+                        <VtInput
                           v-model="launchArgs.ignoreTrackers"
                           placeholder="serial1,serial2"
                           data-testid="ignore-trackers-input"
@@ -474,25 +481,25 @@
                       </el-form-item>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.disableAMDStutterWorkaround"
                           data-testid="disable-amd-stutter-workaround-checkbox"
                         >
                           {{ t("launcher.disableAmdStutter") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.osc"
                           data-testid="osc-enabled-checkbox"
                           @change="onOscEnabledChange"
                         >
                           {{ t("launcher.osc") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div v-if="valueOptionsEnabled.osc" class="sub-options">
-                        <el-input
+                        <VtInput
                           v-model="launchArgs.osc"
                           :placeholder="t('launcher.oscPh')"
                           data-testid="osc-input"
@@ -502,19 +509,19 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.affinity"
                           data-testid="affinity-enabled-checkbox"
                           @change="onAffinityEnabledChange"
                         >
                           {{ t("launcher.affinity") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.affinity"
                         class="sub-options"
                       >
-                        <el-input
+                        <VtInput
                           v-model="launchArgs.affinity"
                           :placeholder="t('launcher.affinityPh')"
                           data-testid="affinity-input"
@@ -532,13 +539,13 @@
                     </h3>
                     <div class="launch-args-advanced">
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.customArmRatio"
                           data-testid="custom-arm-ratio-enabled-checkbox"
                           @change="onCustomArmRatioEnabledChange"
                         >
                           {{ t("launcher.customArmRatio") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.customArmRatio"
@@ -556,31 +563,31 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.disableShoulderTracking"
                           data-testid="disable-shoulder-tracking-checkbox"
                         >
                           {{ t("launcher.disableShoulderTracking") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.enableIkDebugLogging"
                           data-testid="enable-ik-debug-logging-checkbox"
                         >
                           {{ t("launcher.enableIkDebugLogging") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="valueOptionsEnabled.calibrationRange"
                           data-testid="calibration-range-enabled-checkbox"
                           @change="onCalibrationRangeEnabledChange"
                         >
                           {{ t("launcher.calibrationRange") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                       <div
                         v-if="valueOptionsEnabled.calibrationRange"
@@ -598,12 +605,12 @@
                       </div>
 
                       <div class="arg-row">
-                        <el-checkbox
+                        <VtCheckbox
                           v-model="launchArgs.freezeTrackingOnDisconnect"
                           data-testid="freeze-tracking-on-disconnect-checkbox"
                         >
                           {{ t("launcher.freezeTrackingOnDisconnect") }}
-                        </el-checkbox>
+                        </VtCheckbox>
                       </div>
                     </div>
                   </div>
@@ -621,8 +628,14 @@
 import { ref, reactive, computed, onMounted, onBeforeUnmount } from "vue";
 import { onBeforeRouteLeave } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { ElMessage, ElMessageBox } from "element-plus";
+import { ElMessageBox } from "element-plus";
 import { Expand, Fold } from "@element-plus/icons-vue";
+import VtAlert from "../components/VtAlert.vue";
+import VtButton from "../components/VtButton.vue";
+import VtCheckbox from "../components/VtCheckbox.vue";
+import VtIcon from "../components/VtIcon.vue";
+import VtInput from "../components/VtInput.vue";
+import VtTag from "../components/VtTag.vue";
 import {
   App,
   type LaunchProfileDTO,
@@ -643,6 +656,7 @@ import {
   type ValueOptionsEnabled,
 } from "./launcher/launcherProfileEdits";
 import { formatError } from "../utils/formatError";
+import { showToast } from "../utils/showToast";
 import {
   VT_BUTTON_DANGER_CONFIRM_CLASS,
   VT_BUTTON_SECONDARY_CANCEL_CLASS,
@@ -709,7 +723,7 @@ const advancedCollapseActive = ref<string[]>([]);
 let profileSaveGen = 0;
 
 function showSaveError(e: unknown) {
-  ElMessage.error(formatError(e, t("launcher.errSave")));
+  showToast.error(formatError(e, t("launcher.errSave")));
 }
 const currentSnapshot = computed((): LaunchProfileEditSnapshot | null => {
   if (!selected.value) return null;
@@ -1193,7 +1207,7 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 <style scoped>
 .launcher-layout {
   display: flex;
-  gap: 1rem;
+  gap: var(--space-block);
   align-items: flex-start;
 }
 
@@ -1210,7 +1224,7 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 
 .sidebar-toolbar {
   display: flex;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-action-group);
   align-items: center;
 }
 
@@ -1224,30 +1238,30 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 
 .btn-add {
   width: 100%;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-action-group);
   border-style: dashed !important;
-  color: var(--text-secondary) !important;
+  color: var(--color-text-secondary) !important;
 }
 
 .btn-add:hover {
-  color: var(--accent) !important;
+  color: var(--color-brand) !important;
 }
 
 .profile-card {
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-  background: var(--bg-secondary);
+  padding: var(--space-form-field);
+  margin-bottom: var(--space-action-group);
+  background: var(--color-bg-elevated);
   border-radius: var(--radius);
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   transition: background 0.15s;
 }
 
 .profile-card:hover,
 .profile-card.active {
-  background: var(--bg-tertiary);
+  background: var(--color-bg-muted);
 }
 
 .profile-name {
@@ -1258,10 +1272,10 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 }
 
 .unsaved-dot {
-  width: 8px;
-  height: 8px;
+  width: var(--space-action-group);
+  height: var(--space-action-group);
   border-radius: 50%;
-  background: var(--el-color-warning);
+  background: var(--color-warning);
   flex-shrink: 0;
 }
 
@@ -1274,8 +1288,8 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 .editor-toolbar {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: var(--space-form-field);
+  margin-bottom: var(--space-block);
 }
 
 .unsaved-banner {
@@ -1284,7 +1298,7 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 
 .toolbar-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   justify-content: flex-end;
   flex-wrap: wrap;
   align-items: center;
@@ -1293,7 +1307,7 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 .launch-args-gui {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   width: 100%;
 }
 
@@ -1303,74 +1317,75 @@ onBeforeRouteLeave(async (_to, _from, next) => {
 }
 
 .sub-options {
-  margin: 0.25rem 0 0.5rem 1.5rem;
+  margin: var(--space-inline-tight) 0 var(--space-action-group)
+    var(--space-section);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   flex-wrap: wrap;
 }
 
 .nested-form-item {
-  margin-bottom: 0.5rem !important;
+  margin-bottom: var(--space-action-group) !important;
 }
 
 .nested-form-item :deep(.el-form-item__label) {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  padding-bottom: 0.25rem !important;
+  font-size: var(--font-size-14);
+  color: var(--color-text-secondary);
+  padding-bottom: var(--space-inline-tight) !important;
 }
 
 .resolution-fields {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
 }
 
 .resolution-sep {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .args-collapse {
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  background: var(--bg-tertiary);
-  margin: 0.5rem 0;
+  background: var(--color-bg-muted);
+  margin: var(--space-action-group) 0;
 }
 
 .args-collapse :deep(.el-collapse-item__header) {
   background: transparent;
-  border-bottom-color: var(--border);
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  padding: 0 0.75rem;
+  border-bottom-color: var(--color-border);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-14);
+  padding: 0 var(--space-form-field);
   height: 40px;
 }
 
 .args-collapse :deep(.el-collapse-item__content) {
-  padding: 0.75rem;
+  padding: var(--space-form-field);
 }
 
 .args-collapse :deep(.el-collapse-item__wrap) {
-  border-bottom-color: var(--border);
+  border-bottom-color: var(--color-border);
   background: transparent;
 }
 
 .advanced-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-form-field);
 }
 
 .advanced-section-title {
   margin: 0;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--text-secondary);
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-600);
+  color: var(--color-text-secondary);
 }
 
 .launch-args-advanced {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--space-inline-tight);
 }
 </style>

--- a/frontend/src/views/LicensesView.vue
+++ b/frontend/src/views/LicensesView.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="licenses-view">
     <h1 class="page-title">{{ t("licenses.title") }}</h1>
-    <el-text type="info" size="default" class="intro">
+    <p class="text-body-sm intro">
       {{ t("licenses.intro") }}
-    </el-text>
+    </p>
 
     <section class="licenses-section">
-      <h2 class="section-title">{{ t("licenses.frontend") }}</h2>
+      <h2 class="text-h2 section-title">{{ t("licenses.frontend") }}</h2>
       <el-table
         :data="npmLicensesArray"
         class="licenses-table"
@@ -30,7 +30,7 @@
         />
         <el-table-column :label="t('licenses.colLicense')" width="120">
           <template #default="{ row }">
-            <el-tag size="small">{{ row.licenses }}</el-tag>
+            <VtTag size="small" variant="neutral">{{ row.licenses }}</VtTag>
           </template>
         </el-table-column>
         <el-table-column :label="t('licenses.colRepo')" min-width="200">
@@ -44,14 +44,16 @@
             >
               {{ truncateUrl(row.repository) }}
             </a>
-            <el-text v-else type="info">-</el-text>
+            <span v-else class="text-caption repo-missing">{{
+              t("common.dash")
+            }}</span>
           </template>
         </el-table-column>
       </el-table>
     </section>
 
     <section class="licenses-section">
-      <h2 class="section-title">{{ t("licenses.backend") }}</h2>
+      <h2 class="text-h2 section-title">{{ t("licenses.backend") }}</h2>
       <el-table :data="goLicenses" style="width: 100%" size="small" stripe>
         <el-table-column
           prop="path"
@@ -64,7 +66,7 @@
         </el-table-column>
         <el-table-column :label="t('licenses.colLicense')" width="120">
           <template #default="{ row }">
-            <el-tag size="small">{{ row.license }}</el-tag>
+            <VtTag size="small" variant="neutral">{{ row.license }}</VtTag>
           </template>
         </el-table-column>
         <el-table-column :label="t('licenses.colRepo')" min-width="200">
@@ -78,7 +80,9 @@
             >
               {{ truncateUrl(row.repository) }}
             </a>
-            <el-text v-else type="info">-</el-text>
+            <span v-else class="text-caption repo-missing">{{
+              t("common.dash")
+            }}</span>
           </template>
         </el-table-column>
       </el-table>
@@ -89,6 +93,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import VtTag from "../components/VtTag.vue";
 
 const { t } = useI18n();
 import npmLicensesData from "../data/licenses.json";
@@ -136,33 +141,36 @@ function truncateUrl(url: string): string {
 
 .intro {
   display: block;
-  margin-bottom: 2rem;
-  line-height: 1.6;
+  margin: 0 0 var(--space-page);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
 }
 
 .licenses-section {
-  margin-bottom: 2.5rem;
+  margin-bottom: var(--space-48);
 }
 
 .section-title {
-  font-size: 1.1rem;
-  margin: 0 0 1rem;
-  color: var(--text-primary);
-  font-weight: 600;
+  margin: 0 0 var(--space-block);
+  color: var(--color-text-primary);
 }
 
 .package-name {
   font-family: ui-monospace, monospace;
-  font-size: 0.85rem;
+  font-size: var(--font-size-14);
 }
 
 .repo-link {
-  color: var(--accent);
+  color: var(--color-brand);
   text-decoration: none;
 }
 
 .repo-link:hover {
-  color: var(--accent-hover);
+  color: var(--color-brand-hover);
   text-decoration: underline;
+}
+
+.repo-missing {
+  color: var(--color-text-secondary);
 }
 </style>

--- a/frontend/src/views/SelfProfileView.vue
+++ b/frontend/src/views/SelfProfileView.vue
@@ -1,27 +1,21 @@
 <template>
   <div class="self-profile-view">
     <h1 class="page-title">{{ t("selfProfile.title") }}</h1>
-    <el-alert
+    <VtAlert
       v-if="!isLoggedIn"
+      variant="info"
       :title="t('selfProfile.loginRequired')"
-      type="info"
-      :closable="false"
-      show-icon
       class="login-hint"
     >
-      <template #default>
-        <router-link class="settings-link" :to="{ name: 'settings' }">
-          {{ t("selfProfile.openSettings") }}
-        </router-link>
-      </template>
-    </el-alert>
+      <router-link class="settings-link" :to="{ name: 'settings' }">
+        {{ t("selfProfile.openSettings") }}
+      </router-link>
+    </VtAlert>
     <div v-else-if="loading" class="msg">{{ t("selfProfile.loading") }}</div>
-    <el-alert
+    <VtAlert
       v-else-if="loadError && !selected"
+      variant="warning"
       :title="loadError"
-      type="warning"
-      :closable="false"
-      show-icon
     />
     <div v-else-if="selected" class="detail-wrap">
       <VrcUserCacheDetail
@@ -38,6 +32,7 @@
 import { onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import VrcUserCacheDetail from "../components/VrcUserCacheDetail.vue";
+import VtAlert from "../components/VtAlert.vue";
 import { useSessionUnlock } from "../composables/useSessionUnlock";
 import { App } from "../wails/app";
 import type { UserCacheDTO } from "../wails/app";
@@ -102,11 +97,11 @@ onMounted(async () => {
 }
 
 .login-hint {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-block);
 }
 
 .settings-link {
-  color: var(--el-color-primary);
+  color: var(--color-brand);
   text-decoration: none;
 }
 
@@ -115,8 +110,8 @@ onMounted(async () => {
 }
 
 .msg {
-  padding: 1rem;
-  color: var(--text-secondary);
+  padding: var(--space-block);
+  color: var(--color-text-secondary);
 }
 
 .detail-wrap {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -9,7 +9,7 @@
       <el-text type="info" size="small" class="hint block-hint">{{
         t("settings.languageHint")
       }}</el-text>
-      <el-select
+      <VtSelect
         class="language-select"
         :model-value="locale"
         data-testid="settings-ui-language"
@@ -20,7 +20,7 @@
         <el-option value="ko" :label="t('settingsLanguages.ko')" />
         <el-option value="zh-TW" :label="t('settingsLanguages.zhTW')" />
         <el-option value="zh-CN" :label="t('settingsLanguages.zhCN')" />
-      </el-select>
+      </VtSelect>
     </el-card>
 
     <!-- VRChat ログイン -->
@@ -71,44 +71,36 @@
             </router-link>
           </div>
         </div>
-        <el-alert
-          v-if="profileError"
-          :title="profileError"
-          type="error"
-          :closable="false"
-          show-icon
-        />
-        <el-tag type="success" size="large">{{
+        <VtAlert v-if="profileError" variant="danger" :title="profileError" />
+        <VtTag variant="success" size="large">{{
           t("settings.loggedInTag")
-        }}</el-tag>
+        }}</VtTag>
         <div class="login-actions">
-          <el-button
-            type="primary"
+          <VtButton
+            variant="tertiary"
             :loading="profileLoading"
             @click="loadSelfProfileSummary(true)"
           >
             {{ t("settings.refreshProfile") }}
-          </el-button>
-          <el-button type="primary" @click="refreshFriends">
+          </VtButton>
+          <VtButton variant="secondary" @click="refreshFriends">
             {{ t("settings.refreshFriends") }}
-          </el-button>
-          <el-button type="danger" plain @click="logout">
+          </VtButton>
+          <VtButton variant="danger" plain @click="logout">
             {{ t("settings.logout") }}
-          </el-button>
+          </VtButton>
         </div>
       </div>
       <div v-else class="login-form">
-        <el-alert
+        <VtAlert
           v-if="unlockState === 'needs-relogin' && unlockErrorMessage"
+          variant="warning"
           :title="unlockErrorMessage"
-          type="warning"
-          :closable="false"
-          show-icon
           class="login-error"
         />
         <el-form label-position="top" size="default">
           <el-form-item :label="t('settings.username')">
-            <el-input
+            <VtInput
               id="login-username"
               v-model="loginForm.username"
               :placeholder="t('settings.usernamePh')"
@@ -116,7 +108,7 @@
             />
           </el-form-item>
           <el-form-item :label="t('settings.password')">
-            <el-input
+            <VtInput
               id="login-password"
               v-model="loginForm.password"
               type="password"
@@ -126,23 +118,21 @@
             />
           </el-form-item>
           <el-form-item :label="t('settings.twoFactor')">
-            <el-input
+            <VtInput
               id="login-2fa"
               v-model="loginForm.twoFactorCode"
               :placeholder="t('settings.twoFactorPh')"
               autocomplete="one-time-code"
             />
           </el-form-item>
-          <el-alert
+          <VtAlert
             v-if="loginError"
+            variant="danger"
             :title="loginError"
-            type="error"
-            :closable="false"
-            show-icon
             class="login-error"
           />
-          <el-button
-            type="primary"
+          <VtButton
+            variant="primary"
             :loading="loginLoading"
             :disabled="
               loginLoading || !loginForm.username || !loginForm.password
@@ -150,7 +140,7 @@
             @click="login"
           >
             {{ loginLoading ? t("settings.loggingIn") : t("settings.login") }}
-          </el-button>
+          </VtButton>
         </el-form>
       </div>
     </el-card>
@@ -164,27 +154,29 @@
         <div v-for="field in pathFields" :key="field.key" class="path-row">
           <label class="path-label">{{ field.label }}</label>
           <div class="path-input-group">
-            <el-input
+            <VtInput
               v-model="pathSettings[field.key]"
               :placeholder="field.placeholder"
               @change="savePathSettings"
             />
-            <el-button
+            <VtButton
               v-for="btn in field.buttons"
               :key="btn.label"
+              variant="secondary"
               :data-testid="btn.testid"
               :title="btn.title"
               @click="btn.handler"
             >
               {{ btn.label }}
-            </el-button>
-            <el-button
-              type="primary"
+            </VtButton>
+            <VtButton
+              variant="secondary"
+              :data-testid="`path-validate-${field.key}`"
               :disabled="!pathSettings[field.key]"
               @click="validatePathField(field.key)"
             >
               {{ t("settings.validateExists") }}
-            </el-button>
+            </VtButton>
           </div>
           <el-text
             v-if="validateResult[field.key] !== null"
@@ -216,7 +208,7 @@
             t("settings.suppressSleepHint")
           }}</el-text>
         </div>
-        <el-switch
+        <VtSwitch
           v-model="suppressSleepWhileVRChat"
           class="power-switch"
           @change="saveSuppressSleepWhileVRChat"
@@ -251,9 +243,9 @@
       <el-text type="info" size="small" class="hint">{{
         t("settings.ossHint")
       }}</el-text>
-      <div style="margin-top: 0.75rem">
+      <div class="oss-link-row">
         <router-link class="btn-licenses" to="/licenses">
-          <el-button type="primary">{{ t("settings.ossButton") }}</el-button>
+          <VtButton variant="primary">{{ t("settings.ossButton") }}</VtButton>
         </router-link>
       </div>
     </el-card>
@@ -263,52 +255,49 @@
       <template #header>
         <span>{{ t("settings.dbSection") }}</span>
       </template>
-      <el-text
-        type="info"
-        size="small"
-        class="hint"
-        style="display: block; margin-bottom: 1rem"
-      >
+      <el-text type="info" size="small" class="hint db-hint">
         {{ t("settings.dbHint") }}
       </el-text>
-      <el-alert
+      <VtAlert
         v-if="maintenanceError"
+        variant="danger"
         :title="maintenanceError"
-        type="error"
-        :closable="false"
-        show-icon
-        style="margin-bottom: 0.75rem"
+        class="maintenance-error-alert"
       />
       <div class="maintenance-actions">
-        <el-button :loading="maintenanceLoading" @click="doVacuumDb">
+        <VtButton
+          variant="secondary"
+          :loading="maintenanceLoading"
+          @click="doVacuumDb"
+        >
           {{
             maintenanceLoading ? t("settings.running") : t("settings.vacuum")
           }}
-        </el-button>
-        <el-button
-          type="danger"
+        </VtButton>
+        <VtButton
+          variant="danger"
           plain
           :loading="maintenanceLoading"
           @click="doClearEncounters"
         >
           {{ t("settings.clearEncounters") }}
-        </el-button>
-        <el-button
-          type="danger"
+        </VtButton>
+        <VtButton
+          variant="danger"
           plain
           :loading="maintenanceLoading"
           @click="doClearScreenshots"
         >
           {{ t("settings.clearScreenshots") }}
-        </el-button>
-        <el-button
-          type="danger"
+        </VtButton>
+        <VtButton
+          variant="danger"
           plain
           :loading="maintenanceLoading"
           @click="doClearFriendsCache"
         >
           {{ t("settings.clearFriends") }}
-        </el-button>
+        </VtButton>
       </div>
     </el-card>
   </div>
@@ -317,12 +306,23 @@
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
-import { ElMessageBox, ElMessage } from "element-plus";
+import { ElMessageBox } from "element-plus";
+import VtAlert from "../components/VtAlert.vue";
+import VtButton from "../components/VtButton.vue";
+import VtInput from "../components/VtInput.vue";
+import VtSelect from "../components/VtSelect.vue";
+import VtSwitch from "../components/VtSwitch.vue";
+import VtTag from "../components/VtTag.vue";
+import {
+  VT_BUTTON_DANGER_CONFIRM_CLASS,
+  VT_BUTTON_SECONDARY_CANCEL_CLASS,
+} from "../components/vtButtonClasses";
 import { App } from "../wails/app";
 import type { PathSettingsDTO, UserCacheDTO } from "../wails/app";
 import { friendThumbUrl } from "../utils/vrcUserCacheDisplay";
 import { useSessionUnlock } from "../composables/useSessionUnlock";
 import { isAppLocale, setLanguage } from "../i18n";
+import { showToast } from "../utils/showToast";
 
 const {
   state: unlockState,
@@ -432,7 +432,7 @@ async function onLanguageChange(v: string) {
   try {
     await App.setLanguage(v);
   } catch (e) {
-    ElMessage.error(formatBackendError(e, t("settings.errLanguageSave")));
+    showToast.error(formatBackendError(e, t("settings.errLanguageSave")));
     return;
   }
   setLanguage(v);
@@ -534,7 +534,7 @@ async function savePathSettings() {
   try {
     await App.setPathSettings(pathSettings);
   } catch (e) {
-    ElMessage.error(formatBackendError(e, t("settings.errOperation")));
+    showToast.error(formatBackendError(e, t("settings.errOperation")));
     return;
   }
 }
@@ -612,6 +612,8 @@ async function runWithConfirm(
       confirmButtonText: t("common.execute"),
       cancelButtonText: t("common.cancel"),
       type: "warning",
+      confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
+      cancelButtonClass: VT_BUTTON_SECONDARY_CANCEL_CLASS,
     });
   } catch {
     return;
@@ -624,7 +626,7 @@ async function runWithConfirm(
       ? successMessage(typeof result === "number" ? result : undefined)
       : t("settings.complete");
     if (msg) {
-      ElMessage.success(msg);
+      showToast.success(msg);
     }
   } catch (e) {
     maintenanceError.value =
@@ -675,34 +677,34 @@ function doClearFriendsCache() {
 
 <style scoped>
 .settings-card {
-  margin-bottom: 1.5rem;
-  background: var(--bg-secondary) !important;
-  border-color: var(--border) !important;
+  margin-bottom: var(--space-section);
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
 }
 
 .settings-card :deep(.el-card__header) {
-  font-weight: 600;
-  border-bottom-color: var(--border);
+  font-weight: var(--font-weight-600);
+  border-bottom-color: var(--color-border);
 }
 
 .login-status {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-form-field);
 }
 
 .profile-loading {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
+  font-size: var(--font-size-12);
+  color: var(--color-text-secondary);
 }
 
 .current-user-card {
   display: flex;
-  gap: 1rem;
+  gap: var(--space-block);
   align-items: flex-start;
-  padding: 0.75rem;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  padding: var(--space-form-field);
+  background: var(--color-bg-muted);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
   max-width: 480px;
 }
@@ -711,38 +713,38 @@ function doClearFriendsCache() {
   flex-shrink: 0;
   border-radius: var(--radius);
   object-fit: cover;
-  background: var(--bg-primary);
+  background: var(--color-bg-base);
 }
 
 .current-user-details {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: var(--space-inline-tight);
 }
 
 .current-user-display-name {
   margin: 0;
-  font-size: 1.05rem;
-  font-weight: 600;
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-600);
 }
 
 .current-user-line {
   margin: 0;
-  font-size: 0.88rem;
+  font-size: var(--font-size-12);
   word-break: break-all;
 }
 
 .current-user-line.muted {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .self-profile-link {
   display: inline-block;
-  margin-top: 0.65rem;
+  margin-top: var(--space-action-group);
   color: var(--el-color-primary);
   text-decoration: none;
-  font-size: 0.9rem;
+  font-size: var(--font-size-12);
 }
 
 .self-profile-link:hover {
@@ -751,7 +753,7 @@ function doClearFriendsCache() {
 
 .login-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   flex-wrap: wrap;
 }
 
@@ -760,34 +762,47 @@ function doClearFriendsCache() {
 }
 
 .login-error {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-form-field);
 }
 
 .hint {
   display: block;
-  margin-top: 0.75rem;
+  margin-top: var(--space-form-field);
+}
+
+.db-hint {
+  display: block;
+  margin-bottom: var(--space-block);
+}
+
+.maintenance-error-alert {
+  margin-bottom: var(--space-form-field);
+}
+
+.oss-link-row {
+  margin-top: var(--space-form-field);
 }
 
 .path-settings {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-block);
 }
 
 .path-row {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--space-inline-tight);
 }
 
 .path-label {
-  font-size: 0.95rem;
-  color: var(--text-primary);
+  font-size: var(--font-size-14);
+  color: var(--color-text-primary);
 }
 
 .path-input-group {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   align-items: center;
   flex-wrap: wrap;
 }
@@ -800,8 +815,8 @@ function doClearFriendsCache() {
 .setting-row {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-block);
+  margin-bottom: var(--space-action-group);
 }
 
 .power-setting-row {
@@ -815,23 +830,23 @@ function doClearFriendsCache() {
 
 .block-hint {
   display: block;
-  margin-top: 0.35rem;
+  margin-top: var(--space-inline-tight);
 }
 
 .power-switch {
   flex-shrink: 0;
-  margin-top: 0.15rem;
+  margin-top: var(--space-inline-tight);
 }
 
 .maintenance-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
 }
 
 .language-select {
   display: block;
-  margin-top: 0.65rem;
+  margin-top: var(--space-action-group);
   max-width: 22rem;
   width: 100%;
 }

--- a/frontend/src/views/UserProfileDetailView.vue
+++ b/frontend/src/views/UserProfileDetailView.vue
@@ -2,12 +2,10 @@
   <div class="user-profile-detail-view">
     <h1 class="page-title">{{ t("userProfile.title") }}</h1>
     <div v-if="loading" class="msg">{{ t("userProfile.loading") }}</div>
-    <el-alert
+    <VtAlert
       v-else-if="loadError && !selected"
+      variant="warning"
       :title="loadError"
-      type="warning"
-      :closable="false"
-      show-icon
     />
     <div v-else-if="selected" class="detail-wrap">
       <VrcUserCacheDetail
@@ -23,6 +21,7 @@ import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import VrcUserCacheDetail from "../components/VrcUserCacheDetail.vue";
+import VtAlert from "../components/VtAlert.vue";
 import { App } from "../wails/app";
 import type { UserCacheDTO } from "../wails/app";
 
@@ -116,8 +115,8 @@ void load();
 }
 
 .msg {
-  padding: 1rem;
-  color: var(--text-secondary);
+  padding: var(--space-block);
+  color: var(--color-text-secondary);
 }
 
 .detail-wrap {

--- a/frontend/src/views/VideoView.vue
+++ b/frontend/src/views/VideoView.vue
@@ -13,11 +13,9 @@
       <p class="history-retention-hint">
         {{ t("video.historyRetentionHint", { days: logRetentionDays }) }}
       </p>
-      <el-alert
+      <VtAlert
         v-if="historyFetchError"
-        type="error"
-        :closable="false"
-        show-icon
+        variant="danger"
         class="block-hint"
         data-testid="video-history-fetch-error"
         :title="t('video.historyFetchError')"
@@ -52,15 +50,15 @@
           <template #default="{ row }">
             <div class="url-cell">
               <span class="url-text">{{ row.url }}</span>
-              <el-button
+              <VtButton
+                variant="primary"
                 link
-                type="primary"
                 size="small"
                 data-testid="video-history-copy-url"
                 @click="copyAttemptUrl(row.url)"
               >
                 {{ t("video.historyCopyUrl") }}
-              </el-button>
+              </VtButton>
             </div>
           </template>
         </el-table-column>
@@ -118,35 +116,27 @@
         <template v-else>
           <!-- 1. 注意・エラー（置換ブロック直下・1箇所） -->
           <div class="video-alerts" data-testid="ytdlp-alert-area">
-            <el-alert
+            <VtAlert
               v-if="actionError"
-              type="error"
-              :closable="false"
-              show-icon
+              variant="danger"
               class="block-hint"
               data-testid="ytdlp-error-banner"
               :title="actionError"
             />
-            <el-alert
+            <VtAlert
               v-else-if="!status.supported"
-              type="warning"
-              :closable="false"
-              show-icon
+              variant="warning"
               :title="userFacingReason(status.unsupportedReason ?? '')"
             />
             <template v-else>
-              <el-alert
-                type="warning"
-                :closable="false"
-                show-icon
+              <VtAlert
+                variant="warning"
                 class="block-hint"
                 :title="t('video.alwaysWarn')"
               />
-              <el-alert
+              <VtAlert
                 v-if="bannerError"
-                type="error"
-                :closable="false"
-                show-icon
+                variant="danger"
                 class="block-hint"
                 data-testid="ytdlp-error-banner"
                 :title="bannerError"
@@ -158,7 +148,7 @@
             <!-- 2. 操作エリア -->
             <section class="video-ops" data-testid="ytdlp-ops">
               <div class="video-switch-row">
-                <el-switch
+                <VtSwitch
                   v-model="maintainOn"
                   data-testid="ytdlp-maintain-switch"
                   :disabled="busy"
@@ -173,39 +163,46 @@
               </div>
 
               <div class="video-actions" data-testid="ytdlp-action-grid">
-                <el-button
+                <VtButton
+                  variant="secondary"
                   data-testid="ytdlp-check-latest"
                   :loading="checkLoading"
                   :disabled="busy"
                   @click="checkLatest"
                 >
                   {{ t("video.checkLatest") }}
-                </el-button>
-                <el-button
-                  type="primary"
+                </VtButton>
+                <VtButton
+                  variant="primary"
                   data-testid="ytdlp-update-cache"
                   :loading="updateLoading"
                   :disabled="busy"
                   @click="updateCache"
                 >
                   {{ t("video.updateCache") }}
-                </el-button>
-                <el-button
+                </VtButton>
+                <VtButton
+                  variant="secondary"
                   data-testid="ytdlp-open-cache-folder"
                   :disabled="busy"
                   @click="openCacheFolder"
                 >
-                  <el-icon class="btn-icon"><FolderOpened /></el-icon>
+                  <VtIcon size="default" class="btn-icon"
+                    ><FolderOpened
+                  /></VtIcon>
                   {{ t("video.openCacheFolder") }}
-                </el-button>
-                <el-button
+                </VtButton>
+                <VtButton
+                  variant="secondary"
                   data-testid="ytdlp-open-tools-folder"
                   :disabled="busy"
                   @click="openToolsFolder"
                 >
-                  <el-icon class="btn-icon"><FolderOpened /></el-icon>
+                  <VtIcon size="default" class="btn-icon"
+                    ><FolderOpened
+                  /></VtIcon>
                   {{ t("video.openToolsFolder") }}
-                </el-button>
+                </VtButton>
               </div>
 
               <p
@@ -227,10 +224,10 @@
                 :aria-controls="detailsPanelId"
                 @click="detailsExpanded = !detailsExpanded"
               >
-                <el-icon class="details-toggle-icon" aria-hidden="true">
+                <VtIcon size="default" class="details-toggle-icon" decorative>
                   <CaretBottom v-if="detailsExpanded" />
                   <CaretRight v-else />
-                </el-icon>
+                </VtIcon>
                 <span>{{ t("video.detailsToggle") }}</span>
               </button>
               <div
@@ -270,6 +267,14 @@ import { useI18n } from "vue-i18n";
 import { ElMessageBox } from "element-plus";
 import { CaretBottom, CaretRight, FolderOpened } from "@element-plus/icons-vue";
 import CookieLinkageSection from "../components/CookieLinkageSection.vue";
+import VtAlert from "../components/VtAlert.vue";
+import VtButton from "../components/VtButton.vue";
+import VtIcon from "../components/VtIcon.vue";
+import VtSwitch from "../components/VtSwitch.vue";
+import {
+  VT_BUTTON_DANGER_CONFIRM_CLASS,
+  VT_BUTTON_SECONDARY_CANCEL_CLASS,
+} from "../components/vtButtonClasses";
 import {
   App,
   type VideoPlaybackDTO,
@@ -487,6 +492,8 @@ async function onMaintainChange(on: boolean) {
           confirmButtonText: t("video.riskAckConfirm"),
           cancelButtonText: t("common.cancel"),
           type: "warning",
+          confirmButtonClass: VT_BUTTON_DANGER_CONFIRM_CLASS,
+          cancelButtonClass: VT_BUTTON_SECONDARY_CANCEL_CLASS,
         },
       );
       if (isViewStale(gen)) return;
@@ -661,13 +668,13 @@ onUnmounted(() => {
   box-sizing: border-box;
 }
 .video-card {
-  margin-top: 1rem;
+  margin-top: var(--space-block);
   width: 100%;
 }
 .history-retention-hint {
-  margin: 0 0 0.75rem;
-  color: var(--text-secondary);
-  font-size: 0.875rem;
+  margin: 0 0 var(--space-form-field);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-14);
 }
 .history-table {
   width: 100%;
@@ -675,7 +682,7 @@ onUnmounted(() => {
 .url-cell {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-action-group);
   min-width: 0;
 }
 .url-text {
@@ -685,33 +692,33 @@ onUnmounted(() => {
   min-width: 0;
 }
 .video-block-title {
-  margin: 0 0 0.75rem;
-  font-size: 1rem;
-  font-weight: 600;
+  margin: 0 0 var(--space-form-field);
+  font-size: var(--font-size-16);
+  font-weight: var(--font-weight-600);
 }
 .video-alerts {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-block);
 }
 .block-hint {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-form-field);
 }
 .video-ops {
-  margin-bottom: 1.25rem;
+  margin-bottom: var(--space-section);
 }
 .video-switch-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.75rem 1rem;
-  margin-bottom: 1rem;
+  gap: var(--space-form-field) var(--space-block);
+  margin-bottom: var(--space-block);
 }
 .switch-status {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 .video-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.75rem;
+  gap: var(--space-form-field);
   width: 100%;
   max-width: 40rem;
 }
@@ -721,53 +728,53 @@ onUnmounted(() => {
   justify-content: center;
 }
 .btn-icon {
-  margin-right: 0.25rem;
+  margin-right: var(--space-inline-tight);
   vertical-align: middle;
 }
 .video-status {
-  margin-top: 0.25rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border);
+  margin-top: var(--space-inline-tight);
+  padding-top: var(--space-block);
+  border-top: 1px solid var(--color-border);
 }
 .details-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-inline-tight);
   padding: 0;
   border: none;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font: inherit;
   cursor: pointer;
 }
 .details-toggle:hover {
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 .details-toggle-icon {
-  font-size: 0.9rem;
+  font-size: var(--font-size-14);
 }
 .details-panel {
-  margin-top: 0.75rem;
+  margin-top: var(--space-form-field);
 }
 .video-dl {
   display: grid;
   grid-template-columns: minmax(10rem, 14rem) 1fr;
-  gap: 0.4rem 1rem;
+  gap: var(--space-inline-tight) var(--space-block);
   margin: 0;
 }
 .video-dl dt {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 .video-dl dd {
   margin: 0;
 }
 .muted {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 .flash {
-  margin-top: 0.75rem;
+  margin-top: var(--space-form-field);
 }
 .flash-ok {
-  color: var(--el-color-success);
+  color: var(--color-success);
 }
 </style>

--- a/frontend/src/views/__tests__/AutomationView.spec.ts
+++ b/frontend/src/views/__tests__/AutomationView.spec.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
-import { ElMessage, ElMessageBox } from "element-plus";
+import { ElMessageBox } from "element-plus";
 import AutomationView from "../AutomationView.vue";
 import type { AutomationItemDTO } from "../../wails/app";
+import { showToast } from "../../utils/showToast";
+
+vi.mock("../../utils/showToast", () => ({
+  showToast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
 
 const {
   mockListAutomationItems,
@@ -83,16 +93,13 @@ describe("AutomationView unsaved guard", () => {
     const confirmSpy = vi
       .spyOn(ElMessageBox, "confirm")
       .mockResolvedValue("confirm" as never);
-    const errorSpy = vi
-      .spyOn(ElMessage, "error")
-      .mockImplementation(() => ({ close: () => {} }) as never);
 
     await wrapper.find(".rule-card").trigger("click");
     await flushPromises();
 
     expect(confirmSpy).toHaveBeenCalled();
     expect(mockSaveAutomationItem).toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalled();
+    expect(showToast.error).toHaveBeenCalled();
     // Still editing the draft (did not switch to seeded card editor).
     expect(wrapper.find(".rule-editor").exists()).toBe(true);
     expect(
@@ -100,7 +107,6 @@ describe("AutomationView unsaved guard", () => {
     ).toBe("Draft rule");
 
     confirmSpy.mockRestore();
-    errorSpy.mockRestore();
   });
 
   it("does not treat list refresh failure as save failure", async () => {
@@ -113,18 +119,13 @@ describe("AutomationView unsaved guard", () => {
     await flushPromises();
 
     mockListAutomationItems.mockRejectedValueOnce(new Error("list failed"));
-    const errorSpy = vi
-      .spyOn(ElMessage, "error")
-      .mockImplementation(() => ({ close: () => {} }) as never);
 
     await wrapper.find('[data-testid="save-item"]').trigger("click");
     await flushPromises();
 
     expect(mockSaveAutomationItem).toHaveBeenCalled();
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(showToast.error).not.toHaveBeenCalled();
     expect(wrapper.find('[data-testid="unsaved-banner"]').exists()).toBe(false);
-
-    errorSpy.mockRestore();
   });
 
   it("clears the editor when selecting an item with invalid JSON", async () => {
@@ -146,17 +147,11 @@ describe("AutomationView unsaved guard", () => {
     await flushPromises();
     expect(wrapper.find(".rule-editor").exists()).toBe(true);
 
-    const errorSpy = vi
-      .spyOn(ElMessage, "error")
-      .mockImplementation(() => ({ close: () => {} }) as never);
-
     await wrapper.findAll(".rule-card")[1]?.trigger("click");
     await flushPromises();
 
-    expect(errorSpy).toHaveBeenCalled();
+    expect(showToast.error).toHaveBeenCalled();
     expect(wrapper.find(".rule-editor").exists()).toBe(false);
-
-    errorSpy.mockRestore();
   });
 
   it("does not keep a generated id on the editor when save fails", async () => {
@@ -169,9 +164,6 @@ describe("AutomationView unsaved guard", () => {
     await flushPromises();
 
     mockSaveAutomationItem.mockRejectedValueOnce(new Error("save failed"));
-    const errorSpy = vi
-      .spyOn(ElMessage, "error")
-      .mockImplementation(() => ({ close: () => {} }) as never);
 
     await wrapper.find('[data-testid="save-item"]').trigger("click");
     await flushPromises();
@@ -180,7 +172,7 @@ describe("AutomationView unsaved guard", () => {
       mockSaveAutomationItem.mock.calls[0]?.[0] as AutomationItemDTO
     ).id;
     expect(firstId).toBeTruthy();
-    expect(errorSpy).toHaveBeenCalled();
+    expect(showToast.error).toHaveBeenCalled();
     expect(wrapper.find('[data-testid="unsaved-banner"]').exists()).toBe(true);
 
     mockSaveAutomationItem.mockResolvedValueOnce(undefined);
@@ -200,7 +192,5 @@ describe("AutomationView unsaved guard", () => {
     // Retry must mint a new id (editor did not keep the failed attempt's UUID).
     expect(secondId).toBeTruthy();
     expect(secondId).not.toBe(firstId);
-
-    errorSpy.mockRestore();
   });
 });

--- a/frontend/src/views/__tests__/ConfigView.spec.ts
+++ b/frontend/src/views/__tests__/ConfigView.spec.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createRouter, createWebHashHistory } from "vue-router";
-import { ElMessageBox, ElSlider, ElMessage } from "element-plus";
+import { ElMessageBox, ElSlider } from "element-plus";
 import ConfigView from "../ConfigView.vue";
 import { App } from "../../wails/app";
+import { showToast } from "../../utils/showToast";
 import type { VRChatConfigDTO } from "../../wails/app";
 
 const router = createRouter({
@@ -650,8 +651,10 @@ describe("ConfigView asset cache clear", () => {
     vi.spyOn(App, "clearVRChatAssetCache").mockResolvedValue(12);
     vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
     const successSpy = vi
-      .spyOn(ElMessage, "success")
-      .mockImplementation(() => ({ close: () => {} }));
+      .spyOn(showToast, "success")
+      .mockImplementation(() => ({
+        close: () => {},
+      }));
     const wrapper = await mountEditor();
 
     await wrapper

--- a/frontend/src/views/__tests__/FriendsView.spec.ts
+++ b/frontend/src/views/__tests__/FriendsView.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createRouter, createWebHashHistory } from "vue-router";
-import { ElMessage } from "element-plus";
 import FriendsView from "../FriendsView.vue";
 import { App, type UserCacheDTO } from "../../wails/app";
+import { showToast } from "../../utils/showToast";
 
 async function mountFriendsView(query: Record<string, string> = {}) {
   const router = createRouter({
@@ -325,10 +325,9 @@ describe("FriendsView", () => {
   });
 
   it("warns and removes vrcUserId query when id is not in friends list", async () => {
-    const noopHandler = { close: () => {} };
-    const warnSpy = vi
-      .spyOn(ElMessage, "warning")
-      .mockImplementation(() => noopHandler);
+    const warnSpy = vi.spyOn(showToast, "warning").mockImplementation(() => ({
+      close: () => {},
+    }));
     mockFriends.mockResolvedValue([
       minimalUser({
         vrcUserId: "1",

--- a/frontend/src/views/__tests__/LauncherView.spec.ts
+++ b/frontend/src/views/__tests__/LauncherView.spec.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { ElMessageBox } from "element-plus";
 import LauncherView from "../LauncherView.vue";
 import type { LaunchProfileDTO, LaunchArgsParsedDTO } from "../../wails/app";
+import { showToast } from "../../utils/showToast";
 
 const {
   mockLaunchProfiles,
@@ -682,9 +683,8 @@ describe("LauncherView", () => {
     );
   });
 
-  it("shows ElMessage.error when save fails", async () => {
-    const { ElMessage } = await import("element-plus");
-    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+  it("shows showToast.error when save fails", async () => {
+    const errorSpy = vi.spyOn(showToast, "error").mockImplementation(() => ({
       close: () => {},
     }));
     mockSaveLaunchProfile.mockRejectedValue(new Error("db locked"));
@@ -713,8 +713,7 @@ describe("LauncherView", () => {
   });
 
   it("shows error when save succeeds but profile is missing from list", async () => {
-    const { ElMessage } = await import("element-plus");
-    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+    const errorSpy = vi.spyOn(showToast, "error").mockImplementation(() => ({
       close: () => {},
     }));
     mockSaveLaunchProfile.mockResolvedValue(undefined);
@@ -760,8 +759,7 @@ describe("LauncherView", () => {
   });
 
   it("refreshes profile list after create failure even with empty selection", async () => {
-    const { ElMessage } = await import("element-plus");
-    const errorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
+    const errorSpy = vi.spyOn(showToast, "error").mockImplementation(() => ({
       close: () => {},
     }));
     mockLaunchProfiles.mockResolvedValueOnce([]).mockResolvedValueOnce([]);

--- a/frontend/src/views/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/__tests__/SettingsView.spec.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
-import { ElMessage, ElMessageBox } from "element-plus";
+import { ElMessageBox } from "element-plus";
 import { createRouter, createWebHashHistory } from "vue-router";
 import SettingsView from "../SettingsView.vue";
 import { App } from "../../wails/app";
 import * as I18nModule from "../../i18n";
 import { resetSessionUnlockForStorybook } from "../../composables/useSessionUnlock";
+import { showToast } from "../../utils/showToast";
+
+vi.mock("../../utils/showToast", () => ({
+  showToast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -36,11 +46,19 @@ function pathRowInput(wrapper: ReturnType<typeof mount>, rowIndex: number) {
   return wrapper.findAll(".path-row .el-input input")[rowIndex]!;
 }
 
+const pathFieldKeys = [
+  "vrchatPathWindows",
+  "steamPathLinux",
+  "outputLogPath",
+] as const;
+
 function validateExistsBtn(
   wrapper: ReturnType<typeof mount>,
   rowIndex: number,
 ) {
-  return wrapper.findAll(".path-row .el-button--primary")[rowIndex]!;
+  return wrapper.find(
+    `[data-testid="path-validate-${pathFieldKeys[rowIndex]}"]`,
+  );
 }
 
 function setupAppMocks() {
@@ -282,11 +300,6 @@ describe("SettingsView", () => {
 
   it("runs vacuum DB after confirmation", async () => {
     vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
-    const successSpy = vi
-      .spyOn(ElMessage, "success")
-      .mockImplementation(() => ({
-        close: () => {},
-      }));
     const wrapper = mountSettings();
     await flushPromises();
 
@@ -297,14 +310,11 @@ describe("SettingsView", () => {
     await flushPromises();
 
     expect(App.vacuumDb).toHaveBeenCalled();
-    expect(successSpy).toHaveBeenCalled();
+    expect(showToast.success).toHaveBeenCalled();
   });
 
   it("clears encounters after confirmation", async () => {
     vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
-    vi.spyOn(ElMessage, "success").mockImplementation(() => ({
-      close: () => {},
-    }));
     const wrapper = mountSettings();
     await flushPromises();
 
@@ -319,9 +329,6 @@ describe("SettingsView", () => {
 
   it("clears screenshots after confirmation", async () => {
     vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
-    vi.spyOn(ElMessage, "success").mockImplementation(() => ({
-      close: () => {},
-    }));
     const wrapper = mountSettings();
     await flushPromises();
 
@@ -336,9 +343,6 @@ describe("SettingsView", () => {
 
   it("clears friends cache after confirmation", async () => {
     vi.spyOn(ElMessageBox, "confirm").mockResolvedValue(undefined as never);
-    vi.spyOn(ElMessage, "success").mockImplementation(() => ({
-      close: () => {},
-    }));
     const wrapper = mountSettings();
     await flushPromises();
 
@@ -620,9 +624,6 @@ describe("SettingsView onLanguageChange", () => {
 
   it("does not call i18n setLanguage when App.setLanguage fails", async () => {
     vi.mocked(App.setLanguage).mockRejectedValueOnce(new Error("save failed"));
-    const elErrorSpy = vi.spyOn(ElMessage, "error").mockImplementation(() => ({
-      close: () => {},
-    }));
 
     const wrapper = mountSettings();
     await flushPromises();
@@ -634,7 +635,7 @@ describe("SettingsView onLanguageChange", () => {
     await flushPromises();
 
     expect(I18nModule.setLanguage).not.toHaveBeenCalled();
-    expect(elErrorSpy).toHaveBeenCalledWith("save failed");
+    expect(showToast.error).toHaveBeenCalledWith("save failed");
   });
 
   it("ignores invalid locale values", async () => {

--- a/frontend/src/views/friends/FriendsListPanel.vue
+++ b/frontend/src/views/friends/FriendsListPanel.vue
@@ -18,9 +18,9 @@
       <div v-else class="friend-thumb friend-thumb-placeholder" />
       <span class="friend-name">{{ f.displayName }}</span>
       <VrcStatusTag :status="f.status" />
-      <el-button
+      <VtButton
         link
-        :type="f.isFavorite ? 'primary' : 'info'"
+        :variant="f.isFavorite ? 'primary' : 'tertiary'"
         :title="
           f.isFavorite
             ? t('friendsList.favoriteRemove')
@@ -30,7 +30,7 @@
         @click.stop="emit('toggleFavorite', f)"
       >
         ★
-      </el-button>
+      </VtButton>
     </div>
     <p v-if="friends.length === 0 && !loading" class="empty-message">
       {{ emptyMessage }}
@@ -41,6 +41,7 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import VrcStatusTag from "../../components/VrcStatusTag.vue";
+import VtButton from "../../components/VtButton.vue";
 import type { UserCacheDTO } from "../../wails/app";
 import { friendThumbUrl } from "@/utils/vrcUserCacheDisplay";
 
@@ -73,10 +74,10 @@ const emit = defineEmits<{
 .friend-card {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-  background: var(--bg-secondary);
+  gap: var(--space-action-group);
+  padding: var(--space-form-field);
+  margin-bottom: var(--space-action-group);
+  background: var(--color-bg-elevated);
   border-radius: var(--radius);
   cursor: pointer;
   transition: background 0.15s;
@@ -84,7 +85,7 @@ const emit = defineEmits<{
 
 .friend-card:hover,
 .friend-card.active {
-  background: var(--bg-tertiary);
+  background: var(--color-bg-muted);
 }
 
 .friend-thumb {
@@ -96,13 +97,13 @@ const emit = defineEmits<{
 }
 
 .friend-thumb-placeholder {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  background: var(--color-bg-muted);
+  border: 1px solid var(--color-border);
 }
 
 .friend-name {
   flex: 1;
-  font-weight: 500;
+  font-weight: var(--font-weight-500);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -111,13 +112,13 @@ const emit = defineEmits<{
 
 .btn-favorite {
   flex-shrink: 0;
-  font-size: 1rem !important;
-  padding: 0 4px !important;
+  font-size: var(--font-size-16) !important;
+  padding: 0 var(--space-inline-tight) !important;
 }
 
 .empty-message {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  margin: 1rem 0;
+  font-size: var(--font-size-14);
+  color: var(--color-text-secondary);
+  margin: var(--space-block) 0;
 }
 </style>

--- a/frontend/src/views/friends/FriendsViewToolbar.vue
+++ b/frontend/src/views/friends/FriendsViewToolbar.vue
@@ -18,8 +18,8 @@
           >Offline</span
         >
       </div>
-      <el-button
-        type="primary"
+      <VtButton
+        variant="primary"
         :disabled="!isLoggedIn || refreshLoading"
         :loading="refreshLoading"
         :title="
@@ -30,9 +30,9 @@
         @click="emit('refresh')"
       >
         {{ refreshLoading ? t("common.updating") : t("common.refresh") }}
-      </el-button>
+      </VtButton>
     </div>
-    <el-input
+    <VtInput
       v-model.trim="displayNameQuery"
       type="search"
       :placeholder="t('friends.searchPlaceholder')"
@@ -42,15 +42,18 @@
       autocomplete="off"
     >
       <template #prefix>
-        <el-icon><Search /></el-icon>
+        <VtIcon size="default"><Search /></VtIcon>
       </template>
-    </el-input>
+    </VtInput>
   </div>
 </template>
 
 <script setup lang="ts">
 import { Search } from "@element-plus/icons-vue";
 import { useI18n } from "vue-i18n";
+import VtButton from "../../components/VtButton.vue";
+import VtIcon from "../../components/VtIcon.vue";
+import VtInput from "../../components/VtInput.vue";
 
 const { t } = useI18n();
 
@@ -73,16 +76,16 @@ const displayNameQuery = defineModel<string>("displayNameQuery", {
 
 <style scoped>
 .friends-toolbar {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-block);
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: var(--space-form-field);
 }
 
 .friends-header {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-block);
 }
 
 .friends-search-input {
@@ -92,19 +95,19 @@ const displayNameQuery = defineModel<string>("displayNameQuery", {
 .filter-mode {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: var(--space-form-field);
   flex-wrap: wrap;
 }
 
 .mode-label {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
+  font-size: var(--font-size-14);
+  color: var(--color-text-secondary);
   min-width: 3.25rem;
   transition: color 0.15s ease;
 }
 
 .mode-label.active {
-  color: var(--text-primary);
-  font-weight: 600;
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-600);
 }
 </style>


### PR DESCRIPTION
## Summary
- Apply the design system (VtButton / Form / VtAlert / VtTag / showToast / color·spacing·typography·icon tokens) across all existing views and shared UI components.
- Document the intentional bulk adoption campaign as [ADR 0024](docs/adr/0024-bulk-design-system-adoption-campaign.md) (exception to touch-and-migrate in ADR 0017–0023) and link it from `CONTEXT.md`.
- Leave documented exceptions in place: Presence semantic buttons, Friends Online/Offline UI mode switch, Domain badges, and EP controls without Vt* wrappers (`el-input-number`, `el-table`, etc.).

## Test plan
- [x] `make fmt`
- [x] `make test` (Go + frontend Vitest 569)
- [x] `make lint`
- [x] `make test-e2e` (58 passed)
- [ ] Spot-check Storybook catalogs / key views (Settings, Launcher, Automation, Gallery) in `wails dev` or Storybook
- [ ] Confirm Presence color buttons and Friends Online/Offline switch still behave as before


Made with [Cursor](https://cursor.com)