### PR TITLE
feat(frontend): replace sidebar emoji with EP Navigation glyphs

### DIFF
--- a/.cursor/rules/iconography-design-system.mdc
+++ b/.cursor/rules/iconography-design-system.mdc
@@ -13,7 +13,7 @@ alwaysApply: false
 | 含む | 含まない |
 |------|----------|
 | **UI icon**（`@element-plus/icons-vue` + **VtIcon**） | アバター・サムネ |
-| **Navigation glyph**（絵文字。v1 はサイズのみ） | Server status ドット |
+| **Navigation glyph**（サイドバー。`navMenuItems.ts` + **VtIcon**） | Server status ドット |
 | **Domain icon**（friend mark 等） | Presence 色ボタン |
 | **Custom icon**（`frontend/src/icons/*.vue`） | EP 全件グローバル登録 |
 
@@ -30,13 +30,12 @@ alwaysApply: false
 
 Legacy（v1 見た目不変）: `--icon-size-legacy-toggle` → `--font-size-14`（adoption 先: `--icon-size-default`）
 
-**Navigation glyph** 絵文字: `.nav-glyph-size-compact` / `.nav-glyph-size-default` / `.nav-glyph-size-legacy`（14px 現行サイドバー）等（`VtIcon` で包まない）
+**Navigation glyph**（サイドバー）: `frontend/src/navigation/navMenuItems.ts` の Element Plus アイコン + `<VtIcon size="default">`。色は親メニュー項目の `currentColor`。
 
 ## Icon color rule
 
 - SVG / EP: **`currentColor`**。親は **Neutral text token**
 - 装飾単体: `--color-text-secondary`
-- 絵文字: サイズのみ（色は固有）
 - **Semantic / Domain color** を汎用 UI icon に直付けしない
 
 ## VtIcon
@@ -58,7 +57,7 @@ Legacy（v1 見た目不変）: `--icon-size-legacy-toggle` → `--font-size-14`
 ## 移行（Iconography adoption）
 
 - 新規・改修は **VtIcon** + icon トークン
-- 未触りの `<el-icon>` / 絵文字直書きは一括置換しない
+- 未触りの `<el-icon>` 直書きは一括置換しない
 - スケール外寸法は **四捨五入で最寄り**（14→16）。v1 deliverables では寄せない
 - ESLint 禁止は v1 では入れない
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1204,8 +1204,12 @@ _Avoid_: アイコン（実装部品名だけ）, 絵文字（**Navigation glyph
 _Avoid_: el-icon（実装タグ名だけ）, アイコンフォント（EP は Vue コンポーネント）
 
 **Navigation glyph**:
-サイドバー等のナビ項目左に置く目的地を示すグリフ。現行は Unicode 絵文字（🏠 等）だが、**Iconography** では **UI icon** と同じサイズ段階・スロット幅で扱う（将来 SVG／EP アイコンへ置換してよい）。テキストラベル（`nav.*`）とは別要素。
-_Avoid_: サイドバーアイコン（実装クラス名だけ）, ファビコン, アプリアイコン（OS／インストーラ資産）
+サイドバー等のナビ項目左に置く目的地を示すグリフ。正本は `@element-plus/icons-vue` を **VtIcon** で包んだ **UI icon**（サイズは `default` = 16px）。テキストラベル（`nav.*`）とは別要素で、装飾として **Icon color rule**（`currentColor`）に従う。
+_Avoid_: サイドバーアイコン（実装クラス名だけ）, ファビコン, アプリアイコン（OS／インストーラ資産）, Unicode 絵文字（移行済みの俗称）
+
+**Navigation glyph catalog**:
+アプリ主ナビの **Navigation glyph** 一覧の正本。`frontend/src/navigation/navMenuItems.ts` にルート path・i18n ラベルキー（`nav.*`）・Element Plus アイコン・プラットフォーム条件（例: Windows のみ）を定義する。サイドバーと **Iconography Storybook catalog** は同じ配列を参照する。
+_Avoid_: main.ts の RouteMeta（画面タイトル用 `routes.*` と混同）, Sidebar 内の直書き配列（正本の二重管理）
 
 **Domain icon**:
 特定画面・ドメインだけが持つ意味付きグリフ。**Domain badge**（`el-tag` チップ）・**Semantic button**（Presence 色ボタン）・Server status の色ドットとは別。サイズと配置は **Iconography**、色の意味は各ドメイン（例: **Encounter friend mark** は **Neutral text** 系）。**Semantic color catalog** や **Presence color** を横断フィードバックとして流用しない。
@@ -1244,16 +1248,16 @@ Iconography における色の付け方の正本。SVG／Element Plus アイコ�
 _Avoid_: アイコン専用パレット（**App color token** と二重管理）, hex 直書き, danger 赤の単独 UI icon（**Semantic button** / **VtButton** と混同しやすいため）
 
 **Navigation glyph color**:
-**Navigation glyph** が Unicode 絵文字の間は **Icon color rule** の CSS `color` は効かない（絵文字固有の色）。v1 では **Icon size scale** のみ揃える。SVG／EP アイコンへ置換後は、メニュー項目の `color` 継承（`currentColor`）に従い **Neutral text**／active 時 **primary** を親が担当する。**Brand color** をナビ専用に追加しない（サイドバー active は既存の左ボーダー等で足りる）。
-_Avoid_: 絵文字の色統一（不可能なため）, ナビ active の Brand 固定（**Icon color rule** 案 C）
+**Navigation glyph** の色は **Icon color rule** に従い、メニュー項目の `color` 継承（`currentColor`）で **Neutral text**／active 時 **primary** を親が担当する。**Brand color** をナビ専用に追加しない（サイドバー active は既存の左ボーダー等で足りる）。
+_Avoid_: ナビ active の Brand 固定（**Icon color rule** 案 C）, 絵文字固有色（移行済み）
 
 **Icon color adoption**:
 **Icon color rule** への移行方針。新規・改修で触ったファイルではレガシー `--text-*` や hex をアイコンに増やさず、親の **Neutral text token** または `currentColor` に寄せる。未着手の既存 View は一括置換しない。
 _Avoid_: 全面置換, アイコンに Brand 直指定の新規増殖
 
 **VtIcon**:
-**UI icon**・**Custom icon** の標準ラッパー。内部は `el-icon`。**Icon size pattern** に対応する `size` prop（`compact` | `default` | `emphasis` | `large`）を**必須**とし、暗黙既定は持たない。色は **Icon color rule** に従い `currentColor`（親の **Neutral text token**）。`data-testid` 等は透過。**Navigation glyph** の Unicode 絵文字は v1 では `VtIcon` で包まず、同じ **Icon size token**／pattern クラスを `span` 等に当てる（SVG 化後は `VtIcon` に寄せる）。
-_Avoid_: el-icon（移行完了後の直呼び）, Icon component（汎用フレームワークの俗称）
+**UI icon**・**Custom icon**・**Navigation glyph** の標準ラッパー。内部は `el-icon`。**Icon size pattern** に対応する `size` prop（`compact` | `default` | `emphasis` | `large`）を**必須**とし、暗黙既定は持たない。色は **Icon color rule** に従い `currentColor`（親の **Neutral text token**）。`data-testid` 等は透過。サイドバー **Navigation glyph** は `size="default"` と装飾既定（`aria-hidden`）を使う。
+_Avoid_: el-icon（移行完了後の直呼び）, Icon component（汎用フレームワークの俗称）, `.nav-glyph-size-*`（絵文字期のレガシー）
 
 **VtIcon adoption**:
 VtIcon への移行方針。新規・改修で **UI icon** には **VtIcon** を使う。未着手の `<el-icon>` 直書きは一括置換しない（触ったところから順次）。ESLint 強制は v1 では入れない。見た目の正本は **Iconography Storybook catalog**。
@@ -1264,12 +1268,12 @@ _Avoid_: 全面置換, el-icon 禁止の CI 強制（即時一括・CI 強制を
 _Avoid_: 生 SVG ファイル直置き（`.svg` を import するだけ）, PNG アイコン, インライン `<svg>` の View 直書き（再利用グリフの場合）
 
 **Iconography Storybook catalog**:
-Iconography の Storybook 一覧。**Icon size scale**・**Icon size pattern** 対応表、**Icon color rule** 要点、**VtIcon** の 4 `size`、EP 代表アイコン（Search / Caret）と **Custom icon component** 1 例、**Navigation glyph**（絵文字サイズ揃え）の使用例を載せる（**Spacing Storybook catalog** / **Color Storybook catalog** と同型）。
-_Avoid_: 全画面 Storybook, EP Icons 全件一覧
+Iconography の Storybook 一覧。**Icon size scale**・**Icon size pattern** 対応表、**Icon color rule** 要点、**VtIcon** の 4 `size`、EP 代表アイコン（Search / Caret）と **Custom icon component** 1 例、**Navigation glyph catalog** の **VtIcon** 一覧を載せる（**Spacing Storybook catalog** / **Color Storybook catalog** と同型）。
+_Avoid_: 全画面 Storybook, EP Icons 全件一覧, 絵文字サイズ例（移行済み）
 
 **Iconography adoption**:
-Iconography トークン・**VtIcon**・**Icon color rule** への移行方針。新規・改修で触ったファイルでは **Icon size token**／**VtIcon**／`currentColor` を使う。未着手の既存 `<el-icon>`・任意 px・絵文字サイズ直書きは一括置換しない。**Iconography v1 deliverables** の共有スタイルと Storybook は v1 で寄せる。サイドバー SVG 化は後続。**Iconography migration rounding** は adoption 時のみ。
-_Avoid_: 全面置換, 絵文字即時 SVG 化の v1 強制
+Iconography トークン・**VtIcon**・**Icon color rule** への移行方針。新規・改修で触ったファイルでは **Icon size token**／**VtIcon**／`currentColor` を使う。未着手の既存 `<el-icon>`・任意 px 直書きは一括置換しない。**Iconography migration rounding** は adoption 時のみ。サイドバー **Navigation glyph** の EP 化は完了済み（**Navigation glyph catalog** 正本）。
+_Avoid_: 全面置換, サイドバー絵文字への回帰
 
 **Iconography v1 deliverables**:
 Issue／PR で最初に届ける具体物。(1) `frontend/src/assets/style.css` の **Icon size token**・**Icon size pattern**、(2) `frontend/src/design/iconTokens.ts` + 単体テスト、(3) **VtIcon** + variants + 単体テスト、(4) **Iconography Storybook catalog**（EP 代表 + **Custom icon component** サンプル 1 例 + **Navigation glyph** サイズ例）、(5) 共有スタイル（`.section-card__toggle-icon` 等）のトークン参照化（**Iconography v1 visual policy**）、(6) `.cursor/rules/iconography-design-system.mdc`、(7) `docs/adr/0023-iconography-design-system.md`（**Icon accessibility rule** を含む）、(8) `CONTEXT.md` 同期。各 View の `<el-icon>` 直書きは **Iconography adoption** のみ。

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -56,7 +56,7 @@ test.describe("Navigation", () => {
     });
   }
 
-  test("footer settings (⚙️ 設定) navigates to settings", async ({ page }) => {
+  test("footer settings navigates to settings", async ({ page }) => {
     await page.goto("/");
     await page
       .locator(".sidebar-footer")

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -385,12 +385,7 @@ a:hover {
 .vt-icon--size-compact,
 .vt-icon--size-default,
 .vt-icon--size-emphasis,
-.vt-icon--size-large,
-.nav-glyph-size-compact,
-.nav-glyph-size-default,
-.nav-glyph-size-legacy,
-.nav-glyph-size-emphasis,
-.nav-glyph-size-large {
+.vt-icon--size-large {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -412,25 +407,5 @@ a:hover {
 }
 
 .vt-icon--size-large {
-  font-size: var(--icon-size-large);
-}
-
-.nav-glyph-size-compact {
-  font-size: var(--icon-size-compact);
-}
-
-.nav-glyph-size-default {
-  font-size: var(--icon-size-default);
-}
-
-.nav-glyph-size-legacy {
-  font-size: var(--icon-size-legacy-toggle);
-}
-
-.nav-glyph-size-emphasis {
-  font-size: var(--icon-size-emphasis);
-}
-
-.nav-glyph-size-large {
   font-size: var(--icon-size-large);
 }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -6,15 +6,19 @@
         :key="item.path"
         :index="item.path"
       >
-        <span class="sidebar-icon nav-glyph-size-default">{{ item.icon }}</span>
+        <VtIcon size="default" class="sidebar-icon">
+          <component :is="item.icon" />
+        </VtIcon>
         <template #title>{{ item.label }}</template>
       </el-menu-item>
     </el-menu>
     <div class="sidebar-footer">
       <el-menu :default-active="route.path" router class="sidebar-nav">
-        <el-menu-item index="/settings">
-          <span class="sidebar-icon nav-glyph-size-default">⚙️</span>
-          <template #title>{{ t("nav.settings") }}</template>
+        <el-menu-item :index="settingsItem.path">
+          <VtIcon size="default" class="sidebar-icon">
+            <component :is="settingsItem.icon" />
+          </VtIcon>
+          <template #title>{{ settingsItem.label }}</template>
         </el-menu-item>
       </el-menu>
     </div>
@@ -25,6 +29,11 @@
 import { computed, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
+import {
+  NAV_MAIN_MENU_ITEMS,
+  NAV_SETTINGS_MENU_ITEM,
+} from "../navigation/navMenuItems";
+import VtIcon from "./VtIcon.vue";
 import { App } from "../wails/app";
 
 const route = useRoute();
@@ -39,28 +48,19 @@ onMounted(async () => {
   }
 });
 
-const menuItems = computed(() => {
-  const items = [
-    { path: "/", icon: "🏠", label: t("nav.dashboard") },
-    { path: "/launcher", icon: "🚀", label: t("nav.launcher") },
-    { path: "/gallery", icon: "🖼️", label: t("nav.gallery") },
-    { path: "/activity", icon: "📊", label: t("nav.activity") },
-    { path: "/me", icon: "👤", label: t("nav.me") },
-    { path: "/friends", icon: "👥", label: t("nav.friends") },
-    { path: "/automation", icon: "🤖", label: t("nav.automation") },
-    { path: "/config", icon: "📝", label: t("nav.configOther") },
-  ];
-  if (isWindows.value) {
-    const configIdx = items.findIndex((item) => item.path === "/config");
-    const insertAt = configIdx === -1 ? items.length : configIdx;
-    return [
-      ...items.slice(0, insertAt),
-      { path: "/video", icon: "🎬", label: t("nav.video") },
-      ...items.slice(insertAt),
-    ];
-  }
-  return items;
-});
+const menuItems = computed(() =>
+  NAV_MAIN_MENU_ITEMS.filter(
+    (item) => !item.windowsOnly || isWindows.value,
+  ).map((item) => ({
+    ...item,
+    label: t(item.labelKey),
+  })),
+);
+
+const settingsItem = computed(() => ({
+  ...NAV_SETTINGS_MENU_ITEM,
+  label: t(NAV_SETTINGS_MENU_ITEM.labelKey),
+}));
 </script>
 
 <style scoped>

--- a/frontend/src/components/__tests__/Sidebar.spec.ts
+++ b/frontend/src/components/__tests__/Sidebar.spec.ts
@@ -57,4 +57,15 @@ describe("Sidebar", () => {
     await flushPromises();
     expect(wrapper.text()).toContain("動画");
   });
+
+  it("renders VtIcon navigation glyphs without emoji", async () => {
+    const wrapper = mount(Sidebar, {
+      global: {
+        plugins: [router],
+      },
+    });
+    await flushPromises();
+    expect(wrapper.findAll(".vt-icon").length).toBeGreaterThanOrEqual(8);
+    expect(wrapper.html()).not.toMatch(/[\u{1F300}-\u{1FAFF}]/u);
+  });
 });

--- a/frontend/src/design/Iconography.stories.ts
+++ b/frontend/src/design/Iconography.stories.ts
@@ -3,6 +3,10 @@ import { CaretRight, Search } from "@element-plus/icons-vue";
 import VtIcon from "../components/VtIcon.vue";
 import SampleIcon from "../icons/SampleIcon.vue";
 import {
+  NAV_MAIN_MENU_ITEMS,
+  NAV_SETTINGS_MENU_ITEM,
+} from "../navigation/navMenuItems";
+import {
   ICON_SIZE_LEGACY,
   ICON_SIZE_PATTERNS,
   VT_ICON_SIZES,
@@ -128,23 +132,32 @@ export const ColorRule: Story = {
 };
 
 export const NavigationGlyph: Story = {
-  name: "Navigation glyph (emoji)",
+  name: "Navigation glyph",
   render: () => ({
+    components: { VtIcon },
+    setup: () => ({
+      mainItems: NAV_MAIN_MENU_ITEMS,
+      settingsItem: NAV_SETTINGS_MENU_ITEM,
+    }),
     template: `
       <div class="iconography-story">
         <h2>Navigation glyph</h2>
-        <p>Emoji keep intrinsic colors. Align size with <code>.nav-glyph-size-default</code> until SVG migration.</p>
-        <div class="iconography-story-nav-row">
-          <span class="nav-glyph-size-legacy" aria-hidden="true">🏠</span>
-          <span>Dashboard (legacy 14px — current sidebar)</span>
+        <p>Catalog from <code>navMenuItems.ts</code>. Sidebar uses <code>VtIcon size="default"</code> and menu <code>currentColor</code>.</p>
+        <div
+          v-for="item in mainItems"
+          :key="item.path"
+          class="iconography-story-nav-row iconography-story-color--secondary"
+        >
+          <VtIcon size="default">
+            <component :is="item.icon" />
+          </VtIcon>
+          <span><code>{{ item.path }}</code> · <code>{{ item.labelKey }}</code><span v-if="item.windowsOnly"> (Windows only)</span></span>
         </div>
-        <div class="iconography-story-nav-row">
-          <span class="nav-glyph-size-default" aria-hidden="true">🏠</span>
-          <span>Dashboard (default 16px — adoption target)</span>
-        </div>
-        <div class="iconography-story-nav-row">
-          <span class="nav-glyph-size-compact" aria-hidden="true">📊</span>
-          <span>Activity (compact)</span>
+        <div class="iconography-story-nav-row iconography-story-color--secondary">
+          <VtIcon size="default">
+            <component :is="settingsItem.icon" />
+          </VtIcon>
+          <span><code>{{ settingsItem.path }}</code> · <code>{{ settingsItem.labelKey }}</code> (footer)</span>
         </div>
       </div>
     `,

--- a/frontend/src/design/Iconography.stories.ts
+++ b/frontend/src/design/Iconography.stories.ts
@@ -135,10 +135,19 @@ export const NavigationGlyph: Story = {
   name: "Navigation glyph",
   render: () => ({
     components: { VtIcon },
-    setup: () => ({
-      mainItems: NAV_MAIN_MENU_ITEMS,
-      settingsItem: NAV_SETTINGS_MENU_ITEM,
-    }),
+    setup: () => {
+      const mainItems = NAV_MAIN_MENU_ITEMS.map((item) => ({
+        ...item,
+        detail: item.windowsOnly
+          ? `${item.path} · ${item.labelKey} (Windows only)`
+          : `${item.path} · ${item.labelKey}`,
+      }));
+      const settingsItem = {
+        ...NAV_SETTINGS_MENU_ITEM,
+        detail: `${NAV_SETTINGS_MENU_ITEM.path} · ${NAV_SETTINGS_MENU_ITEM.labelKey} (footer)`,
+      };
+      return { mainItems, settingsItem };
+    },
     template: `
       <div class="iconography-story">
         <h2>Navigation glyph</h2>
@@ -151,13 +160,13 @@ export const NavigationGlyph: Story = {
           <VtIcon size="default">
             <component :is="item.icon" />
           </VtIcon>
-          <span><code>{{ item.path }}</code> · <code>{{ item.labelKey }}</code><span v-if="item.windowsOnly"> (Windows only)</span></span>
+          <span><code>{{ item.detail }}</code></span>
         </div>
         <div class="iconography-story-nav-row iconography-story-color--secondary">
           <VtIcon size="default">
             <component :is="settingsItem.icon" />
           </VtIcon>
-          <span><code>{{ settingsItem.path }}</code> · <code>{{ settingsItem.labelKey }}</code> (footer)</span>
+          <span><code>{{ settingsItem.detail }}</code></span>
         </div>
       </div>
     `,

--- a/frontend/src/navigation/__tests__/navMenuItems.spec.ts
+++ b/frontend/src/navigation/__tests__/navMenuItems.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { NAV_MAIN_MENU_ITEMS, NAV_SETTINGS_MENU_ITEM } from "../navMenuItems";
+
+describe("navMenuItems", () => {
+  it("defines unique paths for main nav items", () => {
+    const paths = NAV_MAIN_MENU_ITEMS.map((item) => item.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("marks video as Windows-only", () => {
+    const video = NAV_MAIN_MENU_ITEMS.find((item) => item.path === "/video");
+    expect(video?.windowsOnly).toBe(true);
+  });
+
+  it("keeps settings in a separate footer item", () => {
+    expect(NAV_SETTINGS_MENU_ITEM.path).toBe("/settings");
+    expect(
+      NAV_MAIN_MENU_ITEMS.some(
+        (item) => item.path === NAV_SETTINGS_MENU_ITEM.path,
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/navigation/navMenuItems.ts
+++ b/frontend/src/navigation/navMenuItems.ts
@@ -1,0 +1,44 @@
+import type { Component } from "vue";
+import {
+  Cpu,
+  DataLine,
+  EditPen,
+  House,
+  Picture,
+  Promotion,
+  Setting,
+  User,
+  UserFilled,
+  VideoCamera,
+} from "@element-plus/icons-vue";
+
+export type NavMenuItem = {
+  path: string;
+  labelKey: string;
+  icon: Component;
+  windowsOnly?: boolean;
+};
+
+/** Main sidebar navigation entries (footer settings excluded). */
+export const NAV_MAIN_MENU_ITEMS: readonly NavMenuItem[] = [
+  { path: "/", labelKey: "nav.dashboard", icon: House },
+  { path: "/launcher", labelKey: "nav.launcher", icon: Promotion },
+  { path: "/gallery", labelKey: "nav.gallery", icon: Picture },
+  { path: "/activity", labelKey: "nav.activity", icon: DataLine },
+  { path: "/me", labelKey: "nav.me", icon: User },
+  { path: "/friends", labelKey: "nav.friends", icon: UserFilled },
+  { path: "/automation", labelKey: "nav.automation", icon: Cpu },
+  {
+    path: "/video",
+    labelKey: "nav.video",
+    icon: VideoCamera,
+    windowsOnly: true,
+  },
+  { path: "/config", labelKey: "nav.configOther", icon: EditPen },
+];
+
+export const NAV_SETTINGS_MENU_ITEM: NavMenuItem = {
+  path: "/settings",
+  labelKey: "nav.settings",
+  icon: Setting,
+};


### PR DESCRIPTION
## Summary

- Replace Unicode emoji in the sidebar with Element Plus icons wrapped in `VtIcon` (`size="default"`, `currentColor`).
- Add `frontend/src/navigation/navMenuItems.ts` as the Navigation glyph catalog (path, i18n key, icon, Windows-only `/video`).
- Remove unused `.nav-glyph-size-*` CSS; update Iconography Storybook, `iconography-design-system.mdc`, and `CONTEXT.md`.

## Test plan

- [x] `make fmt`
- [x] `make test` (frontend Vitest 573 passed)
- [x] `pnpm run build-storybook`
- [ ] `make test-e2e` (navigation sidebar clicks)
- [ ] Visual check: sidebar icons are monochrome; hover/active follow menu text color


Made with [Cursor](https://cursor.com)