### PR TITLE
refactor(automation): remove unused LegacyEvalRule

### DIFF
--- a/internal/domain/automation/evaluate.go
+++ b/internal/domain/automation/evaluate.go
@@ -171,15 +171,6 @@ func SortItemsByID(items []*AutomationItem) []*AutomationItem {
 	return out
 }
 
-// LegacyEvalRule evaluates old AutomationRule shape (tests / migration).
-func LegacyEvalRule(rule *AutomationRule, ctx *EvalContext) (bool, error) {
-	if rule == nil || !rule.IsEnabled {
-		return false, nil
-	}
-	item := RuleToItem(rule)
-	return EvalItem(item, ctx)
-}
-
 // RuleToItem converts a legacy rule row.
 func RuleToItem(rule *AutomationRule) *AutomationItem {
 	if rule == nil {


### PR DESCRIPTION
## Summary
- Remove `LegacyEvalRule`, a thin wrapper around `RuleToItem` + `EvalItem` with zero callers.
- Keep `RuleToItem` for legacy migration paths.

## Test plan
- [x] `go test ./internal/domain/automation/...`


Made with [Cursor](https://cursor.com)